### PR TITLE
Bypass patterns fix file too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ another format with the `--format` argument. Common Bandcamp download formats ar
 | `alac`          | Apple lossless format. Large file sizes. Original quality.      |
 | `wav`           | Uncompressed audio format. Biggest file size. Original quality. |
 
+You can also use `-i` or `--ignore` to bypass artists that have data issues that
+your OS can not handle.
+
+```bash
+$ bandcampsync --cookies cookies.txt --directory /path/to/music --ignore "badband"
+```
 
 # Contributing
 

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -21,9 +21,11 @@ if __name__ == '__main__':
         help='Path to the cookies file')
     parser.add_argument('-d', '--directory', required=True,
         help='Path to the directory to download media to')
+    parser.add_argument('-b', '--bypass', default='',
+        help='A space-delimited list of patterns for artists to bypass')
     parser.add_argument('-f', '--format', default='flac',
         help='Media format to download, defaults to "flac"')
-    parser.add_argument('-t', '--temp-dir', default=None,
+    parser.add_argument('-t', '--temp-dir', default='',
         help='Path to use for temporary downloads')
     args = parser.parse_args()
     if args.version:
@@ -31,11 +33,15 @@ if __name__ == '__main__':
         sys.exit(0)
     cookies_path = Path(args.cookies).resolve()
     dir_path = Path(args.directory).resolve()
+    ign_patterns = args.bypass
     media_format = args.format
     if not cookies_path.is_file():
         raise ValueError(f'Cookies file does not exist: {cookies_path}')
     if not dir_path.is_dir():
         raise ValueError(f'Directory does not exist: {dir_path}')
+    if args.bypass:
+        patterns = args.bypass
+        log.warning(f'BandcampSync is bypassing: {patterns}')
     if args.temp_dir:
         temp_dir = Path(args.temp_dir).resolve()
         if not temp_dir.is_dir():
@@ -46,5 +52,5 @@ if __name__ == '__main__':
     with open(cookies_path, 'rt') as f:
         cookies = f.read().strip()
     log.info(f'Loaded cookies from "{cookies_path}"')
-    do_sync(cookies_path, cookies, dir_path, media_format, temp_dir)
+    do_sync(cookies_path, cookies, dir_path, media_format, temp_dir, ign_patterns)
     log.info(f'Done')

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -21,8 +21,8 @@ if __name__ == '__main__':
         help='Path to the cookies file')
     parser.add_argument('-d', '--directory', required=True,
         help='Path to the directory to download media to')
-    parser.add_argument('-b', '--bypass', default='',
-        help='A space-delimited list of patterns for artists to bypass')
+    parser.add_argument('-i', '--ignore', default='',
+        help='A space-delimited list of patterns matching artists to bypass')
     parser.add_argument('-f', '--format', default='flac',
         help='Media format to download, defaults to "flac"')
     parser.add_argument('-t', '--temp-dir', default='',
@@ -33,14 +33,14 @@ if __name__ == '__main__':
         sys.exit(0)
     cookies_path = Path(args.cookies).resolve()
     dir_path = Path(args.directory).resolve()
-    ign_patterns = args.bypass
+    ign_patterns = args.ignore
     media_format = args.format
     if not cookies_path.is_file():
         raise ValueError(f'Cookies file does not exist: {cookies_path}')
     if not dir_path.is_dir():
         raise ValueError(f'Directory does not exist: {dir_path}')
-    if args.bypass:
-        patterns = args.bypass
+    if args.ignore:
+        patterns = args.ignore
         log.warning(f'BandcampSync is bypassing: {patterns}')
     if args.temp_dir:
         temp_dir = Path(args.temp_dir).resolve()

--- a/bin/bandcampsync-service
+++ b/bin/bandcampsync-service
@@ -20,7 +20,7 @@ class CatchShutdownSignal:
         self.shutdown = False
         signal.signal(signal.SIGINT, self.got_exit_signal)
         signal.signal(signal.SIGTERM, self.got_exit_signal)
-    
+
     def got_exit_signal(self, *args, **kwargs):
         self.shutdown = True
 
@@ -30,6 +30,7 @@ if __name__ == '__main__':
     cookies_path_env = os.getenv('COOKIES_FILE', '/config/cookies.txt')
     dir_path_env = os.getenv('DIRECTORY', '/downloads')
     media_format_env = os.getenv('FORMAT', 'flac')
+    bypass_patterns = os.getenv('BYPASS_PATTERNS', '')
     run_daily_at_env = os.getenv('RUN_DAILY_AT', '3')
     exit_after_run_env = os.getenv('EXIT_AFTER_RUN', '0')
     temp_dir_env = os.getenv('TEMP_DIR', '')
@@ -71,7 +72,7 @@ if __name__ == '__main__':
     try:
         while not catch_shutdown.shutdown:
             log.info(f'Starting synchronisation')
-            do_sync(cookies_path, cookies, dir_path, media_format_env, temp_dir)
+            do_sync(cookies_path, cookies, dir_path, media_format_env, temp_dir, bypass_patterns)
             random_delay = randrange(0, 3600)
             time_now = datetime.now(tz).replace(microsecond=0)
             time_tomorrow = time_now + timedelta(days=1)

--- a/bin/bandcampsync-service
+++ b/bin/bandcampsync-service
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     cookies_path_env = os.getenv('COOKIES_FILE', '/config/cookies.txt')
     dir_path_env = os.getenv('DIRECTORY', '/downloads')
     media_format_env = os.getenv('FORMAT', 'flac')
-    bypass_patterns = os.getenv('BYPASS_PATTERNS', '')
+    ign_patterns = os.getenv('IGNORE', '')
     run_daily_at_env = os.getenv('RUN_DAILY_AT', '3')
     exit_after_run_env = os.getenv('EXIT_AFTER_RUN', '0')
     temp_dir_env = os.getenv('TEMP_DIR', '')
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     try:
         while not catch_shutdown.shutdown:
             log.info(f'Starting synchronisation')
-            do_sync(cookies_path, cookies, dir_path, media_format_env, temp_dir, bypass_patterns)
+            do_sync(cookies_path, cookies, dir_path, media_format_env, temp_dir, ign_patterns)
             random_delay = randrange(0, 3600)
             time_now = datetime.now(tz).replace(microsecond=0)
             time_tomorrow = time_now + timedelta(days=1)


### PR DESCRIPTION
add `-i` or `--ignore` support to bypass bandname that contains impossible to process data.

See https://github.com/meeb/bandcampsync/issues/10