### PR TITLE
Add missing import for mask_sig in bandcamp.py

### DIFF
--- a/bandcampsync/bandcamp.py
+++ b/bandcampsync/bandcamp.py
@@ -7,6 +7,7 @@ from urllib.parse import urlsplit, urlunsplit
 from bs4 import BeautifulSoup
 import requests
 from .config import USER_AGENT
+from .download import mask_sig
 from .logger import get_logger
 
 


### PR DESCRIPTION
Fix the following issue when an error is thrown in `self._request`:

date | stream | content
-- | -- | --
2023/10/16 16:03:23 | stdout | NameError: name 'mask_sig' is not defined
2023/10/16 16:03:23 | stdout | ^^^^^^^^
2023/10/16 16:03:23 | stdout | raise BandcampError(f'Failed to make HTTP request to {mask_sig(url)}: {e}') from e
2023/10/16 16:03:23 | stdout | File "/usr/local/lib/python3.11/dist-packages/bandcampsync/bandcamp.py", line 89, in _request
2023/10/16 16:03:23 | stdout | ^^^^^^^^^^^^^^^^^^^^^^^^^
2023/10/16 16:03:23 | stdout | soup = self._request('get', url)
2023/10/16 16:03:23 | stdout | File "/usr/local/lib/python3.11/dist-packages/bandcampsync/bandcamp.py", line 147, in verify_authentication
2023/10/16 16:03:23 | stdout | bandcamp.verify_authentication()
2023/10/16 16:03:23 | stdout | File "/usr/local/lib/python3.11/dist-packages/bandcampsync/__init__.py", line 19, in do_sync
2023/10/16 16:03:23 | stdout | do_sync(cookies_path, cookies, dir_path, media_format_env, temp_dir)
2023/10/16 16:03:23 | stdout | File "/usr/local/bin/bandcampsync-service", line 74, in <module>