### PR TITLE
Use album_title field as title.

### DIFF
--- a/bandcampsync/bandcamp.py
+++ b/bandcampsync/bandcamp.py
@@ -211,7 +211,7 @@ class Bandcamp:
                     log.error(f'Failed to locate band name in item metadata, skipping item...')
                     continue
                 try:
-                    title = item_data['title']
+                    title = item_data['album_title']
                 except KeyError:
                     log.error(f'Failed to locate title in item metadata (possibly a subscription?) for "{band_name}", skipping item...')
                     continue


### PR DESCRIPTION
Hi there!

Not sure if Bandcamp changed their API or what, but my downloads do not have a `title` field in them, causing the tool to loop endlessly through all purchases and not download anything; this change fixes said problem for me, but I saw that the response also includes keys such as `item_title`, which might be a more robust choice, but I haven't tested it.