### PR TITLE
#53 - address some corner-cases

### DIFF
--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -85,7 +85,7 @@ class LocalMedia:
         return (
             self.media_dir
             / self._clean_path(item.band_name)
-            / self._clean_path(item.item_title)
+            / self._clean_path(f"{item.item_title}{item.folder_suffix}")
         )
 
     def get_path_for_file(self, local_path, file_name):

--- a/tests/data/collection-item-digital-only.json
+++ b/tests/data/collection-item-digital-only.json
@@ -1,0 +1,213 @@
+{
+  "collectors": {},
+  "item_lookup": {
+    "1951128144": {
+      "item_type": "a",
+      "purchased": true
+    }
+  },
+  "items": [
+    {
+      "added": "07 Jul 2020 01:34:59 GMT",
+      "album_id": 1951128144,
+      "album_title": "Primavera Sound: Live in Barcelona (2017)",
+      "also_collected_count": 460,
+      "band_id": 859041092,
+      "band_image_id": null,
+      "band_location": null,
+      "band_name": "Arab Strap",
+      "band_url": "https://arabstrap.bandcamp.com",
+      "currency": "GBP",
+      "discount": null,
+      "download_available": true,
+      "fan_id": 5226501,
+      "featured_track": 1061879304,
+      "featured_track_duration": 478.922,
+      "featured_track_encodings_id": 1021332053,
+      "featured_track_is_custom": false,
+      "featured_track_license_id": null,
+      "featured_track_number": 4,
+      "featured_track_title": "Girls of Summer",
+      "featured_track_url": null,
+      "genre_id": 2,
+      "gift_id": null,
+      "gift_recipient_name": null,
+      "gift_sender_name": null,
+      "gift_sender_note": null,
+      "has_digital_download": null,
+      "hidden": null,
+      "index": null,
+      "is_giftable": true,
+      "is_preorder": false,
+      "is_private": false,
+      "is_purchasable": true,
+      "is_set_price": false,
+      "is_subscriber_only": false,
+      "is_subscription_item": false,
+      "item_art": {
+        "art_id": 1172909073,
+        "thumb_url": "https://f4.bcbits.com/img/a1172909073_3.jpg",
+        "url": "https://f4.bcbits.com/img/a1172909073_9.jpg"
+      },
+      "item_art_id": 1172909073,
+      "item_art_ids": null,
+      "item_art_url": "https://f4.bcbits.com/img/a1172909073_9.jpg",
+      "item_id": 1951128144,
+      "item_title": "Primavera Sound: Live in Barcelona (2017)",
+      "item_type": "album",
+      "item_url": "https://arabstrap.bandcamp.com/album/primavera-sound-live-in-barcelona-2017",
+      "label": null,
+      "label_id": null,
+      "licensed_item": null,
+      "listen_in_app_url": "https://bandcamp.com/redirect_to_app?fallback_url=https%3A%2F%2Fbandcamp.com%2Fthis_is_an_appstore_url%3Fapp%3Dfan_app&url=x-bandcamp%3A%2F%2Fshow_tralbum%3Ftralbum_type%3Da%26tralbum_id%3D1951128144%26play%3D1&sig=0539e831d2ee0bc552ec8add315459a2",
+      "merch_ids": null,
+      "merch_snapshot": null,
+      "merch_sold_out": null,
+      "message_count": null,
+      "num_streamable_tracks": 11,
+      "package_details": null,
+      "price": 0.0,
+      "purchased": "07 Jul 2020 01:34:59 GMT",
+      "release_count": null,
+      "releases": null,
+      "require_email": null,
+      "sale_item_id": 122605825,
+      "sale_item_type": "p",
+      "service_name": null,
+      "service_url_fragment": null,
+      "token": "1594085699:1951128144:a::",
+      "tralbum_id": 1951128144,
+      "tralbum_type": "a",
+      "updated": "07 Jul 2020 01:34:59 GMT",
+      "url_hints": {
+        "custom_domain": null,
+        "custom_domain_verified": null,
+        "item_type": "a",
+        "slug": "primavera-sound-live-in-barcelona-2017",
+        "subdomain": "arabstrap"
+      },
+      "variant_id": null,
+      "why": null
+    }
+  ],
+  "last_token": "1594085699:1951128144:a::",
+  "more_available": false,
+  "purchase_infos": {},
+  "redownload_urls": {
+    "p122605825": "https://bandcamp.com/download?from=collection&payment_id=3166564483&sig=aad9e4e74adaf89fb19b6d33529bfa5a&sitem_id=122605825"
+  },
+  "tracklists": {
+    "a1951128144": [
+      {
+        "artist": "Arab Strap",
+        "duration": 113.369,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2369932498&ts=1768864598&t=444f1bd66162fc08400ae37482d52310064d2455"
+        },
+        "id": 2369932498,
+        "title": "Intro",
+        "track_number": 1
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 135.634,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2283159365&ts=1768864598&t=a1cad4cc9ece8b5ae74792c4c9f507e8dd47b2dd"
+        },
+        "id": 2283159365,
+        "title": "Stink",
+        "track_number": 2
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 311.979,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=3134622243&ts=1768864598&t=7f8ad940e59c4581d987cb753dbf72964f1b24b4"
+        },
+        "id": 3134622243,
+        "title": "Fucking Little Bastards",
+        "track_number": 3
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 478.922,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1061879304&ts=1768864598&t=19ecbcbbbac841f565e1097ac0afbb6a2ab94f95"
+        },
+        "id": 1061879304,
+        "title": "Girls of Summer",
+        "track_number": 4
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 345.226,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1128636576&ts=1768864598&t=cac098fa95b3317c5afaf0e6a5aee4be558aceac"
+        },
+        "id": 1128636576,
+        "title": "Rocket, Take Your Turn",
+        "track_number": 5
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 308.009,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=3270493615&ts=1768864598&t=cfc81bbec0f3103626d4dd76ee61fe402cf30efc"
+        },
+        "id": 3270493615,
+        "title": "Don't Ask Me to Dance",
+        "track_number": 6
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 331.095,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2457024955&ts=1768864598&t=bd9e2237d75ca446de2ac32ba63569e16a430f3c"
+        },
+        "id": 2457024955,
+        "title": "Here We Go",
+        "track_number": 7
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 420.279,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2697353436&ts=1768864598&t=a6a72c187ce70e29134875e7ee8009bfe09288e7"
+        },
+        "id": 2697353436,
+        "title": "New Birds",
+        "track_number": 8
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 218.906,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1713307590&ts=1768864598&t=928fb844d1cba956bc1a42c226f50771d1896933"
+        },
+        "id": 1713307590,
+        "title": "Speed-Date",
+        "track_number": 9
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 264.366,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2257052235&ts=1768864598&t=086c0ee7b5c98db88d5035c3351339087dfe5b2d"
+        },
+        "id": 2257052235,
+        "title": "The Shy Retirer",
+        "track_number": 10
+      },
+      {
+        "artist": "Arab Strap",
+        "duration": 322.253,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=4132678311&ts=1768864598&t=dcf0156ccb107bbbb1170e6ce90dc266eb7291ab"
+        },
+        "id": 4132678311,
+        "title": "The First Big Weekend",
+        "track_number": 11
+      }
+    ]
+  }
+}

--- a/tests/data/collection-item-physical-only.json
+++ b/tests/data/collection-item-physical-only.json
@@ -1,0 +1,221 @@
+{
+  "collectors": {},
+  "item_lookup": {
+    "3028132990": {
+      "item_type": "p",
+      "purchased": true
+    }
+  },
+  "items": [
+    {
+      "added": "02 May 2020 03:03:47 GMT",
+      "album_id": 3028132990,
+      "album_title": "Live In Zurich!",
+      "also_collected_count": 140,
+      "band_id": 3538965239,
+      "band_image_id": null,
+      "band_location": null,
+      "band_name": "Malcolm Middleton",
+      "band_url": "https://malcolmmiddleton.bandcamp.com",
+      "currency": "GBP",
+      "discount": null,
+      "download_available": true,
+      "fan_id": 5226501,
+      "featured_track": 1250951122,
+      "featured_track_duration": 305.387,
+      "featured_track_encodings_id": 2484363694,
+      "featured_track_is_custom": false,
+      "featured_track_license_id": null,
+      "featured_track_number": 11,
+      "featured_track_title": "A Brighter Beat",
+      "featured_track_url": null,
+      "genre_id": 2,
+      "gift_id": null,
+      "gift_recipient_name": null,
+      "gift_sender_name": null,
+      "gift_sender_note": null,
+      "has_digital_download": null,
+      "hidden": null,
+      "index": null,
+      "is_giftable": true,
+      "is_preorder": false,
+      "is_private": false,
+      "is_purchasable": true,
+      "is_set_price": true,
+      "is_subscriber_only": false,
+      "is_subscription_item": false,
+      "item_art": {
+        "art_id": 4200321582,
+        "thumb_url": "https://f4.bcbits.com/img/a4200321582_3.jpg",
+        "url": "https://f4.bcbits.com/img/a4200321582_9.jpg"
+      },
+      "item_art_id": 4200321582,
+      "item_art_ids": null,
+      "item_art_url": "https://f4.bcbits.com/img/a4200321582_9.jpg",
+      "item_id": 3366803807,
+      "item_title": "Live In Zurich!",
+      "item_type": "package",
+      "item_url": "https://malcolmmiddleton.bandcamp.com/album/live-in-zurich",
+      "label": null,
+      "label_id": null,
+      "licensed_item": null,
+      "listen_in_app_url": "https://bandcamp.com/redirect_to_app?fallback_url=https%3A%2F%2Fbandcamp.com%2Fthis_is_an_appstore_url%3Fapp%3Dfan_app&url=x-bandcamp%3A%2F%2Fshow_tralbum%3Ftralbum_type%3Da%26tralbum_id%3D3028132990%26play%3D1&sig=bbeadaf418a7f988fb052b29b61447e9",
+      "merch_ids": null,
+      "merch_snapshot": null,
+      "merch_sold_out": null,
+      "message_count": null,
+      "num_streamable_tracks": 12,
+      "package_details": null,
+      "price": 5.0,
+      "purchased": "18 Jan 2012 16:08:46 GMT",
+      "release_count": null,
+      "releases": null,
+      "require_email": null,
+      "sale_item_id": 2373867,
+      "sale_item_type": "p",
+      "service_name": null,
+      "service_url_fragment": null,
+      "token": "1326902926:3366803807:p::",
+      "tralbum_id": 3028132990,
+      "tralbum_type": "a",
+      "updated": "02 May 2020 03:03:47 GMT",
+      "url_hints": {
+        "custom_domain": null,
+        "custom_domain_verified": null,
+        "item_type": "a",
+        "slug": "live-in-zurich",
+        "subdomain": "malcolmmiddleton"
+      },
+      "variant_id": null,
+      "why": null
+    }
+  ],
+  "last_token": "1326902926:3366803807:p::",
+  "more_available": false,
+  "purchase_infos": {},
+  "redownload_urls": {},
+  "tracklists": {
+    "p3366803807": [
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 469.427,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2149785434&ts=1768864598&t=c5a91686ca7a336634c084cf572f549e384b960f"
+        },
+        "id": 2149785434,
+        "title": "Crappo The Clown",
+        "track_number": 1
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 300.533,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1245295522&ts=1768864598&t=3c4e377c3c9b30ea0283e31f0016b1f065b9f75f"
+        },
+        "id": 1245295522,
+        "title": "Choir",
+        "track_number": 2
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 409.533,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1096975252&ts=1768864598&t=4b2428f3a1623c6433bda4561dcbe467d2d16477"
+        },
+        "id": 1096975252,
+        "title": "Love Comes In Waves",
+        "track_number": 3
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 227.667,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1753859466&ts=1768864598&t=f1b6734a56ee066b94735217dc0cecaa00838690"
+        },
+        "id": 1753859466,
+        "title": "Subset Of The World",
+        "track_number": 4
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 231.093,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1085408301&ts=1768864598&t=23b3538d2eab3fa173ae49b1c1f4628b9889d56a"
+        },
+        "id": 1085408301,
+        "title": "One More Song",
+        "track_number": 5
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 359.787,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=360585413&ts=1768864598&t=2dff4792ae7edf750986a19ba882c7102f231e68"
+        },
+        "id": 360585413,
+        "title": "Zero",
+        "track_number": 6
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 260.48,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2101014683&ts=1768864598&t=90310c4970b228717c76ac6e195cd32db2496bec"
+        },
+        "id": 2101014683,
+        "title": "Autumn",
+        "track_number": 7
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 278.813,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=3473560572&ts=1768864598&t=ec03d1a25a4e7fec8a15df8611989c88b2d399b4"
+        },
+        "id": 3473560572,
+        "title": "Stay Close Sit Tight",
+        "track_number": 8
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 402.893,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=3366625140&ts=1768864598&t=ecf4e31588c81db970637690356e29557e49b12b"
+        },
+        "id": 3366625140,
+        "title": "Box And Knife",
+        "track_number": 9
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 177.96,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=3412223305&ts=1768864598&t=67160e7d156bad7bd0ea9cdb02e4deff47394571"
+        },
+        "id": 3412223305,
+        "title": "Blue Plastic Bags",
+        "track_number": 10
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 305.387,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=1250951122&ts=1768864598&t=8b6f02047af3feca15d4ad44ec383e57368b8185"
+        },
+        "id": 1250951122,
+        "title": "A Brighter Beat",
+        "track_number": 11
+      },
+      {
+        "artist": "Malcolm Middleton",
+        "duration": 397.0,
+        "file": {
+          "mp3-v0": "https://bandcamp.com/stream_redirect?enc=mp3-v0&track_id=2896176902&ts=1768864598&t=dcfdd432e179248a58c27d96c33898ec9489cd65"
+        },
+        "id": 2896176902,
+        "title": "Don't Want To Sleep Tonight",
+        "track_number": 12
+      }
+    ]
+  }
+}

--- a/tests/data/download-choose-format.html
+++ b/tests/data/download-choose-format.html
@@ -1,0 +1,858 @@
+<!DOCTYPE html>
+<html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en" class="js has-svg has-cssom has-hover no-touch has-anim prvjy"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"><script type="text/javascript" async="" src="Bandcamp2_files/js" nonce=""></script><script async="" src="Bandcamp2_files/gtm.js"></script>
+    <title>Bandcamp</title>
+    
+    
+
+
+
+    <meta name="description" content="
+">
+    
+    
+    <link rel="apple-touch-icon" sizes="180x180" href="https://s4.bcbits.com/img/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://s4.bcbits.com/img/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://s4.bcbits.com/img/favicon/favicon-16x16.png">
+    <link rel="mask-icon" href="https://s4.bcbits.com/img/favicon/safari-pinned-tab.svg" color="#1da0c3">
+
+
+<meta name="msapplication-TileColor" content="#603cba">
+<meta name="theme-color" content="#ffffff">
+
+    
+
+    
+
+    
+    
+
+    
+    
+    
+
+
+
+    
+        <meta name="referrer" content="no-referrer">
+    
+
+    
+    
+    
+
+    
+
+    
+    
+
+    <link type="text/css" rel="stylesheet" href="Bandcamp2_files/global_new-3c86d7830d2e766c853e22c7210cef22.css">
+<link type="text/css" rel="stylesheet" href="Bandcamp2_files/global-287f5755431dca6cbd6e368f712ddda5.css">
+<link type="text/css" rel="stylesheet" href="Bandcamp2_files/download_2016-54fc4c0176ca2f3c0fd6548108288c22.css">
+
+    <meta id="js-crumbs-data" data-crumbs="[redacted]">
+    
+
+    
+
+    
+
+    
+    
+        <script nonce="" src="Bandcamp2_files/stripe.js" async=""></script>
+    
+
+    
+<script type="text/javascript" nonce="">
+window.BCTracker=window.BCTracker||{preloadQueue:[],record:function(){this.preloadQueue.push(Array.prototype.slice.call(arguments))},prePageViewCallbacks:[],afterPageView:function(e){this.prePageViewCallbacks.push(e)}},window.ScrollDepthTracker=function(){this.track=function(){}},window.ScrollDepthTracker.track=function(){}
+</script>
+
+    <script type="text/javascript" src="Bandcamp2_files/bccookies-fb37f2fdf1cf58b7b623df3dda68227d.js" crossorigin="anonymous" nonce=""></script>
+    <script type="text/javascript" src="Bandcamp2_files/global_head-574a8ace3b730e8b08ab6d298a4b10d3.js" crossorigin="anonymous" nonce="" data-vars="[redacted]" data-validators="{&quot;contact&quot;:{&quot;name&quot;:{&quot;req&quot;:true},&quot;email&quot;:{&quot;req&quot;:true,&quot;match&quot;:&quot;(^)([^\\s\\(\\)\&quot;'/&gt;&lt;,@]+@\\w([^\\s\\(\\)\&quot;'/&gt;&lt;&amp;,@]*\\w)?\\.\\w[^\\s\\(\\)\&quot;'/&gt;&lt;&amp;,@]*\\w)($)&quot;,&quot;message&quot;:&quot;Invalid email address.&quot;},&quot;subject&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:300},&quot;message&quot;:{&quot;req&quot;:true,&quot;type&quot;:&quot;text&quot;,&quot;min&quot;:1,&quot;max&quot;:1999},&quot;attachment_0_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_0_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_1_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_1_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_2_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_2_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_3_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_3_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_4_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_4_data&quot;:{&quot;type&quot;:&quot;text&quot;}}}" data-hide-params="[]"></script>
+
+    
+  <script src="Bandcamp2_files/7c33659f530ef43fb4532fc6e83354dd.min.js" crossorigin="anonymous" nonce="" id="sentry" data-config="[redacted]"></script>
+
+
+
+    
+    
+
+
+    
+
+    
+    
+
+    
+
+</head>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<body class="gecko enable-cookie-control has-menubar" lang="en"><noscript><iframe src="Bandcamp2_files/ns.html" height="0" width="0" style="display: none; visibility: hidden;"></iframe></noscript>
+
+
+
+<svg height="0" width="0" style="position:absolute;margin-left:-100%">
+    <path id="tweet" d="M16.1 3.5a9.6 9.6 0 01-1.7 6c-.6.9-1.3 1.6-2.1 2.3-.8.7-1.8 1.2-2.9 1.6-1.2.4-2.4.6-3.7.6-2.2 0-4.1-.6-5.7-1.6 2.5.2 4.1-.5 5.5-1.5-1.7 0-3-1.1-3.4-2.4.5.1 1.3 0 1.7-.1-1.5-.3-3-1.7-3-3.5.3.2.9.4 1.7.4C1.5 4.8.8 3.7.8 2.4c0-.6.2-1.4.5-1.8 1.7 2 4.4 3.6 7.6 3.7C8.3 1.4 10.6 0 12.5 0c1.1 0 2 .4 2.7 1.1.8-.1 1.6-.4 2.3-.8-.3.8-.8 1.5-1.6 1.9.7-.1 1.4-.2 2.1-.5-.5.7-1.1 1.3-1.9 1.8z"></path>
+    <path id="buy-for-friend" d="M3.5 4h7c1.8-.3 2.4-1.9 2-2.9S10.7-.5 9.3.5 7 3 7 3 6.1 1.5 4.7.5s-2.8-.4-3.2.6.2 2.6 2 2.9zm6.8-3c.9-.2 1.6.1 1.3 1.1-.3 1.2-2.6 1.3-3.8 1.3 0 0 1.6-2.2 2.5-2.4zM3.8 1c1.1.4 2.4 2.4 2.4 2.4-1.3 0-3.4-.3-3.8-1.3C2 1.1 3 .8 3.8 1zM0 9h6V5H0v4zm7-4v4h7V5H7zm0 9h6v-4H7v4zm-6 0h5v-4H1v4z"></path>
+    <path id="edit-profile-info" d="M10 10.5c0 .3-.2.5-.5.5h-8c-.3 0-.5-.2-.5-.5v-8c0-.3.2-.5.5-.5h3.7V1H1.5C.7 1 0 1.7 0 2.5v8c0 .8.7 1.5 1.5 1.5h8c.8 0 1.5-.7 1.5-1.5V7h-1v3.5zm2-9.1L10.5 0 6.4 4.4l-.6 2.2L8 5.7l4-4.3z"></path>
+    <path id="fb-logo-share-profile" d="M3.9 12V6.3h1.8L6 4.2H4V2.9c0-.6.2-1 1-1h1.1V.1C5.8.1 5.2 0 4.4 0 2.8 0 1.8 1 1.8 2.7v1.5H0v2.1h1.8V12h2.1z"></path>
+    <path id="following-checkmark" d="M4.3 10.7L0 5.8l1.5-1.3 2.8 3.1L11 0l1.5 1.3z"></path>
+    <path id="follow-plus" d="M8 3H5V0H3v3H0v2h3v3h2V5h3z"></path>
+    <path id="share-profile" d="M10.7.2s-.1-.1 0 0l-.4-.2h-.1L2.5 4.8.3 8.1v.1s0 .1.1.1l3.3.9h.1l5.1-6.5-3.3 7 .9 2.2.1.1s.1 0 .1-.1l.9-1.5 2.8.9.1-.1L11.8 7 10.7.2z"></path>
+    <path id="search-magnifier" d="M10.1 10.4l-1.4-2C9.5 7.5 10 6.3 10 5c0-2.8-2.2-5-5-5S0 2.2 0 5s2.2 5 5 5c.7 0 1.4-.1 2-.4l1.5 2c.3.4 1 .5 1.4.2.4-.3.5-.9.2-1.4zM5 9C2.8 9 1 7.2 1 5s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
+    <path id="close-search-results" d="M8 .7L7.3 0 4 3.3.7 0 0 .7 3.3 4 0 7.3l.7.7L4 4.7 7.3 8l.7-.7L4.7 4z"></path>
+    <path id="camera-icon" d="M26 2h-4a2 2 0 00-2-2H8a2 2 0 00-2 2H2a2 2 0 00-2 2v14a2 2 0 002 2h24a2 2 0 002-2V4a2 2 0 00-2-2zM14 17a6 6 0 116-6 6 6 0 01-6 6zm1-10h-2v3h-3v2h3v3h2v-3h3v-2h-3z"></path>
+    <g id="search-spinner">
+        <circle class="st1" cx="7" cy="1.5" r="1.5"></circle>
+        <circle class="st2" transform="rotate(-45 10.89 3.11)" cx="10.9" cy="3.1" r="1.5"></circle>
+        <circle class="st3" cx="12.5" cy="7" r="1.5"></circle>
+        <circle class="st4" transform="rotate(-45 10.89 10.89)" cx="10.9" cy="10.9" r="1.5"></circle>
+        <circle class="st5" cx="7" cy="12.5" r="1.5"></circle>
+        <circle class="st6" transform="rotate(-45 3.11 10.89)" cx="3.1" cy="10.9" r="1.5"></circle>
+        <circle class="st8" transform="rotate(-45 3.11 3.11)" cx="3.1" cy="3.1" r="1.5"></circle>
+        <circle class="st7" cx="1.5" cy="7" r="1.5"></circle>
+    </g>
+    <path id="mobile-web-collection-arrow" d="M20.3 17.3L3 0 .3 2.7 17.7 20 .3 37.3 3 40l17.3-17.3L23 20z"></path>
+    <path id="homepage-mobile-arrow" d="M12.9 11L2.1.1 0 2.2l10.8 10.9L0 24l2.1 2.1 10.8-10.9 2.1-2.1z"></path>
+    <path id="collect-control-wishlist" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1zm-4-7.1c1.8 1.6 3.2 3.1 4 4 .8-.9 2.2-2.4 3.9-4 3.1-2.8 4.7-5.2 4.7-7.1 0-1-.4-1.9-1.3-2.7-1-.8-1.9-1.2-2.9-1-2 .3-3.6 2.7-3.6 2.7l-.9 1.4-.8-1.5S8.3 2.3 6.3 1.9c-1-.2-2 .2-3.1 1.1-.9.9-1.3 1.9-1.2 2.9 0 2 1.6 4.3 4.5 7z"></path>
+    <path id="collect-control-purchased" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1z"></path>
+    <path id="collect-control-wishlisted" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1z"></path>
+    <path id="facebook-like" d="M2 0h12c1.15 0 2 .85 2 2v12c0 1.15-.85 2-2 2h-3.49V9.83h2.06l.34-2.52h-2.4V5.83c0-.34.12-.69.23-.8.12-.23.46-.34.92-.34h1.25V2.5c-.45-.11-1.02-.11-1.82-.11-.92 0-1.72.23-2.29.8-.57.57-.8 1.37-.8 2.4v1.83H5.94v2.4H8V16H2c-1.15 0-2-.85-2-2V2C0 .85.85 0 2 0z"></path>
+    <path id="format-dropdown" d="M10 0L5 6 0 0z"></path>
+    <path id="direct-download" d="M11.7 7.3c-.4-.4-1-.4-1.4 0L7 10.6V1c0-.5-.5-1-1-1S5 .5 5 1v9.6L1.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l5 5c.2.2.4.3.7.3.4 0 .5-.1.7-.3l5-5c.4-.4.4-1 0-1.4zM10 15H2c-.5 0-1 .5-1 1s.5 1 1 1h8c.5 0 1-.5 1-1s-.5-1-1-1z"></path>
+    <path id="mobile-gift-ribbon" class="st0" d="M46.3 0C37.4 0 31.1 8.3 28 13.5 24.9 8.3 18.6 0 9.7 0 4.1 0 0 3.5 0 8.2 0 16.6 12.2 22 27.7 22 43.9 22 56 15 56 8.3c0-1.3-.3-2.6-1-3.8C53.5 1.7 50.2 0 46.3 0zM9.6 12.8c-3.1-1.6-3.9-3.1-3.9-4.6 0-1.5 1.5-3.1 4-3.1 6 0 10.8 6.6 13.4 10.9-6.9-.5-11.1-2-13.5-3.2zm37.3-.3c-2.8 1.6-7.4 3-14 3.4C35.5 11.6 40.1 5 46.1 5c2.1 0 4 .9 4 3 0 1.9-1.6 3.6-3.2 4.5z"></path>
+    <path id="grab-app" d="M20.8 25c-.8-.8-2-.8-2.8 0-.8.8-.8 2 0 2.8l7.2 7.2H2a2 2 0 00-2 2c0 1.1.9 2 2 2h23.2L18 46.2c-.8.8-.8 2 0 2.8.8.8 2 .8 2.8 0l10.6-10.6c.3-.3.6-.8.6-1.4 0-.6-.3-1.1-.6-1.4L20.8 25zM77.6 0h-26C46 0 41 4 41 9.5v56C41 71 46 76 51.6 76h26c5.5 0 9.4-5 9.4-10.5v-56C87 4 83.1 0 77.6 0zM84 65.5c0 3.9-2.6 7.5-6.4 7.5h-26c-3.9 0-7.6-3.6-7.6-7.5V56h40v9.5zM84 53H44V17h40v36zm0-39H44V9.5C44 5.6 47.7 3 51.6 3h26C81.4 3 84 5.6 84 9.5V14zM64 67c1.7 0 3-1.3 3-3s-1.3-3-3-3-3 1.3-3 3 1.4 3 3 3z"></path>
+    <path id="play-app" d="M1 60c-.2 0-.3 0-.5-.1-.3-.2-.5-.5-.5-.9V1C0 .6.2.3.5.1c.4-.1.8-.1 1.1.1l42 29c.3.2.4.5.4.8s-.2.6-.4.8l-42 29c-.2.2-.4.2-.6.2zM2 2.9v54.2L41.3 30 2 2.9z"></path>
+    <path id="play-app-2" d="M18.55 16L2.97 5.61V26.4L18.55 16zM0 32V0l24 16L0 32z"></path>
+    <g id="grab-app-opensignup" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="collection" transform="translate(-67 -505)" fill="#FFF">
+            <g id="mweb-phone-icon-outline" transform="translate(67 505)">
+                <path d="M21.16 3.99v28.02a3 3 0 003 2.99h13.99a3 3 0 003-2.99V3.99a3 3 0 00-3-2.99H24.17a3 3 0 00-3.01 2.99zm-1 0a4 4 0 014-3.99h13.99a4 4 0 014 3.99v28.02a4 4 0 01-4 3.99H24.17a4 4 0 01-4.01-3.99V3.99z" id="Rectangle-1270"></path>
+                <rect id="Rectangle-1271" x="29.41" y="29.73" width="2.5" height="2.5" rx="1.25"></rect>
+                <path d="M20.66 8.23h21v-1h-21v1zm0 19h21v-1h-21v1z" id="Combined-Shape"></path>
+                <path d="M.29 18.44c0 .36.31.67.68.67h11.62L8.86 23.3a.72.72 0 000 .99l.36.41c.26.26.68.26.94 0l5.89-6.05a.72.72 0 000-1L9.96 11.3a.66.66 0 00-.94 0l-.36.41a.72.72 0 000 1l3.9 4.43H.96a.69.69 0 00-.67.67v.63z" id="→"></path>
+            </g>
+        </g>
+    </g>
+    <g id="has-app">
+        <path class="has-app-phone" d="M18 56a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2zM29 0H7C3.1 0 0 3.1 0 7v48c0 3.9 3.1 7 7 7h22c3.9 0 7-3.1 7-7V7c0-3.9-3.1-7-7-7zm5 55c0 2.8-2.2 5-5 5H7c-2.8 0-5-2.2-5-5v-6h32v6zm0-8H2V12h32v35zm0-37H2V7c0-2.8 2.2-5 5-5h22c2.8 0 5 2.2 5 5v3z"></path>
+        <path class="has-app-confirm" d="M18 18c-6.4 0-11.5 5.1-11.5 11.5S11.6 41 18 41s11.5-5.1 11.5-11.5S24.4 18 18 18zm5.3 9.6l-5.8 5.8c-.3.3-.7.4-1.1.4-.4 0-.8-.1-1.1-.4l-2.6-2.6c-.6-.6-.6-1.5 0-2.1s1.5-.6 2.1 0l1.6 1.6 4.8-4.8c.6-.6 1.5-.6 2.1 0 .6.6.6 1.6 0 2.1z"></path>
+    </g>
+    <g id="no-app">
+        <path class="no-app-phone" d="M18 56a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2zM29 0H7C3.1 0 0 3.1 0 7v48c0 3.9 3.1 7 7 7h22c3.9 0 7-3.1 7-7V7c0-3.9-3.1-7-7-7zm5 55c0 2.8-2.2 5-5 5H7c-2.8 0-5-2.2-5-5v-6h32v6zm0-8H2V12h32v35zm0-37H2V7c0-2.8 2.2-5 5-5h22c2.8 0 5 2.2 5 5v3z"></path>
+        <path class="no-app-bc-logo" d="M14 23L7 36h15l7-13z"></path>
+    </g>
+    <g id="signup-promo-icon">
+        <path id="signup-phone-background" d="M25 52H5c-2.8 0-5-2.2-5-5V5c0-2.8 2.2-5 5-5h20c2.8 0 5 2.2 5 5v42c0 2.8-2.2 5-5 5z"></path>
+        <g id="signup-promo-phone">
+            <path class="signup-phone-icon" d="M25 0H5C2.2 0 0 2.2 0 5v42c0 2.8 2.2 5 5 5h20c2.8 0 5-2.2 5-5V5c0-2.8-2.2-5-5-5zm3 47c0 1.7-1.3 3-3 3H5c-1.7 0-3-1.3-3-3v-6h26v6zm0-8H2V10h26v29zm0-31H2V5c0-1.7 1.3-3 3-3h20c1.7 0 3 1.3 3 3v3zM15 47a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2z"></path>
+            <path class="signup-bc-logo" d="M11.6 19L5.7 30h12.7l5.9-11z"></path>
+        </g>
+    </g>
+    <path id="format-dropdown-selected" d="M8.6.3C8.2-.1 7.5-.1 7 .3L3.4 4 2 2.5c-.4-.4-1.2-.4-1.6 0-.4.4-.4 1.2 0 1.6l2.2 2.2c.2.2.5.3.8.3.3 0 .6-.1.8-.3L8.6 2c.5-.5.5-1.2 0-1.7z"></path>
+    <defs>
+        <linearGradient id="ribbon-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#00BAEF"></stop>
+            <stop offset="90%" stop-color="#1DA0C3"></stop>
+        </linearGradient>
+    </defs>
+    <path id="rarr-ico" d="M5 5L0 9l2 1 6-5-6-5-2 1 5 4z"></path>
+    <path id="larr-ico" d="M5 5L0 9l2 1 6-5-6-5-2 1 5 4z" transform="rotate(-180 4 5)"></path>
+    <path d="M2.57 0L.44 2.13 7.31 9 .43 15.87 2.56 18l9-9z" transform="rotate(-180 7.5 9)" id="larr-onboarding-ico"></path>
+    <g id="rarr-onboarding-ico" transform="translate(3)">
+        <path id="Fill-2" d="M2.57 0L.44 2.13 7.31 9 .43 15.87 2.56 18l9-9z"></path>
+    </g>
+    <path d="M0 3h3v3H0V3zm6 0l2-1-2-2-1.5 2.3L3 0 1 2l2 1h1v3h5V3H6zm-5 7h2V7H1v3zm3 0h4V7H4v3z" id="gift-card-icon"></path>
+    <path id="not-shipped" d="M7.9 0L4.75 3.16 1.58 0 0 1.58l3.16 3.17L0 7.9l1.58 1.58 3.16-3.16 3.17 3.16 1.58-1.58-3.16-3.16 3.16-3.17z"></path>
+    <path id="checkmark-shipped" d="M4.66 6.5L1.38 3.37 0 4.8l3.28 3.14 1.18 1.12.26.26 7.6-7.95L10.89 0z"></path>
+    <path fill-rule="evenodd" d="M11.82 21.35a60.6 60.6 0 011.25 1.4 42.86 42.86 0 011.21-1.4 56.68 56.68 0 014.18-4.24c5.95-5.4 8.04-9.93 4.2-13.42-2.69-2.35-5.25-1.9-7.63.34a11.2 11.2 0 00-1.62 1.92l-.46.73-.4-.75a10.42 10.42 0 00-1.5-1.97c-2.28-2.32-4.85-2.78-7.72-.3-3.62 3.7-1.54 8.23 4.22 13.45a69.17 69.17 0 014.27 4.24zm1.21-16.6c.38-.5.82-.99 1.31-1.45 2.72-2.55 5.84-3.1 8.99-.35 4.49 4.07 2.15 9.14-4.2 14.9a55.69 55.69 0 00-5.65 5.99l-.38.49-.4-.48c-.07-.1-.21-.26-.42-.5a68.18 68.18 0 00-5.4-5.5C.74 12.28-1.57 7.24 2.64 2.94 6 .04 9.14.6 11.75 3.26A11.4 11.4 0 0113 4.79l.03-.04z" id="menubar-collection-icon"></path>
+    <path fill-rule="evenodd" d="M14.4.87a1 1 0 011.77.77l-1.1 7.84h6.46a1 1 0 01.74 1.68L9.24 25.2a1 1 0 01-1.72-.85L9 15.56H4.5a1 1 0 01-.77-1.63L14.4.87zm.78.63L4.5 14.57H9a1 1 0 01.98 1.16l-1.47 8.8 13.02-14.05h-6.47a1 1 0 01-.99-1.14l1.11-7.84z" id="menubar-feed-icon"></path>
+    <path d="M21.38 19.44a.13.13 0 01-.12.07H1.13a.12.12 0 01-.11-.07.33.33 0 01-.03-.09l3.27-4.15c.37-.59.57-1.27.57-1.97V7.67C4.83 4.09 7.6 1.1 11 1h.2c1.66 0 3.23.63 4.43 1.8a6.33 6.33 0 011.94 4.58v5.85c0 .7.2 1.38.6 2.01l3.2 4.05c.03.06.02.11 0 .15m-7.45 1.32a2.73 2.73 0 01-5.46 0c0-.09.03-.17.03-.25h5.4c.01.08.03.16.03.25m8.27-2.04L19 14.67a2.66 2.66 0 01-.42-1.44V7.38A7.36 7.36 0 0010.98 0C7.03.11 3.83 3.55 3.83 7.66v5.56c0 .51-.15 1-.39 1.4L.17 18.78c-.22.36-.23.79-.02 1.15.2.36.57.58.98.58H7.5c0 .08-.03.16-.03.25a3.73 3.73 0 007.46 0c0-.09-.02-.17-.03-.25h6.36a1.14 1.14 0 00.94-1.78" id="menubar-messages-icon" fill-rule="evenodd"></path>
+    <path fill-rule="evenodd" d="M11.43 19.7a9.02 9.02 0 008.93-9.1c0-5.03-4-9.1-8.93-9.1a9.02 9.02 0 00-8.93 9.1c0 5.03 4 9.1 8.93 9.1zm6.95-1.9l6 6.87c.44.5-.32 1.16-.76.66l-5.98-6.85a9.78 9.78 0 01-6.21 2.22c-5.49 0-9.93-4.52-9.93-10.1S5.94.5 11.43.5c5.48 0 9.93 4.52 9.93 10.1 0 2.82-1.14 5.37-2.98 7.2z" id="menubar-search-icon"></path>
+    <path d="M10.7 10.47l3.74 4.2c.44.5-.3 1.16-.75.66l-3.73-4.2c-.44-.5.3-1.16.75-.66zM6.6 11.7a5.1 5.1 0 100-10.2 5.1 5.1 0 000 10.2zm0 1A6.1 6.1 0 116.6.5a6.1 6.1 0 010 12.2z" id="menubar-search-input-icon"></path>
+    <g id="menubar-cart-icon" fill-rule="evenodd">
+        <path d="M21.5 25a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+        <circle cx="8.5" cy="23.5" r="1.5" opacity=".9"></circle>
+        <path fill-rule="nonzero" d="M4.57 2H.5a.5.5 0 010-1h4.48a.5.5 0 01.5.4l.5 2.7 18.52.18c.31 0 .54.28.5.58l-2.28 13.72a.5.5 0 01-.49.42H8.16a.5.5 0 01-.49-.4L4.57 2zm1.6 3.1L8.57 18h13.24l2.1-12.73L6.17 5.1z"></path>
+    </g>
+    <g id="menubar-phone-menu-icon">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 6.25H3V4.75H21V6.25Z" fill="#222222"></path>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 12.75H3V11.25H21V12.75Z" fill="#222222"></path>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 19.75L3 19.75V18.25H12L21 18.25V19.75Z" fill="#222222"></path>
+    </g>
+    <g id="bandcamp-logo-color-bcaqua">
+        <path d="M26.62 0h2.42v5.8h.04a3.96 3.96 0 013.28-1.78c3.46 0 5.14 2.73 5.14 6.05C37.5 13.12 36 16 32.76 16c-1.49 0-3.08-.37-3.8-1.87h-.05v1.57h-2.3V0m5.43 6c-2.04 0-3.08 1.6-3.08 4.02 0 2.29 1.12 4 3.08 4 2.2 0 3.04-2.02 3.04-4 0-2.06-1.05-4.02-3.04-4.02" id="b" fill="#333"></path>
+        <path d="M56.26 4.05c-1.44 0-2.7.77-3.42 2.03l-.04-.05V4.36h-2.3v9.68l-1.61.01c-.45 0-.58-.24-.58-.85V7.35c0-2.4-2.25-3.3-4.4-3.3-2.42 0-4.82.86-4.99 3.78h2.42c.11-1.23 1.07-1.8 2.43-1.8.97 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.87 1.38.4 0 1.17-.15 4.96-.28v-.03h.02v-6.7c0-1.67 1.04-2.99 2.65-2.99 1.42 0 2.1.77 2.15 2.55v7.14h2.42v-7.8c0-2.55-1.5-3.87-3.88-3.87zM45.9 11.9c0 1.58-1.66 2.15-2.72 2.15-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87z" id="an" fill="#333"></path>
+        <path d="M72.62 15.7h-2.29v-1.54h-.04c-.64 1.3-2.02 1.84-3.4 1.84-3.47 0-5.14-2.66-5.14-6.06 0-4.12 2.35-5.92 4.76-5.92 1.38 0 2.9.53 3.65 1.78h.04V0h2.43v15.7m-5.42-1.68c2.16 0 3.08-2.04 3.08-4.02 0-2.5-1.17-4-3.04-4-2.27 0-3.08 2.09-3.08 4.13 0 1.96.93 3.9 3.04 3.9" id="d" fill="#333"></path>
+        <path d="M82.25 8.16c-.19-1.38-1.17-2.13-2.5-2.13-1.26 0-3.02.68-3.02 4.13 0 1.9.8 3.9 2.9 3.9 1.41 0 2.39-.97 2.62-2.6h2.42c-.44 2.95-2.2 4.57-5.03 4.57-3.44 0-5.34-2.53-5.34-5.87 0-3.43 1.81-6.1 5.42-6.1 2.55 0 4.72 1.31 4.95 4.1h-2.41" id="c" fill="#333"></path>
+        <path d="M106.44 5.94c-.5-1.3-1.75-1.89-3.09-1.89-1.74 0-2.65.77-3.37 1.9l-.07-1.59h-2.3v9.68l-1.61.01c-.45 0-.57-.24-.57-.85V7.35c0-2.4-2.26-3.3-4.4-3.3-2.42 0-4.83.86-5 3.78h2.43c.1-1.23 1.06-1.8 2.42-1.8.98 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.88 1.38.4 0 1.16-.15 4.92-.28l.05-6.77c0-1.9 1.15-2.95 2.4-2.95 1.47 0 1.93.84 1.93 2.4v7.3h2.43V9.05c0-1.9.7-3.03 2.33-3.03 1.9 0 2 1.25 2 3.06v6.63h2.42V7.88c0-2.77-1.36-3.83-3.67-3.83-1.6 0-2.64.73-3.44 1.9zm-16.15 8.11c-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87c0 1.58-1.66 2.15-2.72 2.15z" id="am" fill="#333"></path>
+        <path d="M118.04 4.36V5.9h.04c.68-1.3 2-1.85 3.4-1.85 3.46 0 5.14 2.73 5.14 6.05 0 3.05-1.48 5.93-4.74 5.93-1.4 0-2.9-.53-3.67-1.78h-.05v5.67h-2.42V4.36h2.3zm.04 5.7c0 2.28 1.13 4 3.08 4 2.21 0 3.04-2.03 3.04-4 0-2.07-1.04-4.03-3.04-4.03-2.04 0-3.08 1.6-3.08 4.02z" id="p" fill="#333"></path>
+        <path id="rhomboid" fill="#1DA0C3" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"></path>
+    </g>
+    <g id="bandcamp-logo-color-white" fill="#FFF">
+        <path d="M26.62 0h2.42v5.8h.04a3.96 3.96 0 013.28-1.78c3.46 0 5.14 2.73 5.14 6.05C37.5 13.12 36 16 32.76 16c-1.49 0-3.08-.37-3.8-1.87h-.05v1.57h-2.3V0m5.43 6c-2.04 0-3.08 1.6-3.08 4.02 0 2.29 1.12 4 3.08 4 2.2 0 3.04-2.02 3.04-4 0-2.06-1.05-4.02-3.04-4.02" id="b"></path>
+        <path d="M56.26 4.05c-1.44 0-2.7.77-3.42 2.03l-.04-.05V4.36h-2.3v9.68l-1.61.01c-.45 0-.58-.24-.58-.85V7.35c0-2.4-2.25-3.3-4.4-3.3-2.42 0-4.82.86-4.99 3.78h2.42c.11-1.23 1.07-1.8 2.43-1.8.97 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.87 1.38.4 0 1.17-.15 4.96-.28v-.03h.02v-6.7c0-1.67 1.04-2.99 2.65-2.99 1.42 0 2.1.77 2.15 2.55v7.14h2.42v-7.8c0-2.55-1.5-3.87-3.88-3.87zM45.9 11.9c0 1.58-1.66 2.15-2.72 2.15-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87z" id="an"></path>
+        <path d="M72.62 15.7h-2.29v-1.54h-.04c-.64 1.3-2.02 1.84-3.4 1.84-3.47 0-5.14-2.66-5.14-6.06 0-4.12 2.35-5.92 4.76-5.92 1.38 0 2.9.53 3.65 1.78h.04V0h2.43v15.7m-5.42-1.68c2.16 0 3.08-2.04 3.08-4.02 0-2.5-1.17-4-3.04-4-2.27 0-3.08 2.09-3.08 4.13 0 1.96.93 3.9 3.04 3.9" id="d"></path>
+        <path d="M82.25 8.16c-.19-1.38-1.17-2.13-2.5-2.13-1.26 0-3.02.68-3.02 4.13 0 1.9.8 3.9 2.9 3.9 1.41 0 2.39-.97 2.62-2.6h2.42c-.44 2.95-2.2 4.57-5.03 4.57-3.44 0-5.34-2.53-5.34-5.87 0-3.43 1.81-6.1 5.42-6.1 2.55 0 4.72 1.31 4.95 4.1h-2.41" id="c"></path>
+        <path d="M106.44 5.94c-.5-1.3-1.75-1.89-3.09-1.89-1.74 0-2.65.77-3.37 1.9l-.07-1.59h-2.3v9.68l-1.61.01c-.45 0-.57-.24-.57-.85V7.35c0-2.4-2.26-3.3-4.4-3.3-2.42 0-4.83.86-5 3.78h2.43c.1-1.23 1.06-1.8 2.42-1.8.98 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.88 1.38.4 0 1.16-.15 4.92-.28l.05-6.77c0-1.9 1.15-2.95 2.4-2.95 1.47 0 1.93.84 1.93 2.4v7.3h2.43V9.05c0-1.9.7-3.03 2.33-3.03 1.9 0 2 1.25 2 3.06v6.63h2.42V7.88c0-2.77-1.36-3.83-3.67-3.83-1.6 0-2.64.73-3.44 1.9zm-16.15 8.11c-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87c0 1.58-1.66 2.15-2.72 2.15z" id="am"></path>
+        <path d="M118.04 4.36V5.9h.04c.68-1.3 2-1.85 3.4-1.85 3.46 0 5.14 2.73 5.14 6.05 0 3.05-1.48 5.93-4.74 5.93-1.4 0-2.9-.53-3.67-1.78h-.05v5.67h-2.42V4.36h2.3zm.04 5.7c0 2.28 1.13 4 3.08 4 2.21 0 3.04-2.03 3.04-4 0-2.07-1.04-4.03-3.04-4.03-2.04 0-3.08 1.6-3.08 4.02z" id="p"></path>
+        <path id="rhomboid" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"></path>
+    </g>
+    <g id="bandcamp-rhomboid-white">
+        <path id="rhomboid" fill="#FFF" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"></path>
+    </g>
+    <g id="mobile-cart-up">
+        <path fill="#fff" stroke="#eee" d="M5 12L16 1h0l11 11"></path>
+        <path fill="none" id="blocking" stroke="#fff" stroke-width="2" d="M4.5 12H27"></path>
+    </g>
+    <defs>
+        <linearGradient x1="50%" y1="100%" x2="50%" y2="0%" id="fanAppGradient">
+            <stop stop-color="#00BAEF" offset="0%"></stop>
+            <stop stop-color="#1DA0C3" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="fan-app-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mobileweb-fanartist-02" transform="translate(-86 -385)">
+            <g id="Group">
+                <g id="menu" transform="translate(58 39)">
+                    <g id="fan-app-icon" transform="translate(28 346)">
+                        <rect id="bg" fill="#FFF" x="0" y="0" width="23" height="23" rx="3"></rect>
+                        <path id="tent" fill="url(#fanAppGradient)" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g id="artist-app-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mobileweb-fanartist-02" transform="translate(-86 -334)">
+            <g id="Group">
+                <g id="menu" transform="translate(58 39)">
+                    <g id="artist-app-icon" transform="translate(28 295)">
+                        <rect id="bg" fill="#4999AD" x="0" y="0" width="23" height="23" rx="3"></rect>
+                        <path id="tent" fill="#FFF" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <path id="embed-icon" d="M16.9 2.3L22 6.97l-5.1 4.68c-.43.43-1 .43-1.43 0-.43-.43-.4-1.13.02-1.57l3.42-3.1-3.42-3.12a1.12 1.12 0 01-.02-1.56c.43-.43 1-.43 1.43 0zm-6.48 10.76c-.14.63-.62.98-1.2.87-.58-.12-.93-.72-.8-1.35L11.47.88c.14-.62.62-.97 1.2-.86.58.12.93.72.8 1.35l-2.8 10.77-.24.92zM5.1 2.3c.43-.43 1-.43 1.43 0 .43.43.43 1.13 0 1.56L3.1 6.97l3.44 3.11c.43.44.43 1.14 0 1.57-.42.43-1 .43-1.43 0L0 6.97 5.1 2.3z"></path>
+    <path id="email-link" d="M0 2C0 .9.9 0 2 0h14a2 2 0 012 2v8a2 2 0 01-2 2H2a2 2 0 01-2-2V2zm16.06 9l.94-.9-4.7-4.55L17 1.9 16.06 1 9.24 6.47h-.48L1.94 1 1 1.9l4.7 3.65L1 10.09l.94.91 4.7-4.55 2.12 1.82h.48l2.11-1.82 4.7 4.55z"></path>
+    <path id="reddit-share" d="M24 11.78a2.65 2.65 0 00-4.5-1.9 13.7 13.7 0 00-6.97-2.05l1.49-4.66 4.01.94v.05a2.17 2.17 0 004.34 0 2.17 2.17 0 00-4.2-.78l-4.32-1.02a.37.37 0 00-.44.25l-1.66 5.21c-2.83.03-5.4.8-7.3 2.03a2.64 2.64 0 10-3.13 4.2c-.06.28-.09.57-.09.86 0 3.9 4.8 7.09 10.72 7.09s10.72-3.18 10.72-7.1c0-.27-.03-.54-.08-.8A2.63 2.63 0 0024 11.78zM6.78 13.6a1.58 1.58 0 013.16 0 1.58 1.58 0 01-3.16 0zm9.06 4.66c-.8.8-2.05 1.18-3.83 1.18H12c-1.78 0-3.03-.38-3.83-1.18a.37.37 0 010-.52.37.37 0 01.53 0c.65.65 1.73.96 3.3.96H12c1.57 0 2.65-.31 3.3-.96a.37.37 0 01.53 0c.14.14.14.38 0 .52zm-.2-3.1c-.86 0-1.57-.7-1.57-1.57a1.58 1.58 0 013.16 0c0 .87-.71 1.58-1.58 1.58z"></path>
+    <path id="copy-icon" d="M16.95 7.05a1 1 0 010 1.41l-8.48 8.49a1 1 0 11-1.42-1.41l8.49-8.49a1 1 0 011.4 0zm-5.8 10.04A4.2 4.2 0 0110 19.2l-1.66 1.65c-1.56 1.56-3.99 1.67-5.41.24-1.43-1.43-1.33-3.86.23-5.42L4.82 14c.6-.6 1.33-.98 2.09-1.14l1.93-1.94c-1.82-.3-3.83.3-5.31 1.79l-1.66 1.66c-2.35 2.34-2.5 5.98-.36 8.12 2.15 2.15 5.79 1.99 8.12-.35l1.66-1.66a6.14 6.14 0 001.79-5.32l-1.94 1.93zm3.22-15.23L12.7 3.52a6.14 6.14 0 00-1.79 5.32l1.94-1.93c.16-.76.54-1.49 1.14-2.1l1.66-1.65c1.56-1.56 3.99-1.66 5.42-.24 1.43 1.43 1.32 3.86-.24 5.42L19.18 10c-.6.6-1.33.98-2.08 1.14l-1.94 1.94c1.82.3 3.83-.3 5.32-1.78l1.66-1.67c2.34-2.34 2.5-5.97.35-8.12-2.14-2.14-5.78-1.98-8.12.35z"></path>
+    <path id="share-icon" d="M6 17A15.24 15.24 0 0117 5.33V2l7 6.64-7 6.7V12s-6.17-.17-11 5zm12 .14V20H2V8h6.6a17 17 0 012.34-2H0v16h20v-6.77l-2 1.91z"></path>
+<!--hubs-->
+    <g transform="translate(-1036 -601)" fill-rule="nonzero" stroke="#323232" id="hub-page-next" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 602.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 624l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape"></path>
+    </g>
+    <g transform="translate(-1036 -655)" fill-rule="nonzero" stroke="#323232" id="hub-page-prev" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 656.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 678l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape" transform="matrix(-1 0 0 1 2100 0)"></path>
+    </g>
+    <g transform="translate(-1036 -601)" fill-rule="nonzero" stroke="#FFF" id="hub-page-next-light" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 602.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 624l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape"></path>
+    </g>
+    <g transform="translate(-1036 -655)" fill-rule="nonzero" stroke="#FFF" id="hub-page-prev-light" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 656.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 678l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape" transform="matrix(-1 0 0 1 2100 0)"></path>
+    </g>
+    <g id="material-close">
+        <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+        <path d="M0 0h24v24H0z" fill="none"></path>
+    </g>
+    <g id="material-add">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
+    </g>
+    <g id="material-arrow-fwd">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"></path>
+    </g>
+    <g id="material-done">
+        <path fill="none" d="M0 0h24v24H0z"></path>
+        <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"></svg>-->
+    <g id="material-queue">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M15 6H3v2h12V6zm0 4H3v2h12v-2zM3 16h8v-2H3v2zM17 6v8.18A3 3 0 1019 17V8h3V6h-5z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"></svg>-->
+    <g id="material-vol-up">
+        <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3A4.5 4.5 0 0014 7.97v8.05A4.47 4.47 0 0016.5 12zM14 3.23v2.06a7 7 0 010 13.42v2.06a9 9 0 000-17.54z" id="Shape" fill="#333" fill-rule="nonzero"></path>
+    </g>
+    <path fill="#333" d="M3 9v6h4l5 5V4L7 9z" id="material-vol-mute"></path>
+    <g id="material-unlock">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6A5 5 0 007 6h1.9a3.1 3.1 0 016.2 0v2H6a2 2 0 00-2 2v10c0 1.1.9 2 2 2h12a2 2 0 002-2V10a2 2 0 00-2-2zm0 12H6V10h12v10z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 128 128" > <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-heart"></use> </svg>-->
+    <path d="M25.75 36.06C10.4 51.72 18.82 70.11 41.2 90.41a249.17 249.17 0 0115.33 15.21c1.63 1.77 3.09 3.4 4.34 4.84.76.86 1.27 1.48 1.54 1.8l1.44 1.74 1.4-1.8 1.46-1.79A201.31 201.31 0 0185.85 90.4c23.11-21 31.63-39.47 15.27-54.3-11.46-10.04-22.82-8-32.73 1.29a44.91 44.91 0 00-4.78 5.28l-.1.13-.09-.13a41.46 41.46 0 00-4.48-5.45C53.8 32 48.12 29 42.04 29c-5.19 0-10.65 2.19-16.29 7.06z" id="material-heart"></path>
+<!--<svg width="16px" height="15px" viewBox="0 0 16 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="material-comment">
+        <path id="ic-comment" d="M14.93 0c.59 0 1.06.48 1.07 1.08v8.57c0 .59-.48 1.06-1.07 1.06H8V15l-4.27-4.29H1.07c-.59 0-1.06-.47-1.07-1.06V1.08C0 .48.48 0 1.07 0h13.86zM1.5 1.5V9.2h2.86l2.14 2.16V9.2h8V1.5h-13z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-keyboard-up"></use></svg>-->
+    <g id="material-keyboard-up">
+        <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path>
+        <path d="M0 0h24v24H0z" fill="none"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-keyboard-down"></use></svg>-->
+    <g id="material-keyboard-down">
+        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"></path>
+        <path fill="none" d="M0 0h24v24H0V0z"></path>
+    </g>
+    <defs>
+        <linearGradient id="pledge-processing-mask" x1="50%" x2="50%" y1="0%" y2="100%">
+            <stop offset="0%" stop-color="#F8E71C"></stop>
+            <stop offset="100%" stop-color="#4E8E25"></stop>
+        </linearGradient>
+    </defs>
+    <path d="M50.17 100.08l5.33 4.51c.49.69-.73 1.95-1.5 1.5l-8-7 8-7c.77-.44 1.99.82 1.5 1.5l-5.3 4.49a45 45 0 001.06-89.93l2.12-1.85a47 47 0 01-3.21 93.78zM45.46 6.12L40.1 1.59c-.48-.68.73-1.94 1.5-1.5l8 7-8 7c-.77.45-1.98-.81-1.5-1.5l5.29-4.47a45 45 0 00-1.03 89.9l-2.1 1.84a47 47 0 013.19-93.74zm1.14 71.27v-5.4a22.16 22.16 0 01-12.75-5.57l2.43-3.24c3.24 2.92 6.43 4.7 10.48 5.13v-13.5c-8-1.89-11.5-4.86-11.5-10.47v-.11c0-5.56 4.7-9.61 11.34-9.94v-3.13h3.45v3.24c4.05.38 7.18 1.9 10.32 4.32l-2.33 3.24c-2.59-2.21-5.29-3.4-8.15-3.89v13.29c8.2 1.89 11.66 5.02 11.66 10.47v.11c0 5.78-4.7 9.72-11.5 10.15v5.3H46.6zm.16-26.79V37.91c-4.54.16-7.35 2.76-7.35 6.05v.1c0 3.03 1.4 5.03 7.35 6.54zm3.13 17.88c4.59-.22 7.5-2.76 7.5-6.27v-.1c0-3.2-1.5-5.08-7.5-6.54v12.9z" transform="translate(0 .9)" id="pledge-processing"></path>
+<!--common icons-->
+    <g id="help" fill="none" fill-rule="evenodd">
+        <rect width="15" height="15" fill="#B8B8B8" rx="7.5"></rect>
+        <path fill="#FFF" d="M6.57 9.8h1.72v1.7H6.57V9.8zM4.79 6.19c.01-.4.08-.76.2-1.1.14-.32.32-.6.55-.85.23-.24.5-.43.83-.57a3.45 3.45 0 012.4.01c.35.15.63.32.84.54a1.93 1.93 0 01.6 1.37 2.14 2.14 0 01-.93 1.86l-.47.35c-.15.11-.28.24-.4.39-.1.14-.18.33-.2.55v.42H6.7v-.5a2.25 2.25 0 01.54-1.34c.13-.15.27-.28.42-.39.14-.1.28-.22.4-.33.13-.1.23-.23.3-.36a.9.9 0 00.1-.5c0-.33-.07-.58-.24-.74a.94.94 0 00-.69-.24c-.2 0-.36.03-.5.11-.15.08-.27.18-.36.3-.1.14-.16.29-.2.46-.05.17-.07.36-.07.56H4.8z"></path>
+    </g>
+    <g id="ic-add-video">
+        <path d="M88 32a8 8 0 018 8v19l24-24v69L96 80v16a8 8 0 01-8 8H16a8 8 0 01-8-8V40a8 8 0 018-8h72zM56 52h-8v12H36v8h12v12h8V72h12v-8H56V52z" id="ic-add-video"></path>
+    </g>
+    <g id="ic-add-photo">
+        <path d="M104 8H88a8 8 0 00-8-8H32a8 8 0 00-8 8H8a8 8 0 00-8 8v56a8 8 0 008 8h96a8 8 0 008-8V16a8 8 0 00-8-8zM56 68a24 24 0 110-48 24 24 0 010 48zm4-40h-8v12H40v8h12v12h8V48h12v-8H60V28z" id="ic-add-photo"></path>
+    </g>
+    <path fill="#1DA0C3" fill-rule="evenodd" d="M8.86 8.26H0L4.14.62H13L8.86 8.26" id="bc-logo-tent"></path>
+<!--<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="contextual-dots" stroke="none" fill="none" fill-rule="evenodd">
+        <g transform="translate(7 17)" fill="#818285">
+            <circle cx="3" cy="3" r="3"></circle>
+            <circle cx="13" cy="3" r="3"></circle>
+            <circle cx="23" cy="3" r="3"></circle>
+        </g>
+        <path d="M0 0h40v40H0z"></path>
+    </g>
+<!--<svg width="128px" height="128px" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="report-flag-icon">
+        <path fill="none" d="M0 0h128v128H0z"></path>
+        <path d="M34.56 20v95.7h-7.9V20h7.9zm7.78 5.01s9.54-10 19.34 0c21.28 21.72 40.61-.65 40.61-.65v46.58s-19.33 22.37-40.61.65c-9.8-10-19.34 0-19.34 0z"></path>
+    </g>
+
+
+    <!-- <svg id="icon-allow-comment" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="allow-comment-icon">
+        <polygon points="15.981 3 6.573 13.501 2.708 9.635 2 10.342 6.614 14.956 16.726 3.668"></polygon>
+    </g>
+
+    <!-- <svg class="live-calendar-icon" viewBox="0 0 12 11"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#live-calendar-icon"></use></svg> -->
+    <g id="live-calendar-icon" fill="none" fill-rule="evenodd">
+        <g id="live-calendar-icon-stroke" transform="translate(-1033 -482)" stroke-width=".9">
+            <g id="component/event-card/4-col" transform="translate(744 209.5)">
+                <g id="Group" transform="translate(289 272)">
+                    <rect id="Rectangle" x=".45" y="2.65" width="10.73" height="8.36" rx="1.8"></rect>
+                    <path id="Path" d="M2.91.66v3.08M8.72.66v3.08"></path>
+                    <path id="Path-4" d="M.83 5.67h10.8"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+
+    <!-- <svg class="live-clock-icon" viewBox="0 0 12 11"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#live-clock-icon"></use></svg> -->
+    <g id="live-clock-icon" fill="none" fill-rule="evenodd">
+        <g id="live-clock-icon-stroke" transform="translate(-1033 -499)">
+            <g id="component/event-card/4-col" transform="translate(744 209.5)">
+                <g id="icon/clock" transform="translate(289 289)">
+                    <circle id="Oval" cx="6" cy="6.5" r="5.5"></circle>
+                    <path id="Path-5" d="M6 2.53V7h3.03"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+
+
+
+    <!-- <svg id="icon-ban" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="ban-user-icon">
+        <path d="M8.0002,0.0002 C3.5822,0.0002 0.0002,3.5822 0.0002,8.0002 C0.0002,12.4182 3.5822,16.0002 8.0002,16.0002 C12.4182,16.0002 16.0002,12.4182 16.0002,8.0002 C16.0002,3.5822 12.4182,0.0002 8.0002,0.0002 L8.0002,0.0002 Z M8.0002,1.0002 C11.8602,1.0002 15.0002,4.1402 15.0002,8.0002 C15.0002,11.8592 11.8602,15.0002 8.0002,15.0002 C4.1402,15.0002 1.0002,11.8592 1.0002,8.0002 C1.0002,4.1402 4.1402,1.0002 8.0002,1.0002 L8.0002,1.0002 Z M8.7072,8.0002 L11.6472,10.9402 L10.9402,11.6472 L8.0002,8.7072 L5.0592,11.6472 L4.3522,10.9402 L7.2922,8.0002 L4.3522,5.0592 L5.0592,4.3522 L8.0002,7.2932 L10.9402,4.3522 L11.6472,5.0592 L8.7072,8.0002 Z"></path>
+    </g>
+
+
+    <!-- <svg id="icon-delete-comment" fill-rule="evenodd" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="delete-comment-icon" fill-rule="evenodd">
+        <path d="M10.5,14.518 L11.5,14.518 L11.5,5.37 L10.5,5.37 L10.5,14.518 Z M6.5,14.518 L7.5,14.518 L7.5,5.37 L6.5,5.37 L6.5,14.518 Z M4.017,16.002 L14.017,16.002 L14.017,3.887 L4.017,3.887 L4.017,16.002 Z M6.464,2.887 L11.536,2.887 L11.536,2 L6.464,2 L6.464,2.887 Z M14.001,2.887 L12.536,2.887 L12.536,1 L5.464,1 L5.464,2.887 L3.999,2.887 L1,2.887 L1,3.887 L3,3.887 L3,15.989 C3,16.541 3.447,16.988 3.999,16.988 L14.001,16.988 C14.553,16.988 15,16.541 15,15.989 L15,3.887 L17,3.887 L17,2.887 L14.001,2.887 Z"></path>
+    </g>
+
+    <!-- <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"></svg> -->
+    <g id="ic-edit">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="m12.02 6.27 1.06-1.07a.56.56 0 0 0 .17-.41c0-.16-.06-.3-.17-.41l-1.36-1.36a.56.56 0 0 0-.4-.17c-.17 0-.31.06-.42.17L9.83 4.08l2.19 2.19zm-7.09 7.08L11.4 6.9 9.2 4.7l-6.45 6.46v2.18h2.18z"></path>
+        </svg>
+    </g>
+
+    <!-- <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-tooltip">
+        <path d="M8 15.06a6.55 6.55 0 0 0 5.74-3.28c.61-1.04.92-2.16.92-3.38a6.55 6.55 0 0 0-3.28-5.74A6.55 6.55 0 0 0 8 1.74c-1.2 0-2.33.3-3.36.92-1 .58-1.8 1.38-2.38 2.38a6.52 6.52 0 0 0-.92 3.36c0 1.2.3 2.33.92 3.36A6.55 6.55 0 0 0 8 15.06zm0-1.32a5.2 5.2 0 0 1-2.69-.73 5.18 5.18 0 0 1-1.92-1.92 5.2 5.2 0 0 1 0-5.38A5.18 5.18 0 0 1 5.31 3.8a5.2 5.2 0 0 1 5.38 0c.8.47 1.45 1.11 1.92 1.92a5.2 5.2 0 0 1 0 5.38A5.18 5.18 0 0 1 10.69 13a5.2 5.2 0 0 1-2.69.73zm.66-3.34c0-.33.1-.64.32-.93.11-.16.34-.38.67-.68.33-.3.56-.53.69-.73.2-.3.32-.64.32-1A2.72 2.72 0 0 0 8 4.4a2.72 2.72 0 0 0-2.66 2.66h1.32c0-.37.13-.68.4-.93.26-.26.58-.39.94-.39s.68.13.94.39c.27.25.4.56.4.93 0 .24-.07.46-.2.65-.1.14-.27.3-.5.48l-.6.48a2.19 2.19 0 0 0-.7 1.73h1.32zm0 2v-1.34H7.34v1.34h1.32z" fill="#999"></path>
+    </g>
+
+    <!-- <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-camera-small">
+        <path d="M9.21 5.93H7.57v1.65h-.93V5.93H5V5h1.64V3.36h.93V5h1.64v.93zm-2.13 3.1A3.57 3.57 0 0 1 3.53 5.5c0-1.94 1.6-3.54 3.55-3.54 1.93 0 3.54 1.6 3.54 3.54s-1.6 3.54-3.54 3.54zm6.2-7.86h-2.75C10.53.53 10 0 9.36 0H4.68C4.03 0 3.5.53 3.5 1.17H.76a.77.77 0 0 0-.76.76v7.43c0 .4.35.76.76.76h12.46c.4 0 .76-.35.76-.76V1.93c.11-.41-.24-.76-.7-.76z"></path>
+    </g>
+
+    <!-- <svg width="326" height="324" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-spinny">
+        <g transform="translate(0 2)" opacity=".99" fill="none" fill-rule="evenodd">
+            <circle fill="#A4A4A5" cx="161" cy="287" r="35"></circle>
+            <circle fill="#606463" cx="161" cy="35" r="35"></circle>
+            <circle fill="#D2D2D1" transform="rotate(90 35 161)" cx="35" cy="161" r="35"></circle>
+            <circle fill="#7C7F7E" transform="rotate(90 287 161)" cx="287" cy="161" r="35"></circle>
+            <circle fill="#BBBAB9" transform="rotate(45 71.9 250.1)" cx="71.9" cy="250.1" r="35"></circle>
+            <circle fill="#717474" transform="rotate(45 250.1 71.9)" cx="250.1" cy="71.9" r="35"></circle>
+            <circle fill="#DCDCDC" transform="rotate(135 71.9 71.9)" cx="71.9" cy="71.9" r="35"></circle>
+            <circle fill="#8D8F8F" transform="rotate(135 250.1 250.1)" cx="250.1" cy="250.1" r="35"></circle>
+        </g>
+    </g>
+    <!-- <svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg> -->
+    <path id="discover-arrow" d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"></path>
+    <g id="fan-app-icon" fill="none" fill-rule="evenodd">
+        <rect fill="#FFF" width="23" height="23" rx="3"></rect>
+        <path fill="url(#fanAppGradient)" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"></path>
+    </g>
+
+    <!-- <svg width="22px" height="15px" viewBox="0 0 22 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"> -->
+    <g id="view-eyeball-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="adminControls---OFF-AIR-Copy" transform="translate(-823.000000, -743.000000)">
+            <g id="component/video/sound-check" transform="translate(134.000000, 222.000000)">
+                <g id="Group" transform="translate(689.000000, 521.000000)">
+                    <g transform="translate(0.000000, 0.000000)" id="Oval">
+                        <circle fill="currentColor" cx="11" cy="7.28" r="3"></circle>
+                        <path d="M11,1 C15.6667595,1 19.5502286,5.64619254 20.7714147,7.28017631 C19.5496534,8.91449561 15.6664139,13.56 11,13.56 C6.33324048,13.56 2.44977141,8.91380746 1.22858526,7.27982369 C2.45034662,5.64550439 6.33358609,1 11,1 Z" stroke="currentColor" stroke-width="2"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+
+    <path id="check" fill="none" stroke-width="1.5" d="M1.5 6.5l4 5 8-11"></path>
+    <g id="two-person-silhouette">
+        <path d="M12.81 8.64c-.244-.359-.808-.605-1.858-.986-1.046-.38-1.38-.701-1.38-1.388 0-.412.32-.277.46-1.032.058-.313.34-.005.394-.72 0-.285-.154-.357-.154-.357s.078-.42.109-.745c.037-.404-.042-1.579-1.494-1.579S6.971 3.008 7.01 3.413c.03.323.108.744.108.744s-.154.072-.154.357c.054.715.336.407.394.72.14.755.46.62.46 1.032 0 .467-.156.765-.583 1.027 2.284.995 2.24 1.2 2.24 2.09V11H13s-.028-2.12-.19-2.36zm-6.046-.7c-1.308-.518-1.726-.954-1.726-1.888 0-.56.399-.378.574-1.404.072-.426.426-.007.493-.98 0-.387-.192-.484-.192-.484s.098-.573.136-1.014C6.097 1.62 5.676 0 3.859 0 2.044 0 1.782 1.62 1.83 2.17c.039.441.136 1.014.136 1.014s-.192.097-.192.484c.067.973.42.554.493.98.175 1.026.575.843.575 1.404 0 .934-.418 1.37-1.727 1.887C.717 8.097 0 8.213 0 8.8V11h8.821V9.35c0-.536-.745-.892-2.057-1.41z"></path>
+    </g>
+
+    
+    <path id="read-more-arr" d="M10.815,3.12018899 C10.809,3.11518899 6.58,0.0611889922 6.58,0.0611889922 C6.427,-0.0388110078 6.221,-0.0138110078 6.097,0.124188992 C5.973,0.260188992 5.967,0.467188992 6.083,0.610188992 L7.863,3.00018899 L0.5,3.00018899 C0.224,3.00018899 0,3.22418899 0,3.50018899 C0,3.77618899 0.224,4.00018899 0.5,4.00018899 L7.863,4.00018899 L6.083,6.39018899 C5.967,6.53318899 5.973,6.74018899 6.097,6.87618899 C6.221,7.01418899 6.427,7.03918899 6.58,6.93918899 L10.802,3.89918899 C10.926,3.78818899 11,3.65518899 11,3.50018899 C11,3.34518899 10.926,3.21218899 10.815,3.12018899 Z"></path>
+    <path id="close-weekly-archive" d="M7.4,6l2.8-2.8c0.4-0.4,0.4-1,0-1.4c-0.4-0.4-1-0.4-1.4,0L6,4.6L3.2,1.8c-0.4-0.4-1-0.4-1.4,0 c-0.4,0.4-0.4,1,0,1.4L4.6,6L1.8,8.8c-0.4,0.4-0.4,1,0,1.4c0.4,0.4,1,0.4,1.4,0L6,7.4l2.8,2.8c0.4,0.4,1,0.4,1.4,0 c0.4-0.4,0.4-1,0-1.4L7.4,6z"></path>
+    <path id="nn-view-album" d="M1.43682992,0L0 1.44492059 9.03679561 10.0650366 0.00617548675 18.5439879 1.43065443 20 12 10.0771364z"></path>
+    <path id="nn-own-this" d="M18.1085095,1.66536531 C16.7611171,0.429117108 15.3262573,-0.0849663045 13.8432411,0.146575233 C12.1400821,0.40973698 10.7946553,1.62150502 9.97698178,2.57215133 C9.22220618,1.60722493 7.97112632,0.38423681 6.31317524,0.0741547518 C4.77610618,-0.210427137 3.24493381,0.32099639 1.70786476,1.71942567 C0.531476234,2.97709402 -0.0414849278,4.41734358 0.00274020481,6.00039409 C0.0725176362,8.52287084 1.68722637,11.252409 4.93728222,14.3481295 L4.93728222,14.3491495 C7.46106312,16.7492254 9.23596511,18.9850803 9.25365516,19.0075204 L10.0379142,19.999987 L10.791707,18.9840603 C10.8084143,18.9616201 12.4820898,16.7186252 14.973439,14.3450695 C18.3561702,11.1198081 20.0013452,8.32804954 20.0003624,5.81169284 C20.0003624,4.25516251 19.3674516,2.86489328 18.1085095,1.66536531"></path>
+    <path id="nn-wishlisted" d="M18.1081467,1.66537829 C16.7607543,0.429130081 15.3258944,-0.0849533313 13.8428783,0.146588206 C12.1397193,0.409749953 10.7942925,1.621518 9.97661895,2.57216431 C9.22184336,1.6072379 7.97076349,0.384249783 6.31281241,0.074167725 C4.77574336,-0.210414164 3.24457099,0.321009364 1.70750194,1.71943865 C0.531113412,2.977107 -0.0418477507,4.41735656 0.00237738193,6.00040707 C0.0721548134,8.52288381 1.68686354,11.2524219 4.9369194,14.3481425 L4.9369194,14.3491625 C7.4607003,16.7492384 9.23560229,18.9850933 9.25329234,19.0075334 L10.0375514,20 L10.7913442,18.9840733 C10.8080514,18.9616331 12.481727,16.7186382 14.9730762,14.3450825 C18.3558074,11.1198211 20.0009823,8.32806252 19.9999996,5.81170581 C19.9999996,4.25517548 19.3670888,2.86490625 18.1081467,1.66537829"></path>
+    <path id="nn-add-wishlist" d="M6.26532856,12.8438659 C7.90059563,14.4003455 9.21450913,15.8670674 9.99381609,16.7758637 C10.7485547,15.8548277 12.0251244,14.3840259 13.643685,12.8428459 C16.5574872,10.0634181 18.0355171,7.69911951 18.0345343,5.81216853 C18.0345343,4.83707385 17.6286658,3.97621622 16.793343,3.18165685 C15.9010218,2.36261813 15.0195107,2.02806682 14.1311204,2.16474327 C12.2285501,2.45747566 10.7858986,4.80953457 10.7711576,4.83299396 L9.87981911,6.33643491 L9.07004744,4.78403523 C9.05923738,4.76261579 7.80428783,2.42075662 5.95675052,2.08110544 C5.03494733,1.91178984 4.06302478,2.28714009 3.05965478,3.19797643 C2.31474346,3.99967561 1.93835687,4.91561181 1.96685611,5.94170516 C2.02090641,7.85619543 3.46650608,10.1786751 6.26532856,12.8448859 L6.26532856,12.8438659 Z M10.0370563,20 L9.2528357,19.0075658 C9.23514652,18.9851264 7.46033142,16.7493444 4.93667407,14.3483268 L4.93667407,14.3473068 C1.68677732,11.2516872 0.0731303674,8.52223813 0.00237361922,6.00086363 C-0.0418493484,4.41786474 0.532066498,2.97766215 1.7074147,1.72003482 C3.24440851,0.320631169 4.77452319,-0.209755055 6.31249973,0.07379758 C7.96938691,0.384889499 9.22138826,1.60681776 9.97612691,2.5717127 C10.7927777,1.62211736 12.1391214,0.409368864 13.842197,0.147235672 C15.3221923,-0.0822583664 16.7599301,0.42874836 18.1082393,1.66597622 C19.3671198,2.86444509 19.9990168,4.25568896 19.9999996,5.81216853 C20.0009823,8.32742319 18.3558879,11.1190907 14.9723395,14.3452669 C12.4811123,16.7177253 10.8085014,18.960647 10.7908122,18.9841064 L10.0370563,20 Z"></path>
+    <path id="bc-daily-expand" d="M9,4H6V1c0-0.6-0.4-1-1-1S4,0.4,4,1v3H1C0.4,4,0,4.4,0,5c0,0.6,0.4,1,1,1h3v3c0,0.6,0.4,1,1,1 s1-0.4,1-1V6h3c0.6,0,1-0.4,1-1C10,4.4,9.6,4,9,4z"></path>
+    
+</svg>
+
+
+
+
+
+<div id="pagedata" data-blob="{&quot;recaptcha_public_key&quot;:&quot;6LfhSPgSAAAAAPwto_qzHuwSmjgfrkg35xXXu_8K&quot;,&quot;invisible_recaptcha_public_key&quot;:&quot;6Ld7hz4UAAAAANlndw60vAheGUwN0Mb-qeWD_LHr&quot;,&quot;localize_page&quot;:true,&quot;locale&quot;:&quot;en&quot;,&quot;languages&quot;:{&quot;en&quot;:&quot;English&quot;,&quot;de&quot;:&quot;Deutsch&quot;,&quot;es&quot;:&quot;Español&quot;,&quot;fr&quot;:&quot;Français&quot;,&quot;pt&quot;:&quot;Português&quot;,&quot;ja&quot;:&quot;日本語&quot;},&quot;help_center_url&quot;:&quot;https://get.bandcamp.help/hc/en-us&quot;,&quot;templglobals&quot;:{&quot;endpoint_mobilized&quot;:true,&quot;is_phone&quot;:false},&quot;cfg&quot;:{&quot;stat_dl_json&quot;:true,&quot;mobile_app&quot;:true,&quot;gifting&quot;:true,&quot;open_signup&quot;:true,&quot;menubar_autocomplete_enabled&quot;:true,&quot;use_elasticsearch_backed_search&quot;:true,&quot;new_search_api_service&quot;:true,&quot;search_tracking&quot;:true,&quot;single_sign_up&quot;:true,&quot;fan_signup_use_captcha&quot;:true,&quot;gift_cards&quot;:true,&quot;order_history&quot;:true,&quot;header_rework_2018&quot;:true,&quot;search_discovery_one_filter_desktop_only&quot;:true,&quot;search_discovery_one_filter_rollout&quot;:true,&quot;community&quot;:true,&quot;login_use_captcha&quot;:true},&quot;identities&quot;:{&quot;user&quot;:{&quot;id&quot;:666909434},&quot;ip_country_code&quot;:null,&quot;fan&quot;:{&quot;id&quot;:5226501,&quot;username&quot;:&quot;[redacted-username]&quot;,&quot;name&quot;:&quot;[redacted-username]&quot;,&quot;photo&quot;:null,&quot;private&quot;:false,&quot;verified&quot;:true,&quot;url&quot;:&quot;https://bandcamp.com/[redacted-username]&quot;},&quot;is_page_band_member&quot;:null,&quot;subscribed_to_page_band&quot;:null,&quot;bands&quot;:[],&quot;partner&quot;:false,&quot;is_admin&quot;:false,&quot;labels&quot;:[]},&quot;digital_items&quot;:[{&quot;sale_id&quot;:196728881,&quot;item_type&quot;:&quot;a&quot;,&quot;item_id&quot;:1627488039,&quot;sale_release_date&quot;:null,&quot;quantity&quot;:1,&quot;unit_price&quot;:1.99,&quot;currency&quot;:&quot;GBP&quot;,&quot;sold_date&quot;:&quot;22 Apr 2022 09:06:29 GMT&quot;,&quot;download_type&quot;:&quot;a&quot;,&quot;download_id&quot;:1627488039,&quot;sale_item_state&quot;:&quot;s&quot;,&quot;band_id&quot;:2309219275,&quot;band_name&quot;:&quot;Hot Chip&quot;,&quot;genre_id&quot;:10,&quot;band_enabled&quot;:1,&quot;has_enhanced_seller&quot;:1,&quot;payment_id&quot;:237867587,&quot;payment_type&quot;:&quot;payflow&quot;,&quot;buyer_type&quot;:&quot;u&quot;,&quot;buyer_id&quot;:666909434,&quot;payment_email&quot;:&quot;[redacted-email]&quot;,&quot;fulfillment_days&quot;:null,&quot;package_title&quot;:null,&quot;package_type_id&quot;:null,&quot;options_title&quot;:null,&quot;is_live_ticket&quot;:null,&quot;live_event_id&quot;:null,&quot;live_event_title&quot;:null,&quot;live_event_description&quot;:null,&quot;live_event_scheduled_start_date&quot;:null,&quot;live_event_scheduled_end_date&quot;:null,&quot;live_event_end_date&quot;:null,&quot;live_event_timezone_sym_id&quot;:null,&quot;service_type&quot;:null,&quot;shippable&quot;:null,&quot;marked_shipped_date&quot;:null,&quot;license_id&quot;:null,&quot;option_name&quot;:null,&quot;package_subdomain&quot;:&quot;hotchip&quot;,&quot;package_custom_domain&quot;:null,&quot;package_custom_domain_verified&quot;:null,&quot;package_slug_text&quot;:null,&quot;package_slug_type&quot;:null,&quot;art_id&quot;:272473020,&quot;package_image_id&quot;:null,&quot;release_date&quot;:&quot;22 Apr 2022 00:00:00 GMT&quot;,&quot;package_release_date&quot;:&quot;22 Apr 2022 00:00:00 GMT&quot;,&quot;tralbum_id&quot;:1627488039,&quot;download_pref&quot;:2,&quot;killed&quot;:null,&quot;gift_sender_note&quot;:null,&quot;gift_state&quot;:null,&quot;gift_redeemed_date&quot;:null,&quot;gift_recipient_email_hidden&quot;:null,&quot;gift_recipient_email&quot;:null,&quot;gift_sender_name&quot;:null,&quot;gift_recipient_name&quot;:null,&quot;gift_card_value&quot;:null,&quot;gift_card_art_id&quot;:null,&quot;gift_card_currency&quot;:null,&quot;gift_card_recipient_email&quot;:null,&quot;label_mailing_list_address&quot;:null,&quot;label_mailing_list_unsubscribe&quot;:null,&quot;subscriber_only&quot;:null,&quot;tax_system&quot;:null,&quot;type&quot;:&quot;album&quot;,&quot;is_preorder&quot;:null,&quot;package_type_name&quot;:null,&quot;includes_digital&quot;:true,&quot;nodl_desc&quot;:null,&quot;desc&quot;:&quot;2 tracks&quot;,&quot;title&quot;:&quot;Line In The Sand&quot;,&quot;track_count&quot;:2,&quot;desc_track_count&quot;:2,&quot;artist&quot;:&quot;Hot Chip x Fay Milton x Brian Eno&quot;,&quot;url_hints&quot;:{&quot;subdomain&quot;:&quot;hotchip&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:&quot;line-in-the-sand&quot;,&quot;item_type&quot;:&quot;a&quot;},&quot;page_url&quot;:&quot;https://hotchip.bandcamp.com/album/line-in-the-sand&quot;,&quot;gift_link&quot;:&quot;https://hotchip.bandcamp.com/album/line-in-the-sand?action=gift&amp;buy_id=a1627488039&quot;,&quot;thumb_title&quot;:&quot;&quot;,&quot;payment_amt&quot;:&quot;&quot;,&quot;shareable&quot;:false,&quot;downloads&quot;:{&quot;mp3-v0&quot;:{&quot;size_mb&quot;:&quot;13.6MB&quot;,&quot;description&quot;:&quot;MP3 V0&quot;,&quot;encoding_name&quot;:&quot;mp3-v0&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-v0&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;mp3-320&quot;:{&quot;size_mb&quot;:&quot;16.7MB&quot;,&quot;description&quot;:&quot;MP3 320&quot;,&quot;encoding_name&quot;:&quot;mp3-320&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-320&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;flac&quot;:{&quot;size_mb&quot;:&quot;79MB&quot;,&quot;description&quot;:&quot;FLAC&quot;,&quot;encoding_name&quot;:&quot;flac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=flac&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;aac-hi&quot;:{&quot;size_mb&quot;:&quot;8.2MB&quot;,&quot;description&quot;:&quot;AAC&quot;,&quot;encoding_name&quot;:&quot;aac-hi&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aac-hi&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;vorbis&quot;:{&quot;size_mb&quot;:&quot;9MB&quot;,&quot;description&quot;:&quot;Ogg Vorbis&quot;,&quot;encoding_name&quot;:&quot;vorbis&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=vorbis&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;alac&quot;:{&quot;size_mb&quot;:&quot;80.3MB&quot;,&quot;description&quot;:&quot;ALAC&quot;,&quot;encoding_name&quot;:&quot;alac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=alac&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;wav&quot;:{&quot;size_mb&quot;:&quot;106.2MB&quot;,&quot;description&quot;:&quot;WAV&quot;,&quot;encoding_name&quot;:&quot;wav&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=wav&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;aiff-lossless&quot;:{&quot;size_mb&quot;:&quot;106.5MB&quot;,&quot;description&quot;:&quot;AIFF&quot;,&quot;encoding_name&quot;:&quot;aiff-lossless&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aiff-lossless&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;}},&quot;ready&quot;:false,&quot;notify_me&quot;:true,&quot;notify_me_label&quot;:false,&quot;min_price&quot;:0.5,&quot;is_pure_free&quot;:false,&quot;download_type_str&quot;:&quot;Album&quot;,&quot;paid_for&quot;:true,&quot;is_name_your_price&quot;:true}],&quot;fan_email&quot;:&quot;[redacted-email]&quot;,&quot;packages&quot;:[],&quot;live_tickets&quot;:[],&quot;sent_gifts&quot;:[],&quot;download_formats&quot;:[{&quot;name&quot;:&quot;mp3-v0&quot;,&quot;db_column&quot;:&quot;mp3_v0&quot;,&quot;file_extension&quot;:&quot;.mp3&quot;,&quot;mime_type&quot;:&quot;audio/mpeg&quot;,&quot;description&quot;:&quot;MP3 V0&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;mp3-320&quot;,&quot;db_column&quot;:&quot;mp3_320&quot;,&quot;file_extension&quot;:&quot;.mp3&quot;,&quot;mime_type&quot;:&quot;audio/mpeg&quot;,&quot;description&quot;:&quot;MP3 320&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;flac&quot;,&quot;db_column&quot;:&quot;flac&quot;,&quot;file_extension&quot;:&quot;.flac&quot;,&quot;mime_type&quot;:&quot;audio/flac&quot;,&quot;description&quot;:&quot;FLAC&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;aac-hi&quot;,&quot;db_column&quot;:&quot;aac_hi&quot;,&quot;file_extension&quot;:&quot;.m4a&quot;,&quot;mime_type&quot;:&quot;audio/mp4&quot;,&quot;description&quot;:&quot;AAC&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;vorbis&quot;,&quot;db_column&quot;:&quot;vorbis&quot;,&quot;file_extension&quot;:&quot;.ogg&quot;,&quot;mime_type&quot;:&quot;application/ogg&quot;,&quot;description&quot;:&quot;Ogg Vorbis&quot;},{&quot;name&quot;:&quot;alac&quot;,&quot;db_column&quot;:&quot;alac&quot;,&quot;file_extension&quot;:&quot;.m4a&quot;,&quot;mime_type&quot;:&quot;audio/alac&quot;,&quot;description&quot;:&quot;ALAC&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;wav&quot;,&quot;db_column&quot;:&quot;wav&quot;,&quot;file_extension&quot;:&quot;.wav&quot;,&quot;mime_type&quot;:&quot;audio/x-wav&quot;,&quot;description&quot;:&quot;WAV&quot;},{&quot;name&quot;:&quot;aiff-lossless&quot;,&quot;db_column&quot;:&quot;aiff_lossless&quot;,&quot;file_extension&quot;:&quot;.aiff&quot;,&quot;mime_type&quot;:&quot;audio/x-aiff&quot;,&quot;description&quot;:&quot;AIFF&quot;,&quot;has_variants&quot;:true}],&quot;download_format&quot;:&quot;vorbis&quot;,&quot;multidownload&quot;:false,&quot;gift_download_page&quot;:false,&quot;logged_out_fan&quot;:false,&quot;app_tralbum_url&quot;:&quot;x-bandcamp://show_tralbum?tralbum_type=a&amp;tralbum_id=1627488039&amp;play=1&quot;,&quot;download_difficulty&quot;:&quot;easy&quot;,&quot;platform&quot;:&quot;nix&quot;,&quot;is_redownload&quot;:true,&quot;has_downloads&quot;:true,&quot;download_items&quot;:[{&quot;sale_id&quot;:196728881,&quot;item_type&quot;:&quot;a&quot;,&quot;item_id&quot;:1627488039,&quot;sale_release_date&quot;:null,&quot;quantity&quot;:1,&quot;unit_price&quot;:1.99,&quot;currency&quot;:&quot;GBP&quot;,&quot;sold_date&quot;:&quot;22 Apr 2022 09:06:29 GMT&quot;,&quot;download_type&quot;:&quot;a&quot;,&quot;download_id&quot;:1627488039,&quot;sale_item_state&quot;:&quot;s&quot;,&quot;band_id&quot;:2309219275,&quot;band_name&quot;:&quot;Hot Chip&quot;,&quot;genre_id&quot;:10,&quot;band_enabled&quot;:1,&quot;has_enhanced_seller&quot;:1,&quot;payment_id&quot;:237867587,&quot;payment_type&quot;:&quot;payflow&quot;,&quot;buyer_type&quot;:&quot;u&quot;,&quot;buyer_id&quot;:666909434,&quot;payment_email&quot;:&quot;[redacted-email]&quot;,&quot;fulfillment_days&quot;:null,&quot;package_title&quot;:null,&quot;package_type_id&quot;:null,&quot;options_title&quot;:null,&quot;is_live_ticket&quot;:null,&quot;live_event_id&quot;:null,&quot;live_event_title&quot;:null,&quot;live_event_description&quot;:null,&quot;live_event_scheduled_start_date&quot;:null,&quot;live_event_scheduled_end_date&quot;:null,&quot;live_event_end_date&quot;:null,&quot;live_event_timezone_sym_id&quot;:null,&quot;service_type&quot;:null,&quot;shippable&quot;:null,&quot;marked_shipped_date&quot;:null,&quot;license_id&quot;:null,&quot;option_name&quot;:null,&quot;package_subdomain&quot;:&quot;hotchip&quot;,&quot;package_custom_domain&quot;:null,&quot;package_custom_domain_verified&quot;:null,&quot;package_slug_text&quot;:null,&quot;package_slug_type&quot;:null,&quot;art_id&quot;:272473020,&quot;package_image_id&quot;:null,&quot;release_date&quot;:&quot;22 Apr 2022 00:00:00 GMT&quot;,&quot;package_release_date&quot;:&quot;22 Apr 2022 00:00:00 GMT&quot;,&quot;tralbum_id&quot;:1627488039,&quot;download_pref&quot;:2,&quot;killed&quot;:null,&quot;gift_sender_note&quot;:null,&quot;gift_state&quot;:null,&quot;gift_redeemed_date&quot;:null,&quot;gift_recipient_email_hidden&quot;:null,&quot;gift_recipient_email&quot;:null,&quot;gift_sender_name&quot;:null,&quot;gift_recipient_name&quot;:null,&quot;gift_card_value&quot;:null,&quot;gift_card_art_id&quot;:null,&quot;gift_card_currency&quot;:null,&quot;gift_card_recipient_email&quot;:null,&quot;label_mailing_list_address&quot;:null,&quot;label_mailing_list_unsubscribe&quot;:null,&quot;subscriber_only&quot;:null,&quot;tax_system&quot;:null,&quot;type&quot;:&quot;album&quot;,&quot;is_preorder&quot;:null,&quot;package_type_name&quot;:null,&quot;includes_digital&quot;:true,&quot;nodl_desc&quot;:null,&quot;desc&quot;:&quot;2 tracks&quot;,&quot;title&quot;:&quot;Line In The Sand&quot;,&quot;track_count&quot;:2,&quot;desc_track_count&quot;:2,&quot;artist&quot;:&quot;Hot Chip x Fay Milton x Brian Eno&quot;,&quot;url_hints&quot;:{&quot;subdomain&quot;:&quot;hotchip&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:&quot;line-in-the-sand&quot;,&quot;item_type&quot;:&quot;a&quot;},&quot;page_url&quot;:&quot;https://hotchip.bandcamp.com/album/line-in-the-sand&quot;,&quot;gift_link&quot;:&quot;https://hotchip.bandcamp.com/album/line-in-the-sand?action=gift&amp;buy_id=a1627488039&quot;,&quot;thumb_title&quot;:&quot;&quot;,&quot;payment_amt&quot;:&quot;&quot;,&quot;shareable&quot;:false,&quot;downloads&quot;:{&quot;mp3-v0&quot;:{&quot;size_mb&quot;:&quot;13.6MB&quot;,&quot;description&quot;:&quot;MP3 V0&quot;,&quot;encoding_name&quot;:&quot;mp3-v0&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-v0&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;mp3-320&quot;:{&quot;size_mb&quot;:&quot;16.7MB&quot;,&quot;description&quot;:&quot;MP3 320&quot;,&quot;encoding_name&quot;:&quot;mp3-320&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-320&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;flac&quot;:{&quot;size_mb&quot;:&quot;79MB&quot;,&quot;description&quot;:&quot;FLAC&quot;,&quot;encoding_name&quot;:&quot;flac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=flac&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;aac-hi&quot;:{&quot;size_mb&quot;:&quot;8.2MB&quot;,&quot;description&quot;:&quot;AAC&quot;,&quot;encoding_name&quot;:&quot;aac-hi&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aac-hi&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;vorbis&quot;:{&quot;size_mb&quot;:&quot;9MB&quot;,&quot;description&quot;:&quot;Ogg Vorbis&quot;,&quot;encoding_name&quot;:&quot;vorbis&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=vorbis&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;alac&quot;:{&quot;size_mb&quot;:&quot;80.3MB&quot;,&quot;description&quot;:&quot;ALAC&quot;,&quot;encoding_name&quot;:&quot;alac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=alac&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;wav&quot;:{&quot;size_mb&quot;:&quot;106.2MB&quot;,&quot;description&quot;:&quot;WAV&quot;,&quot;encoding_name&quot;:&quot;wav&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=wav&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;},&quot;aiff-lossless&quot;:{&quot;size_mb&quot;:&quot;106.5MB&quot;,&quot;description&quot;:&quot;AIFF&quot;,&quot;encoding_name&quot;:&quot;aiff-lossless&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aiff-lossless&amp;id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&quot;}},&quot;ready&quot;:false,&quot;notify_me&quot;:true,&quot;notify_me_label&quot;:false,&quot;min_price&quot;:0.5,&quot;is_pure_free&quot;:false,&quot;download_type_str&quot;:&quot;Album&quot;,&quot;paid_for&quot;:true,&quot;is_name_your_price&quot;:true}],&quot;cancel_pledge_info&quot;:null,&quot;signup_params&quot;:{},&quot;fan_onboarding&quot;:{&quot;tooltips&quot;:null,&quot;num_tooltips&quot;:2,&quot;tooltip_number&quot;:null,&quot;current_index&quot;:null,&quot;complete&quot;:true,&quot;show_collection_banner&quot;:false,&quot;show_feed_banner&quot;:false,&quot;show_verify_banner&quot;:true,&quot;first_wishlisted_item_title&quot;:null,&quot;first_wishlisted_item_type&quot;:null,&quot;first_purchased_item_title&quot;:null,&quot;first_purchased_item_type&quot;:null,&quot;template&quot;:null,&quot;email&quot;:&quot;[redacted-email]&quot;,&quot;has_collection&quot;:1,&quot;has_seen_tooltips&quot;:false,&quot;show_first_wishlist_tooltip&quot;:false,&quot;deferred&quot;:false},&quot;currency_data&quot;:{&quot;info&quot;:{&quot;USD&quot;:{&quot;symbol&quot;:&quot;USD&quot;,&quot;long&quot;:&quot;US Dollar&quot;,&quot;plural&quot;:&quot;US Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;slang&quot;:[&quot;bucks&quot;,&quot;bones&quot;,&quot;clams&quot;,&quot;smackers&quot;],&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;AUD&quot;:{&quot;symbol&quot;:&quot;AUD&quot;,&quot;long&quot;:&quot;Australian Dollar&quot;,&quot;plural&quot;:&quot;Australian Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.5,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;GBP&quot;:{&quot;symbol&quot;:&quot;GBP&quot;,&quot;long&quot;:&quot;British Pound Sterling&quot;,&quot;plural&quot;:&quot;British Pounds Sterling&quot;,&quot;prefix_utf8&quot;:&quot;£&quot;,&quot;prefix&quot;:&quot;&amp;#xA3;&quot;,&quot;prefix_informal_utf8&quot;:&quot;£&quot;,&quot;prefix_informal&quot;:&quot;&amp;#xA3;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.25,&quot;medium_min_price&quot;:0.5,&quot;fixed_rate&quot;:1,&quot;slang&quot;:[&quot;quid&quot;,&quot;nicker&quot;],&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;CAD&quot;:{&quot;symbol&quot;:&quot;CAD&quot;,&quot;long&quot;:&quot;Canadian Dollar&quot;,&quot;plural&quot;:&quot;Canadian Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;CZK&quot;:{&quot;symbol&quot;:&quot;CZK&quot;,&quot;long&quot;:&quot;Czech Koruna&quot;,&quot;plural&quot;:&quot;Czech Koruna&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; Kc&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:20.0,&quot;small_min_price&quot;:10.0,&quot;medium_min_price&quot;:20.0,&quot;fixed_rate&quot;:20,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;DKK&quot;:{&quot;symbol&quot;:&quot;DKK&quot;,&quot;long&quot;:&quot;Danish Krone&quot;,&quot;plural&quot;:&quot;Danish Kroner&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;kr.&quot;,&quot;prefix_informal&quot;:&quot;kr.&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:6.0,&quot;small_min_price&quot;:2.5,&quot;medium_min_price&quot;:5.0,&quot;fixed_rate&quot;:5,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;EUR&quot;:{&quot;symbol&quot;:&quot;EUR&quot;,&quot;long&quot;:&quot;Euro&quot;,&quot;plural&quot;:&quot;Euros&quot;,&quot;prefix_utf8&quot;:&quot;€&quot;,&quot;prefix&quot;:&quot;&amp;#x20AC;&quot;,&quot;prefix_informal_utf8&quot;:&quot;€&quot;,&quot;prefix_informal&quot;:&quot;&amp;#x20AC;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.25,&quot;medium_min_price&quot;:0.5,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;HKD&quot;:{&quot;symbol&quot;:&quot;HKD&quot;,&quot;long&quot;:&quot;Hong Kong Dollar&quot;,&quot;plural&quot;:&quot;Hong Kong Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:8.0,&quot;small_min_price&quot;:2.5,&quot;medium_min_price&quot;:5.0,&quot;fixed_rate&quot;:8,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;HUF&quot;:{&quot;symbol&quot;:&quot;HUF&quot;,&quot;long&quot;:&quot;Hungarian Forint&quot;,&quot;plural&quot;:&quot;Hungarian Forint&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; Ft&quot;,&quot;places&quot;:0,&quot;a_dollar&quot;:200.0,&quot;small_min_price&quot;:100.0,&quot;medium_min_price&quot;:200.0,&quot;fixed_rate&quot;:200,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;ILS&quot;:{&quot;symbol&quot;:&quot;ILS&quot;,&quot;long&quot;:&quot;Israeli New Sheqel&quot;,&quot;plural&quot;:&quot;Israeli New Sheqalim&quot;,&quot;prefix_utf8&quot;:&quot;₪&quot;,&quot;prefix&quot;:&quot;&amp;#x20AA;&quot;,&quot;prefix_informal_utf8&quot;:&quot;₪&quot;,&quot;prefix_informal&quot;:&quot;&amp;#x20AA;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:4.0,&quot;small_min_price&quot;:1.5,&quot;medium_min_price&quot;:3.0,&quot;fixed_rate&quot;:5,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;JPY&quot;:{&quot;symbol&quot;:&quot;JPY&quot;,&quot;long&quot;:&quot;Japanese Yen&quot;,&quot;plural&quot;:&quot;Japanese Yen&quot;,&quot;prefix_utf8&quot;:&quot;¥&quot;,&quot;prefix&quot;:&quot;&amp;#x00A5;&quot;,&quot;prefix_informal_utf8&quot;:&quot;¥&quot;,&quot;prefix_informal&quot;:&quot;&amp;#x00A5;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:0,&quot;a_dollar&quot;:140.0,&quot;small_min_price&quot;:70.0,&quot;medium_min_price&quot;:140.0,&quot;fixed_rate&quot;:140,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;MXN&quot;:{&quot;symbol&quot;:&quot;MXN&quot;,&quot;long&quot;:&quot;Mexican Peso&quot;,&quot;plural&quot;:&quot;Mexican Pesos&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:12.0,&quot;small_min_price&quot;:5.0,&quot;medium_min_price&quot;:10.0,&quot;fixed_rate&quot;:10,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;NZD&quot;:{&quot;symbol&quot;:&quot;NZD&quot;,&quot;long&quot;:&quot;New Zealand Dollar&quot;,&quot;plural&quot;:&quot;New Zealand Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;NOK&quot;:{&quot;symbol&quot;:&quot;NOK&quot;,&quot;long&quot;:&quot;Norwegian Krone&quot;,&quot;plural&quot;:&quot;Norwegian Kroner&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;kr &quot;,&quot;prefix_informal&quot;:&quot;kr &quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:7.0,&quot;small_min_price&quot;:3.0,&quot;medium_min_price&quot;:6.0,&quot;fixed_rate&quot;:6,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;PLN&quot;:{&quot;symbol&quot;:&quot;PLN&quot;,&quot;long&quot;:&quot;Polish Zloty&quot;,&quot;plural&quot;:&quot;Polish Zlotych&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; zl&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:3.0,&quot;small_min_price&quot;:1.5,&quot;medium_min_price&quot;:3.0,&quot;fixed_rate&quot;:3,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;SGD&quot;:{&quot;symbol&quot;:&quot;SGD&quot;,&quot;long&quot;:&quot;Singapore Dollar&quot;,&quot;plural&quot;:&quot;Singapore Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;SEK&quot;:{&quot;symbol&quot;:&quot;SEK&quot;,&quot;long&quot;:&quot;Swedish Krona&quot;,&quot;plural&quot;:&quot;Swedish Kronor&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; kr&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:8.0,&quot;small_min_price&quot;:3.0,&quot;medium_min_price&quot;:6.0,&quot;fixed_rate&quot;:7,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;CHF&quot;:{&quot;symbol&quot;:&quot;CHF&quot;,&quot;long&quot;:&quot;Swiss Franc&quot;,&quot;plural&quot;:&quot;Swiss Francs&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;Sfr. &quot;,&quot;prefix_informal&quot;:&quot;Sfr. &quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;ALL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lek&quot;,&quot;long&quot;:&quot;Lek&quot;,&quot;symbol&quot;:&quot;ALL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;DZD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;DZD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XCD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;XCD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ARS&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;ARS&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;AWG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Guilder&quot;,&quot;long&quot;:&quot;Guilder&quot;,&quot;symbol&quot;:&quot;AWG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SHP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;SHP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BSD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BSD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BHD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;BHD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BDT&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Taka&quot;,&quot;long&quot;:&quot;Taka&quot;,&quot;symbol&quot;:&quot;BDT&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BBD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BBD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BZD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BZD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XOF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;XOF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BMD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BMD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BTN&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ngultrum&quot;,&quot;long&quot;:&quot;Ngultrum&quot;,&quot;symbol&quot;:&quot;BTN&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BOB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Boliviano&quot;,&quot;long&quot;:&quot;Boliviano&quot;,&quot;symbol&quot;:&quot;BOB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BWP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pula&quot;,&quot;long&quot;:&quot;Pula&quot;,&quot;symbol&quot;:&quot;BWP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BRL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Real&quot;,&quot;long&quot;:&quot;Real&quot;,&quot;symbol&quot;:&quot;BRL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BND&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BND&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BIF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;BIF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KHR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Riels&quot;,&quot;long&quot;:&quot;Riels&quot;,&quot;symbol&quot;:&quot;KHR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XAF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;XAF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CVE&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Escudo&quot;,&quot;long&quot;:&quot;Escudo&quot;,&quot;symbol&quot;:&quot;CVE&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KYD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;KYD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CLP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;CLP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CNY&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Yuan Renminbi&quot;,&quot;long&quot;:&quot;Yuan Renminbi&quot;,&quot;symbol&quot;:&quot;CNY&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;COP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;COP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KMF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;KMF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CRC&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Colon&quot;,&quot;long&quot;:&quot;Colon&quot;,&quot;symbol&quot;:&quot;CRC&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ANG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Guilder&quot;,&quot;long&quot;:&quot;Guilder&quot;,&quot;symbol&quot;:&quot;ANG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;DJF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;DJF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;DOP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;DOP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;EGP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;EGP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ETB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Birr&quot;,&quot;long&quot;:&quot;Birr&quot;,&quot;symbol&quot;:&quot;ETB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;FKP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;FKP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XPF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;XPF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GMD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dalasi&quot;,&quot;long&quot;:&quot;Dalasi&quot;,&quot;symbol&quot;:&quot;GMD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GIP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;GIP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GTQ&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Quetzal&quot;,&quot;long&quot;:&quot;Quetzal&quot;,&quot;symbol&quot;:&quot;GTQ&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GNF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;GNF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GYD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;GYD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;HTG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Gourde&quot;,&quot;long&quot;:&quot;Gourde&quot;,&quot;symbol&quot;:&quot;HTG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;HNL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lempira&quot;,&quot;long&quot;:&quot;Lempira&quot;,&quot;symbol&quot;:&quot;HNL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;RUP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;RUP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ISK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Krona&quot;,&quot;long&quot;:&quot;Krona&quot;,&quot;symbol&quot;:&quot;ISK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;INR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;INR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;IDR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupiah&quot;,&quot;long&quot;:&quot;Rupiah&quot;,&quot;symbol&quot;:&quot;IDR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;IQD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;IQD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;JMD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;JMD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;JOD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;JOD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KZT&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Tenge&quot;,&quot;long&quot;:&quot;Tenge&quot;,&quot;symbol&quot;:&quot;KZT&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KES&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;KES&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KWD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;KWD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LAK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kip&quot;,&quot;long&quot;:&quot;Kip&quot;,&quot;symbol&quot;:&quot;LAK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LBP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;LBP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LSL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Loti&quot;,&quot;long&quot;:&quot;Loti&quot;,&quot;symbol&quot;:&quot;LSL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LRD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;LRD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LYD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;LYD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MOP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pataca&quot;,&quot;long&quot;:&quot;Pataca&quot;,&quot;symbol&quot;:&quot;MOP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MKD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Denar&quot;,&quot;long&quot;:&quot;Denar&quot;,&quot;symbol&quot;:&quot;MKD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MWK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kwacha&quot;,&quot;long&quot;:&quot;Kwacha&quot;,&quot;symbol&quot;:&quot;MWK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MYR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ringgit&quot;,&quot;long&quot;:&quot;Ringgit&quot;,&quot;symbol&quot;:&quot;MYR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MVR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rufiyaa&quot;,&quot;long&quot;:&quot;Rufiyaa&quot;,&quot;symbol&quot;:&quot;MVR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MRU&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ouguiya&quot;,&quot;long&quot;:&quot;Ouguiya&quot;,&quot;symbol&quot;:&quot;MRU&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MUR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;MUR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MDL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Leu&quot;,&quot;long&quot;:&quot;Leu&quot;,&quot;symbol&quot;:&quot;MDL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MNT&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Tugrik&quot;,&quot;long&quot;:&quot;Tugrik&quot;,&quot;symbol&quot;:&quot;MNT&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MAD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dirham&quot;,&quot;long&quot;:&quot;Dirham&quot;,&quot;symbol&quot;:&quot;MAD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MMK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kyat&quot;,&quot;long&quot;:&quot;Kyat&quot;,&quot;symbol&quot;:&quot;MMK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NAD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;NAD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NPR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;NPR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NIO&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Cordoba&quot;,&quot;long&quot;:&quot;Cordoba&quot;,&quot;symbol&quot;:&quot;NIO&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NGN&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Naira&quot;,&quot;long&quot;:&quot;Naira&quot;,&quot;symbol&quot;:&quot;NGN&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KPW&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Won&quot;,&quot;long&quot;:&quot;Won&quot;,&quot;symbol&quot;:&quot;KPW&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;OMR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;OMR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PKR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;PKR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PAB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Balboa&quot;,&quot;long&quot;:&quot;Balboa&quot;,&quot;symbol&quot;:&quot;PAB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PGK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kina&quot;,&quot;long&quot;:&quot;Kina&quot;,&quot;symbol&quot;:&quot;PGK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PYG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Guarani&quot;,&quot;long&quot;:&quot;Guarani&quot;,&quot;symbol&quot;:&quot;PYG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PEN&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Sol&quot;,&quot;long&quot;:&quot;Sol&quot;,&quot;symbol&quot;:&quot;PEN&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PHP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;PHP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;QAR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;QAR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;RUB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ruble&quot;,&quot;long&quot;:&quot;Ruble&quot;,&quot;symbol&quot;:&quot;RUB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;WST&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Tala&quot;,&quot;long&quot;:&quot;Tala&quot;,&quot;symbol&quot;:&quot;WST&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;STD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dobra&quot;,&quot;long&quot;:&quot;Dobra&quot;,&quot;symbol&quot;:&quot;STD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SAR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;SAR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SCR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;SCR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SLL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Leone&quot;,&quot;long&quot;:&quot;Leone&quot;,&quot;symbol&quot;:&quot;SLL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SBD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;SBD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SOS&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;SOS&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ZAR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rand&quot;,&quot;long&quot;:&quot;Rand&quot;,&quot;symbol&quot;:&quot;ZAR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KRW&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Won&quot;,&quot;long&quot;:&quot;Won&quot;,&quot;symbol&quot;:&quot;KRW&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LKR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;LKR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SZL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lilangeni&quot;,&quot;long&quot;:&quot;Lilangeni&quot;,&quot;symbol&quot;:&quot;SZL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SYP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;SYP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TWD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;TWD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TZS&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;TZS&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;THB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Baht&quot;,&quot;long&quot;:&quot;Baht&quot;,&quot;symbol&quot;:&quot;THB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TOP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pa'anga&quot;,&quot;long&quot;:&quot;Pa'anga&quot;,&quot;symbol&quot;:&quot;TOP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TTD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;TTD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TND&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;TND&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TRY&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lira&quot;,&quot;long&quot;:&quot;Lira&quot;,&quot;symbol&quot;:&quot;TRY&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;UGX&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;UGX&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;UAH&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Hryvnia&quot;,&quot;long&quot;:&quot;Hryvnia&quot;,&quot;symbol&quot;:&quot;UAH&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;AED&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dirham&quot;,&quot;long&quot;:&quot;Dirham&quot;,&quot;symbol&quot;:&quot;AED&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;UYU&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;UYU&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;VUV&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Vatu&quot;,&quot;long&quot;:&quot;Vatu&quot;,&quot;symbol&quot;:&quot;VUV&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;YER&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;YER&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ZMW&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kwacha&quot;,&quot;long&quot;:&quot;Kwacha&quot;,&quot;symbol&quot;:&quot;ZMW&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false}},&quot;list&quot;:[&quot;USD&quot;,&quot;AUD&quot;,&quot;THB&quot;,&quot;PAB&quot;,&quot;ETB&quot;,&quot;BOB&quot;,&quot;GBP&quot;,&quot;CAD&quot;,&quot;CRC&quot;,&quot;NIO&quot;,&quot;CZK&quot;,&quot;GMD&quot;,&quot;DKK&quot;,&quot;MKD&quot;,&quot;DZD&quot;,&quot;BHD&quot;,&quot;IQD&quot;,&quot;JOD&quot;,&quot;KWD&quot;,&quot;LYD&quot;,&quot;TND&quot;,&quot;MAD&quot;,&quot;AED&quot;,&quot;STD&quot;,&quot;XCD&quot;,&quot;BSD&quot;,&quot;BBD&quot;,&quot;BZD&quot;,&quot;BMD&quot;,&quot;BND&quot;,&quot;KYD&quot;,&quot;GYD&quot;,&quot;JMD&quot;,&quot;LRD&quot;,&quot;NAD&quot;,&quot;SBD&quot;,&quot;TWD&quot;,&quot;TTD&quot;,&quot;CVE&quot;,&quot;EUR&quot;,&quot;XOF&quot;,&quot;BIF&quot;,&quot;XAF&quot;,&quot;KMF&quot;,&quot;DJF&quot;,&quot;XPF&quot;,&quot;GNF&quot;,&quot;HTG&quot;,&quot;PYG&quot;,&quot;AWG&quot;,&quot;ANG&quot;,&quot;HKD&quot;,&quot;UAH&quot;,&quot;HUF&quot;,&quot;ILS&quot;,&quot;JPY&quot;,&quot;PGK&quot;,&quot;LAK&quot;,&quot;ISK&quot;,&quot;MWK&quot;,&quot;ZMW&quot;,&quot;MMK&quot;,&quot;ALL&quot;,&quot;HNL&quot;,&quot;SLL&quot;,&quot;MDL&quot;,&quot;SZL&quot;,&quot;TRY&quot;,&quot;LSL&quot;,&quot;MXN&quot;,&quot;NGN&quot;,&quot;NZD&quot;,&quot;BTN&quot;,&quot;NOK&quot;,&quot;MRU&quot;,&quot;TOP&quot;,&quot;MOP&quot;,&quot;ARS&quot;,&quot;CLP&quot;,&quot;COP&quot;,&quot;DOP&quot;,&quot;PHP&quot;,&quot;UYU&quot;,&quot;PLN&quot;,&quot;SHP&quot;,&quot;EGP&quot;,&quot;FKP&quot;,&quot;GIP&quot;,&quot;LBP&quot;,&quot;SYP&quot;,&quot;BWP&quot;,&quot;GTQ&quot;,&quot;ZAR&quot;,&quot;BRL&quot;,&quot;OMR&quot;,&quot;QAR&quot;,&quot;SAR&quot;,&quot;YER&quot;,&quot;KHR&quot;,&quot;MYR&quot;,&quot;RUB&quot;,&quot;MVR&quot;,&quot;RUP&quot;,&quot;INR&quot;,&quot;MUR&quot;,&quot;NPR&quot;,&quot;PKR&quot;,&quot;SCR&quot;,&quot;LKR&quot;,&quot;IDR&quot;,&quot;KES&quot;,&quot;SOS&quot;,&quot;TZS&quot;,&quot;UGX&quot;,&quot;SGD&quot;,&quot;PEN&quot;,&quot;SEK&quot;,&quot;CHF&quot;,&quot;BDT&quot;,&quot;WST&quot;,&quot;KZT&quot;,&quot;MNT&quot;,&quot;VUV&quot;,&quot;KPW&quot;,&quot;KRW&quot;,&quot;CNY&quot;],&quot;rates&quot;:{&quot;USD&quot;:1.0,&quot;AUD&quot;:0.673362,&quot;THB&quot;:0.0322061,&quot;PAB&quot;:1.0,&quot;ETB&quot;:0.00641886,&quot;BOB&quot;:0.144787,&quot;GBP&quot;:1.34441,&quot;CAD&quot;:0.722695,&quot;CRC&quot;:0.00205188,&quot;NIO&quot;:0.0271893,&quot;CZK&quot;:0.0482039,&quot;GMD&quot;:0.0136054,&quot;DKK&quot;:0.156912,&quot;MKD&quot;:0.0190363,&quot;DZD&quot;:0.00770742,&quot;BHD&quot;:2.65272,&quot;IQD&quot;:0.000763699,&quot;JOD&quot;:1.41044,&quot;KWD&quot;:3.25267,&quot;LYD&quot;:0.184178,&quot;TND&quot;:0.342494,&quot;MAD&quot;:0.109181,&quot;AED&quot;:0.272267,&quot;STD&quot;:0.0000448797,&quot;XCD&quot;:0.370021,&quot;BSD&quot;:1.0,&quot;BBD&quot;:0.5,&quot;BZD&quot;:0.497475,&quot;BMD&quot;:1.0,&quot;BND&quot;:0.780255,&quot;KYD&quot;:1.20061,&quot;GYD&quot;:0.00478225,&quot;JMD&quot;:0.00635369,&quot;LRD&quot;:0.00541643,&quot;NAD&quot;:0.0608719,&quot;SBD&quot;:0.123098,&quot;TWD&quot;:0.0315274,&quot;TTD&quot;:0.147647,&quot;CVE&quot;:0.0106076,&quot;EUR&quot;:1.17226,&quot;XOF&quot;:0.00178709,&quot;BIF&quot;:0.000338325,&quot;XAF&quot;:0.00178709,&quot;KMF&quot;:0.00238095,&quot;DJF&quot;:0.00562549,&quot;XPF&quot;:0.00982351,&quot;GNF&quot;:0.000114259,&quot;HTG&quot;:0.00764246,&quot;PYG&quot;:0.000149805,&quot;AWG&quot;:0.555556,&quot;ANG&quot;:0.558659,&quot;HKD&quot;:0.128226,&quot;UAH&quot;:0.0231154,&quot;HUF&quot;:0.00304372,&quot;ILS&quot;:0.316126,&quot;JPY&quot;:0.00632267,&quot;PGK&quot;:0.234058,&quot;LAK&quot;:0.000046277,&quot;ISK&quot;:0.00801796,&quot;MWK&quot;:0.000576974,&quot;ZMW&quot;:0.0499634,&quot;MMK&quot;:0.000476213,&quot;ALL&quot;:0.0121642,&quot;HNL&quot;:0.0377453,&quot;SLL&quot;:0.0000476883,&quot;MDL&quot;:0.0588378,&quot;SZL&quot;:0.0608648,&quot;TRY&quot;:0.0230993,&quot;LSL&quot;:0.0608719,&quot;MXN&quot;:0.0567829,&quot;NGN&quot;:0.000704944,&quot;NZD&quot;:0.583,&quot;BTN&quot;:0.0110039,&quot;NOK&quot;:0.100012,&quot;MRU&quot;:0.0251105,&quot;TOP&quot;:0.415324,&quot;MOP&quot;:0.124568,&quot;ARS&quot;:0.000697199,&quot;CLP&quot;:0.0011298,&quot;COP&quot;:0.000272973,&quot;DOP&quot;:0.0158208,&quot;PHP&quot;:0.0168478,&quot;UYU&quot;:0.0260453,&quot;PLN&quot;:0.277479,&quot;SHP&quot;:1.34441,&quot;EGP&quot;:0.0210597,&quot;FKP&quot;:1.34441,&quot;GIP&quot;:1.34441,&quot;LBP&quot;:0.0000111742,&quot;SYP&quot;:0.0000769112,&quot;BWP&quot;:0.074868,&quot;GTQ&quot;:0.130477,&quot;ZAR&quot;:0.0608782,&quot;BRL&quot;:0.186015,&quot;OMR&quot;:2.60121,&quot;QAR&quot;:0.274587,&quot;SAR&quot;:0.266671,&quot;YER&quot;:0.00419331,&quot;KHR&quot;:0.000248424,&quot;MYR&quot;:0.24664,&quot;RUB&quot;:0.0128088,&quot;MVR&quot;:0.0647249,&quot;RUP&quot;:1.0,&quot;INR&quot;:0.0109747,&quot;MUR&quot;:0.0216497,&quot;NPR&quot;:0.00687741,&quot;PKR&quot;:0.00357608,&quot;SCR&quot;:0.0722743,&quot;LKR&quot;:0.00323057,&quot;IDR&quot;:0.0000589234,&quot;KES&quot;:0.00775531,&quot;SOS&quot;:0.00175368,&quot;TZS&quot;:0.00039604,&quot;UGX&quot;:0.00028917,&quot;SGD&quot;:0.778765,&quot;PEN&quot;:0.297909,&quot;SEK&quot;:0.109526,&quot;CHF&quot;:1.26601,&quot;BDT&quot;:0.00817858,&quot;WST&quot;:0.361298,&quot;KZT&quot;:0.00196949,&quot;MNT&quot;:0.000280899,&quot;VUV&quot;:0.00824402,&quot;KPW&quot;:0.00111111,&quot;KRW&quot;:0.000676238,&quot;CNY&quot;:0.143653},&quot;setting&quot;:null,&quot;current&quot;:null}}"></div>
+
+
+    <div class="menu-bar-wrapper">
+        <menu-bar page-context="[redacted]" color-scheme="dark" banners=""></menu-bar>
+    </div>
+    <div id="content"></div>
+
+
+
+    
+    
+
+
+
+
+
+
+
+    <div class="bannercontainer" data-banners="[]">
+
+
+
+
+
+
+
+
+    </div>
+
+    
+
+
+
+
+
+
+
+
+
+    
+    
+    
+    
+
+    
+<div class="corpbanner newsletter-invite-banner" style="display: none;">
+    <span class="tell-us-what-you-like">Get fresh music recommendations delivered to your inbox every Friday.</span> <svg class="dismiss" width="18" height="18" viewBox="0 0 24 24"><use xlink="http://www.w3.org/1999/xlink" xlink:href="#material-close"></use></svg>
+</div>
+
+
+
+
+
+    
+    
+    
+
+    
+
+    
+
+
+
+
+
+
+
+
+<!--  -->
+
+<div id="centerWrapper">
+    <div id="propOpenWrapper">
+        
+
+        
+
+        
+
+    
+    
+    
+
+    
+
+        <div id="pgBd" class="yui-skin-sam">
+            
+
+
+
+    
+    
+
+
+
+
+<div class="bd">
+    
+    <div id="customHeaderWrapper" class="bd-section">
+        
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+    <div id="customHeader">
+    
+        <div class="desktop-header">
+            <a href="https://hotchip.bandcamp.com/" referrerpolicy="strict-origin-when-cross-origin"><img src="Bandcamp2_files/0037187237_100.png" width="975" height="180"></a>
+            
+        </div>
+    
+    
+    </div>
+
+
+
+
+        
+
+
+
+
+
+
+
+    <div class="bannercontainer" data-banners="[]">
+
+
+
+
+
+
+
+
+    </div>
+
+    </div>
+    
+
+    <div id="post-checkout-info" class="bd-section post-checkout-container fan simplified redownload">
+        
+            
+    
+
+<div class="download-item-container free">
+    
+
+    <div class="download-artwork">
+
+
+    
+        
+            <a href="https://hotchip.bandcamp.com/album/line-in-the-sand">
+        
+    
+
+    
+
+    
+    
+        <img class="download-thumbnail" src="Bandcamp2_files/a0272473020_7.jpg" title="">
+    
+    
+        </a>
+    
+    
+
+</div>
+
+
+
+    <div class="free-download download" data-bind="with: downloadVMs()[0]">
+        
+        <div class="title">Line In The Sand</div>
+        <div class="artist">by Hot Chip x Fay Milton x Brian Eno</div>
+        <div class="type">
+            
+                Digital Album
+            
+        </div>
+
+        
+
+            <!-- needs to be wrapped inside a container with data-bind="with: downloadVMs()[0] -->
+            <div class="download-format-tmp">
+                    <!--error handlers -->
+                    <div class="download-error" data-bind="visible: downloadError()" style="display: none">
+                        <div data-bind="visible: genericError() &amp;&amp; !supportHighVolShow()" style="display: none;">
+                            <div class="error-text">Download error.</div>
+                            <div><a onclick="window.location.reload()">Click here</a> to reload this page and try again.</div>
+                            <div>If you keep getting this error, please <a data-bind="attr: {href: supportUrl}" href="https://bandcamp.com/contact?subj=Download%20error&amp;amp;msg=I%20keep%20seeing%20this%20error%20when%20I%20try%20to%20download%20stuff%3A%0A%0Aerror%20type%3A%20%0Abrowser%3A%20%0Aurl%3A%20%0Adate%3A%20%0Ahost%3A%20%0A">contact support</a>.</div>
+                        </div>
+                        <div data-bind="visible: genericError() &amp;&amp; supportHighVolShow()" style="display: none;">
+                            <div class="error-text">Download error.</div>
+                            <div>We’re running a <a href="https://daily.bandcamp.com/features/bandcamp-covid-19-fundraiser">fundraiser</a> resulting in a high volume of downloads. You may experience slow download times. Please try again later.</div>
+                        </div>
+                        <div data-bind="visible: dropError()" style="display: none;">
+                            <div class="error-text">There was an error preparing your download.</div>
+                            <div><a onclick="window.location.reload()">Click here</a> to reload this page and try again.</div>
+                            <div>If you keep getting this error, please check out our <a href="https://bandcamp.com/troubleshooting">troubleshooting page</a>.</div>
+                        </div>
+                        <div data-bind="visible: cutoffError()" style="display: none;">
+                            <div class="error-text">You’ve requested this download too many times. You can try again in one hour.</div>
+                            <div>If you’re certain you’ve not made many requests, there could be an issue with your browser or device.</div>
+                            <div>Please read through our <a href="https://bandcamp.com/troubleshooting">troubleshooting guide</a> and give your download another try later.</div>
+                        </div>
+                        <div class="email-reauth-error" data-bind="visible: expiredError()" style="display: none;">
+                            <div data-bind="visible: !reauthEmailSent()">
+    <div class="error-text">Download expired.</div>
+    <div class="error-msg" data-bind="visible: !invalidEmail()">
+        
+            Please enter the email address you used to purchase this item:
+        
+    </div>
+    <div class="error-msg" data-bind="visible: invalidEmail()" style="display: none;">
+        
+            Sorry, that doesn’t seem to be the correct address. <a href="https://get.bandcamp.help/hc/articles/23020691083287">Here’s what to do next.</a>
+        
+    </div>
+    <form class="reauth-form" data-bind="submit: tryDownloadReauth">
+        <input class="reauth-email" type="text" data-bind="value: reauthEmail">
+        <input class="submit" type="submit" value="GO">
+    </form>
+</div>
+<div data-bind="visible: reauthEmailSent()" style="display: none;">
+    Thank you. We’ve sent a link to your download to <span data-bind="text: reauthEmail"></span>
+</div>
+
+                        </div>
+                    </div>
+
+                    <label for="format-type" class="no-wrap" data-bind="visible: hasDownload &amp;&amp; !downloadError()">Choose format:</label>
+                    <select class="bc-select select-margins" id="format-type" data-bind="
+                    options: downloadFormatInfos,
+                    optionsText: (item) =&gt;  item.sizeMb? item.description + ' - ' + item.sizeMb : item.description,
+                    optionsValue:(item) =&gt; item.encodingName,
+                    value: $parent.formatVM.format().name,
+                    event: {change: changeFormat.bind($data, $parent.formatVM)},
+                    visible: hasDownload &amp;&amp; !downloadError()
+                    "><option value="mp3-v0">MP3 V0 - 13.6MB</option><option value="mp3-320">MP3 320 - 16.7MB</option><option value="flac" selected="selected">FLAC - 79MB</option><option value="aac-hi">AAC - 8.2MB</option><option value="vorbis">Ogg Vorbis - 9MB</option><option value="alac">ALAC - 80.3MB</option><option value="wav">WAV - 106.2MB</option><option value="aiff-lossless">AIFF - 106.5MB</option>
+                    </select>
+
+                    <div class="download-button button preparing-wrapper" data-bind="visible: !downloadReady() &amp;&amp; !downloadError()" style="display: none;">
+                        <div class="download-button-inner">
+                            <div class="preparing-title"><em>Preparing</em></div>
+                        </div>
+                    </div>
+
+                    <a style="" data-bind="attr: { href: downloadUrl }, visible: downloadReady() &amp;&amp; !downloadError()" href="https://p4.bcbits.com/download/album/1b0fc55a4521d3c177b748dc0d864d240/flac/1627488039?id=1627488039&amp;sig=4c4cac9ebb4d4b713c00d4f18336e4b3&amp;sitem_id=196728881&amp;token=1769556660_74075f132e10b2b822daac954bb83fcf65813ff0">Download</a> 
+                   
+                    <!-- hate this but with css and flex the box model is too large for a text sized divider-->
+                    <span class="text-divider">|</span>
+                    <a class="left-horizontal-break" href="https://bandcamp.com/help/downloading" data-bind="visible: !downloadError()">Need download help?</a>
+                </div> 
+
+
+
+        
+        
+    </div>
+</div>
+
+    <div class="back-to">
+    
+
+    
+        
+            
+            
+                <div>
+                    Visit <a href="https://hotchip.bandcamp.com/">Hot Chip x Fay Milton x Brian Eno</a>
+                </div>
+            
+        
+    
+
+    
+
+    
+        
+            <div class="fan-url-actions">
+                View: 
+                <a class="fan-url-link round4" href="https://bandcamp.com/[redacted-username]">collection</a>
+                <span class="separator">&nbsp;|&nbsp;</span>
+                <a class="fan-url-link round4" href="https://bandcamp.com/[redacted-username]/purchases?from=ppp">purchases</a>
+            </div>
+        
+    
+
+</div>
+
+
+
+        
+    </div>
+</div>
+
+<div class="download-bottom-area">
+    <div class="bd-section download-bottom-area-inner">
+        
+
+        
+        
+        <div class="discover-container">
+            <div class="discover-content">
+                <h3><a href="https://bandcamp.com/discover?g=electronic&amp;from=dlpage">
+            
+                Explore more electronic music on Bandcamp
+            
+         <span class="discover-go bc-ui"></span></a></h3>
+            </div>
+        </div>
+        
+
+        <div class="bcweekly-container">
+            
+<div class="bcweekly-content">
+    <h3>Don’t miss the latest <nobr>Bandcamp Weekly!</nobr></h3>
+    <div class="bcweekly-image-wrapper">
+        <a href="http://bandcamp.com/?from=bcwdwnlds&amp;play=1">
+            <div class="play-btn">
+                <div class="icon"> </div>
+            </div>
+            <img src="Bandcamp2_files/0042408944_0.jpg">
+        </a>
+    </div>
+    <div class="bcweekly-blurb">
+        <div class="bcweekly-title">
+            <span class="date">Jan 19, 2026</span>:
+            <span class="title">Fuzzy Logic</span>
+        </div>
+        <span class="desc">DJ Harrison stops by to talk about his new record Electrosoul.</span>
+    </div>
+    <h3 class="listen-now"><a href="http://bandcamp.com/?from=bcwdwnlds&amp;play=1">Listen now <span class="bcweekly-go bc-ui"></span></a></h3>
+</div>
+
+
+        </div>
+    </div>
+</div>
+
+            <div style="clear:both"></div>
+        </div>
+
+        
+
+        
+            <span id="webapp-selector-ui" class="webapp-selector-ui" style="display:none" data-webapps="[&quot;flexotest01-1&quot;,&quot;flexotest01-2&quot;,&quot;flexotest01-3&quot;,&quot;flexotest01-4&quot;,&quot;flexotest01-5&quot;,&quot;flexotest01-6&quot;,&quot;flexotest01-7&quot;,&quot;flexotest01-8&quot;,&quot;flexotest01-9&quot;,&quot;flexotest01-10&quot;,&quot;flexotest01-11&quot;,&quot;flexotest01-12&quot;,&quot;flexotest01-13&quot;,&quot;flexotest01-14&quot;,&quot;flexotest01-15&quot;,&quot;flexotest01-16&quot;]" data-backendid="c2flexocentral-mqf8-7" data-bccookie="" data-cookiename="bc_webapp3"></span>
+
+            <page-footer page-context="[redacted]" color-scheme="dark"></page-footer>
+            
+        
+    </div>
+</div>
+
+<div id="global-invisible-recaptcha" style="position: absolute; top: 0;"></div>
+<div id="fan-signup-addnl-bundle" data-url="https://s4.bcbits.com/client-bundle/1/trackpipe/masonry-04ea5cb823ea04af8b7afb16dfe2338e.js"></div>
+
+
+
+
+<script type="text/javascript" src="Bandcamp2_files/tko_trackpipe-525ac32695cf93110d7d35f736fd51e7.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp2_files/global_foot1-427109551f7206160fa1cc083773672b.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp2_files/global_foot2-2402c1c464c97f49f690a4abf5775aae.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp2_files/time-c6f294f92b5c3a7bd018b03b3c71f372.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp2_files/fraud_js-2dae71c049a60b82b63f4cd24b1b062f.js" crossorigin="anonymous" nonce="" data-enterprise-recaptcha="{&quot;render_url&quot;:&quot;https://www.recaptcha.net/recaptcha/enterprise.js?render=6LeBNSocAAAAADrhkgX9-hQq4E4K1P_HVzB7IDFD&quot;,&quot;public_site_key&quot;:&quot;6LeBNSocAAAAADrhkgX9-hQq4E4K1P_HVzB7IDFD&quot;}"></script>
+
+
+
+<script type="text/javascript" src="Bandcamp2_files/download_2016-c7b4d7b612dc7e11af95036a536cd8ab.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp2_files/web_components-bbaf82c832d0268e3b0a18a2f7665387.js" crossorigin="anonymous" nonce=""></script>
+
+
+<script type="text/javascript" src="Bandcamp2_files/analytics-f6d7fd2522940544d7e5f73a03ca3c4f.js" crossorigin="anonymous" nonce="" data-data="{&quot;env&quot;:2,&quot;domain_match&quot;:true,&quot;bandGoogleAnalyticsId&quot;:null}" data-items="[]"></script>
+<script type="text/javascript" src="Bandcamp2_files/impl-2fd8d3e0ca4ebe03fd7a3b7d60fa3671.js" crossorigin="anonymous" nonce="" data-enabled="true" data-transport="&quot;beacon&quot;" data-record-url="&quot;https://bandcamp.com/api/tracker/1/record&quot;" data-send-delay="5" data-auto-track-clicks="true" data-auto-track-filters="null"></script>
+ 
+
+
+
+
+
+<iframe name="__privateStripeMetricsController0250" frameborder="0" allowtransparency="true" scrolling="no" role="presentation" src="Bandcamp2_files/m-outer-3437aaddcdf6922d623e172c2d6f9278.html" aria-hidden="true" tabindex="-1" style="border: medium !important; margin: 0px !important; padding: 0px !important; width: 1px !important; min-width: 100% !important; overflow: hidden !important; display: block !important; visibility: hidden !important; position: fixed !important; height: 1px !important; pointer-events: none !important; user-select: none !important;"></iframe></body></html>
+<!-- c2flexocentral-mqf8-7 2026-01-20 23:30:54 UTC -->

--- a/tests/data/download-expired.html
+++ b/tests/data/download-expired.html
@@ -1,0 +1,926 @@
+<!DOCTYPE html>
+<html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en" class="js has-svg has-cssom has-hover no-touch has-anim gyrtjmeq"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"><script type="text/javascript" async="" src="Bandcamp_files/js" nonce=""></script><script async="" src="Bandcamp_files/gtm.js"></script>
+    <title>Bandcamp</title>
+    
+    
+
+
+
+    <meta name="description" content="
+">
+    
+    
+    <link rel="apple-touch-icon" sizes="180x180" href="https://s4.bcbits.com/img/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://s4.bcbits.com/img/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://s4.bcbits.com/img/favicon/favicon-16x16.png">
+    <link rel="mask-icon" href="https://s4.bcbits.com/img/favicon/safari-pinned-tab.svg" color="#1da0c3">
+
+
+<meta name="msapplication-TileColor" content="#603cba">
+<meta name="theme-color" content="#ffffff">
+
+    
+
+    
+
+    
+    
+
+    
+    
+    
+
+
+
+    
+        <meta name="referrer" content="no-referrer">
+    
+
+    
+    
+    
+
+    
+
+    
+    
+
+    <link type="text/css" rel="stylesheet" href="Bandcamp_files/global_new-3c86d7830d2e766c853e22c7210cef22.css">
+<link type="text/css" rel="stylesheet" href="Bandcamp_files/global-287f5755431dca6cbd6e368f712ddda5.css">
+<link type="text/css" rel="stylesheet" href="Bandcamp_files/download_2016-54fc4c0176ca2f3c0fd6548108288c22.css">
+
+    <meta id="js-crumbs-data" data-crumbs="[redacted]">
+    
+
+    
+
+    
+
+    
+    
+        <script nonce="" src="Bandcamp_files/stripe.js" async=""></script>
+    
+
+    
+<script type="text/javascript" nonce="">
+window.BCTracker=window.BCTracker||{preloadQueue:[],record:function(){this.preloadQueue.push(Array.prototype.slice.call(arguments))},prePageViewCallbacks:[],afterPageView:function(e){this.prePageViewCallbacks.push(e)}},window.ScrollDepthTracker=function(){this.track=function(){}},window.ScrollDepthTracker.track=function(){}
+</script>
+
+    <script type="text/javascript" src="Bandcamp_files/bccookies-fb37f2fdf1cf58b7b623df3dda68227d.js" crossorigin="anonymous" nonce=""></script>
+    <script type="text/javascript" src="Bandcamp_files/global_head-574a8ace3b730e8b08ab6d298a4b10d3.js" crossorigin="anonymous" nonce="" data-vars="[redacted]" data-validators="{&quot;contact&quot;:{&quot;name&quot;:{&quot;req&quot;:true},&quot;email&quot;:{&quot;req&quot;:true,&quot;match&quot;:&quot;(^)([^\\s\\(\\)\&quot;'/&gt;&lt;,@]+@\\w([^\\s\\(\\)\&quot;'/&gt;&lt;&amp;,@]*\\w)?\\.\\w[^\\s\\(\\)\&quot;'/&gt;&lt;&amp;,@]*\\w)($)&quot;,&quot;message&quot;:&quot;Invalid email address.&quot;},&quot;subject&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:300},&quot;message&quot;:{&quot;req&quot;:true,&quot;type&quot;:&quot;text&quot;,&quot;min&quot;:1,&quot;max&quot;:1999},&quot;attachment_0_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_0_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_1_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_1_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_2_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_2_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_3_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_3_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_4_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_4_data&quot;:{&quot;type&quot;:&quot;text&quot;}}}" data-hide-params="[]"></script>
+
+    
+  <script src="Bandcamp_files/7c33659f530ef43fb4532fc6e83354dd.min.js" crossorigin="anonymous" nonce="" id="sentry" data-config="[redacted]"></script>
+
+
+
+    
+    
+
+
+    
+
+    
+    
+
+    
+
+</head>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<body class="gecko enable-cookie-control has-menubar" lang="en"><noscript><iframe src="Bandcamp_files/ns.html" height="0" width="0" style="display: none; visibility: hidden;"></iframe></noscript>
+
+
+
+<svg height="0" width="0" style="position:absolute;margin-left:-100%">
+    <path id="tweet" d="M16.1 3.5a9.6 9.6 0 01-1.7 6c-.6.9-1.3 1.6-2.1 2.3-.8.7-1.8 1.2-2.9 1.6-1.2.4-2.4.6-3.7.6-2.2 0-4.1-.6-5.7-1.6 2.5.2 4.1-.5 5.5-1.5-1.7 0-3-1.1-3.4-2.4.5.1 1.3 0 1.7-.1-1.5-.3-3-1.7-3-3.5.3.2.9.4 1.7.4C1.5 4.8.8 3.7.8 2.4c0-.6.2-1.4.5-1.8 1.7 2 4.4 3.6 7.6 3.7C8.3 1.4 10.6 0 12.5 0c1.1 0 2 .4 2.7 1.1.8-.1 1.6-.4 2.3-.8-.3.8-.8 1.5-1.6 1.9.7-.1 1.4-.2 2.1-.5-.5.7-1.1 1.3-1.9 1.8z"></path>
+    <path id="buy-for-friend" d="M3.5 4h7c1.8-.3 2.4-1.9 2-2.9S10.7-.5 9.3.5 7 3 7 3 6.1 1.5 4.7.5s-2.8-.4-3.2.6.2 2.6 2 2.9zm6.8-3c.9-.2 1.6.1 1.3 1.1-.3 1.2-2.6 1.3-3.8 1.3 0 0 1.6-2.2 2.5-2.4zM3.8 1c1.1.4 2.4 2.4 2.4 2.4-1.3 0-3.4-.3-3.8-1.3C2 1.1 3 .8 3.8 1zM0 9h6V5H0v4zm7-4v4h7V5H7zm0 9h6v-4H7v4zm-6 0h5v-4H1v4z"></path>
+    <path id="edit-profile-info" d="M10 10.5c0 .3-.2.5-.5.5h-8c-.3 0-.5-.2-.5-.5v-8c0-.3.2-.5.5-.5h3.7V1H1.5C.7 1 0 1.7 0 2.5v8c0 .8.7 1.5 1.5 1.5h8c.8 0 1.5-.7 1.5-1.5V7h-1v3.5zm2-9.1L10.5 0 6.4 4.4l-.6 2.2L8 5.7l4-4.3z"></path>
+    <path id="fb-logo-share-profile" d="M3.9 12V6.3h1.8L6 4.2H4V2.9c0-.6.2-1 1-1h1.1V.1C5.8.1 5.2 0 4.4 0 2.8 0 1.8 1 1.8 2.7v1.5H0v2.1h1.8V12h2.1z"></path>
+    <path id="following-checkmark" d="M4.3 10.7L0 5.8l1.5-1.3 2.8 3.1L11 0l1.5 1.3z"></path>
+    <path id="follow-plus" d="M8 3H5V0H3v3H0v2h3v3h2V5h3z"></path>
+    <path id="share-profile" d="M10.7.2s-.1-.1 0 0l-.4-.2h-.1L2.5 4.8.3 8.1v.1s0 .1.1.1l3.3.9h.1l5.1-6.5-3.3 7 .9 2.2.1.1s.1 0 .1-.1l.9-1.5 2.8.9.1-.1L11.8 7 10.7.2z"></path>
+    <path id="search-magnifier" d="M10.1 10.4l-1.4-2C9.5 7.5 10 6.3 10 5c0-2.8-2.2-5-5-5S0 2.2 0 5s2.2 5 5 5c.7 0 1.4-.1 2-.4l1.5 2c.3.4 1 .5 1.4.2.4-.3.5-.9.2-1.4zM5 9C2.8 9 1 7.2 1 5s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
+    <path id="close-search-results" d="M8 .7L7.3 0 4 3.3.7 0 0 .7 3.3 4 0 7.3l.7.7L4 4.7 7.3 8l.7-.7L4.7 4z"></path>
+    <path id="camera-icon" d="M26 2h-4a2 2 0 00-2-2H8a2 2 0 00-2 2H2a2 2 0 00-2 2v14a2 2 0 002 2h24a2 2 0 002-2V4a2 2 0 00-2-2zM14 17a6 6 0 116-6 6 6 0 01-6 6zm1-10h-2v3h-3v2h3v3h2v-3h3v-2h-3z"></path>
+    <g id="search-spinner">
+        <circle class="st1" cx="7" cy="1.5" r="1.5"></circle>
+        <circle class="st2" transform="rotate(-45 10.89 3.11)" cx="10.9" cy="3.1" r="1.5"></circle>
+        <circle class="st3" cx="12.5" cy="7" r="1.5"></circle>
+        <circle class="st4" transform="rotate(-45 10.89 10.89)" cx="10.9" cy="10.9" r="1.5"></circle>
+        <circle class="st5" cx="7" cy="12.5" r="1.5"></circle>
+        <circle class="st6" transform="rotate(-45 3.11 10.89)" cx="3.1" cy="10.9" r="1.5"></circle>
+        <circle class="st8" transform="rotate(-45 3.11 3.11)" cx="3.1" cy="3.1" r="1.5"></circle>
+        <circle class="st7" cx="1.5" cy="7" r="1.5"></circle>
+    </g>
+    <path id="mobile-web-collection-arrow" d="M20.3 17.3L3 0 .3 2.7 17.7 20 .3 37.3 3 40l17.3-17.3L23 20z"></path>
+    <path id="homepage-mobile-arrow" d="M12.9 11L2.1.1 0 2.2l10.8 10.9L0 24l2.1 2.1 10.8-10.9 2.1-2.1z"></path>
+    <path id="collect-control-wishlist" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1zm-4-7.1c1.8 1.6 3.2 3.1 4 4 .8-.9 2.2-2.4 3.9-4 3.1-2.8 4.7-5.2 4.7-7.1 0-1-.4-1.9-1.3-2.7-1-.8-1.9-1.2-2.9-1-2 .3-3.6 2.7-3.6 2.7l-.9 1.4-.8-1.5S8.3 2.3 6.3 1.9c-1-.2-2 .2-3.1 1.1-.9.9-1.3 1.9-1.2 2.9 0 2 1.6 4.3 4.5 7z"></path>
+    <path id="collect-control-purchased" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1z"></path>
+    <path id="collect-control-wishlisted" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1z"></path>
+    <path id="facebook-like" d="M2 0h12c1.15 0 2 .85 2 2v12c0 1.15-.85 2-2 2h-3.49V9.83h2.06l.34-2.52h-2.4V5.83c0-.34.12-.69.23-.8.12-.23.46-.34.92-.34h1.25V2.5c-.45-.11-1.02-.11-1.82-.11-.92 0-1.72.23-2.29.8-.57.57-.8 1.37-.8 2.4v1.83H5.94v2.4H8V16H2c-1.15 0-2-.85-2-2V2C0 .85.85 0 2 0z"></path>
+    <path id="format-dropdown" d="M10 0L5 6 0 0z"></path>
+    <path id="direct-download" d="M11.7 7.3c-.4-.4-1-.4-1.4 0L7 10.6V1c0-.5-.5-1-1-1S5 .5 5 1v9.6L1.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l5 5c.2.2.4.3.7.3.4 0 .5-.1.7-.3l5-5c.4-.4.4-1 0-1.4zM10 15H2c-.5 0-1 .5-1 1s.5 1 1 1h8c.5 0 1-.5 1-1s-.5-1-1-1z"></path>
+    <path id="mobile-gift-ribbon" class="st0" d="M46.3 0C37.4 0 31.1 8.3 28 13.5 24.9 8.3 18.6 0 9.7 0 4.1 0 0 3.5 0 8.2 0 16.6 12.2 22 27.7 22 43.9 22 56 15 56 8.3c0-1.3-.3-2.6-1-3.8C53.5 1.7 50.2 0 46.3 0zM9.6 12.8c-3.1-1.6-3.9-3.1-3.9-4.6 0-1.5 1.5-3.1 4-3.1 6 0 10.8 6.6 13.4 10.9-6.9-.5-11.1-2-13.5-3.2zm37.3-.3c-2.8 1.6-7.4 3-14 3.4C35.5 11.6 40.1 5 46.1 5c2.1 0 4 .9 4 3 0 1.9-1.6 3.6-3.2 4.5z"></path>
+    <path id="grab-app" d="M20.8 25c-.8-.8-2-.8-2.8 0-.8.8-.8 2 0 2.8l7.2 7.2H2a2 2 0 00-2 2c0 1.1.9 2 2 2h23.2L18 46.2c-.8.8-.8 2 0 2.8.8.8 2 .8 2.8 0l10.6-10.6c.3-.3.6-.8.6-1.4 0-.6-.3-1.1-.6-1.4L20.8 25zM77.6 0h-26C46 0 41 4 41 9.5v56C41 71 46 76 51.6 76h26c5.5 0 9.4-5 9.4-10.5v-56C87 4 83.1 0 77.6 0zM84 65.5c0 3.9-2.6 7.5-6.4 7.5h-26c-3.9 0-7.6-3.6-7.6-7.5V56h40v9.5zM84 53H44V17h40v36zm0-39H44V9.5C44 5.6 47.7 3 51.6 3h26C81.4 3 84 5.6 84 9.5V14zM64 67c1.7 0 3-1.3 3-3s-1.3-3-3-3-3 1.3-3 3 1.4 3 3 3z"></path>
+    <path id="play-app" d="M1 60c-.2 0-.3 0-.5-.1-.3-.2-.5-.5-.5-.9V1C0 .6.2.3.5.1c.4-.1.8-.1 1.1.1l42 29c.3.2.4.5.4.8s-.2.6-.4.8l-42 29c-.2.2-.4.2-.6.2zM2 2.9v54.2L41.3 30 2 2.9z"></path>
+    <path id="play-app-2" d="M18.55 16L2.97 5.61V26.4L18.55 16zM0 32V0l24 16L0 32z"></path>
+    <g id="grab-app-opensignup" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="collection" transform="translate(-67 -505)" fill="#FFF">
+            <g id="mweb-phone-icon-outline" transform="translate(67 505)">
+                <path d="M21.16 3.99v28.02a3 3 0 003 2.99h13.99a3 3 0 003-2.99V3.99a3 3 0 00-3-2.99H24.17a3 3 0 00-3.01 2.99zm-1 0a4 4 0 014-3.99h13.99a4 4 0 014 3.99v28.02a4 4 0 01-4 3.99H24.17a4 4 0 01-4.01-3.99V3.99z" id="Rectangle-1270"></path>
+                <rect id="Rectangle-1271" x="29.41" y="29.73" width="2.5" height="2.5" rx="1.25"></rect>
+                <path d="M20.66 8.23h21v-1h-21v1zm0 19h21v-1h-21v1z" id="Combined-Shape"></path>
+                <path d="M.29 18.44c0 .36.31.67.68.67h11.62L8.86 23.3a.72.72 0 000 .99l.36.41c.26.26.68.26.94 0l5.89-6.05a.72.72 0 000-1L9.96 11.3a.66.66 0 00-.94 0l-.36.41a.72.72 0 000 1l3.9 4.43H.96a.69.69 0 00-.67.67v.63z" id="→"></path>
+            </g>
+        </g>
+    </g>
+    <g id="has-app">
+        <path class="has-app-phone" d="M18 56a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2zM29 0H7C3.1 0 0 3.1 0 7v48c0 3.9 3.1 7 7 7h22c3.9 0 7-3.1 7-7V7c0-3.9-3.1-7-7-7zm5 55c0 2.8-2.2 5-5 5H7c-2.8 0-5-2.2-5-5v-6h32v6zm0-8H2V12h32v35zm0-37H2V7c0-2.8 2.2-5 5-5h22c2.8 0 5 2.2 5 5v3z"></path>
+        <path class="has-app-confirm" d="M18 18c-6.4 0-11.5 5.1-11.5 11.5S11.6 41 18 41s11.5-5.1 11.5-11.5S24.4 18 18 18zm5.3 9.6l-5.8 5.8c-.3.3-.7.4-1.1.4-.4 0-.8-.1-1.1-.4l-2.6-2.6c-.6-.6-.6-1.5 0-2.1s1.5-.6 2.1 0l1.6 1.6 4.8-4.8c.6-.6 1.5-.6 2.1 0 .6.6.6 1.6 0 2.1z"></path>
+    </g>
+    <g id="no-app">
+        <path class="no-app-phone" d="M18 56a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2zM29 0H7C3.1 0 0 3.1 0 7v48c0 3.9 3.1 7 7 7h22c3.9 0 7-3.1 7-7V7c0-3.9-3.1-7-7-7zm5 55c0 2.8-2.2 5-5 5H7c-2.8 0-5-2.2-5-5v-6h32v6zm0-8H2V12h32v35zm0-37H2V7c0-2.8 2.2-5 5-5h22c2.8 0 5 2.2 5 5v3z"></path>
+        <path class="no-app-bc-logo" d="M14 23L7 36h15l7-13z"></path>
+    </g>
+    <g id="signup-promo-icon">
+        <path id="signup-phone-background" d="M25 52H5c-2.8 0-5-2.2-5-5V5c0-2.8 2.2-5 5-5h20c2.8 0 5 2.2 5 5v42c0 2.8-2.2 5-5 5z"></path>
+        <g id="signup-promo-phone">
+            <path class="signup-phone-icon" d="M25 0H5C2.2 0 0 2.2 0 5v42c0 2.8 2.2 5 5 5h20c2.8 0 5-2.2 5-5V5c0-2.8-2.2-5-5-5zm3 47c0 1.7-1.3 3-3 3H5c-1.7 0-3-1.3-3-3v-6h26v6zm0-8H2V10h26v29zm0-31H2V5c0-1.7 1.3-3 3-3h20c1.7 0 3 1.3 3 3v3zM15 47a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2z"></path>
+            <path class="signup-bc-logo" d="M11.6 19L5.7 30h12.7l5.9-11z"></path>
+        </g>
+    </g>
+    <path id="format-dropdown-selected" d="M8.6.3C8.2-.1 7.5-.1 7 .3L3.4 4 2 2.5c-.4-.4-1.2-.4-1.6 0-.4.4-.4 1.2 0 1.6l2.2 2.2c.2.2.5.3.8.3.3 0 .6-.1.8-.3L8.6 2c.5-.5.5-1.2 0-1.7z"></path>
+    <defs>
+        <linearGradient id="ribbon-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#00BAEF"></stop>
+            <stop offset="90%" stop-color="#1DA0C3"></stop>
+        </linearGradient>
+    </defs>
+    <path id="rarr-ico" d="M5 5L0 9l2 1 6-5-6-5-2 1 5 4z"></path>
+    <path id="larr-ico" d="M5 5L0 9l2 1 6-5-6-5-2 1 5 4z" transform="rotate(-180 4 5)"></path>
+    <path d="M2.57 0L.44 2.13 7.31 9 .43 15.87 2.56 18l9-9z" transform="rotate(-180 7.5 9)" id="larr-onboarding-ico"></path>
+    <g id="rarr-onboarding-ico" transform="translate(3)">
+        <path id="Fill-2" d="M2.57 0L.44 2.13 7.31 9 .43 15.87 2.56 18l9-9z"></path>
+    </g>
+    <path d="M0 3h3v3H0V3zm6 0l2-1-2-2-1.5 2.3L3 0 1 2l2 1h1v3h5V3H6zm-5 7h2V7H1v3zm3 0h4V7H4v3z" id="gift-card-icon"></path>
+    <path id="not-shipped" d="M7.9 0L4.75 3.16 1.58 0 0 1.58l3.16 3.17L0 7.9l1.58 1.58 3.16-3.16 3.17 3.16 1.58-1.58-3.16-3.16 3.16-3.17z"></path>
+    <path id="checkmark-shipped" d="M4.66 6.5L1.38 3.37 0 4.8l3.28 3.14 1.18 1.12.26.26 7.6-7.95L10.89 0z"></path>
+    <path fill-rule="evenodd" d="M11.82 21.35a60.6 60.6 0 011.25 1.4 42.86 42.86 0 011.21-1.4 56.68 56.68 0 014.18-4.24c5.95-5.4 8.04-9.93 4.2-13.42-2.69-2.35-5.25-1.9-7.63.34a11.2 11.2 0 00-1.62 1.92l-.46.73-.4-.75a10.42 10.42 0 00-1.5-1.97c-2.28-2.32-4.85-2.78-7.72-.3-3.62 3.7-1.54 8.23 4.22 13.45a69.17 69.17 0 014.27 4.24zm1.21-16.6c.38-.5.82-.99 1.31-1.45 2.72-2.55 5.84-3.1 8.99-.35 4.49 4.07 2.15 9.14-4.2 14.9a55.69 55.69 0 00-5.65 5.99l-.38.49-.4-.48c-.07-.1-.21-.26-.42-.5a68.18 68.18 0 00-5.4-5.5C.74 12.28-1.57 7.24 2.64 2.94 6 .04 9.14.6 11.75 3.26A11.4 11.4 0 0113 4.79l.03-.04z" id="menubar-collection-icon"></path>
+    <path fill-rule="evenodd" d="M14.4.87a1 1 0 011.77.77l-1.1 7.84h6.46a1 1 0 01.74 1.68L9.24 25.2a1 1 0 01-1.72-.85L9 15.56H4.5a1 1 0 01-.77-1.63L14.4.87zm.78.63L4.5 14.57H9a1 1 0 01.98 1.16l-1.47 8.8 13.02-14.05h-6.47a1 1 0 01-.99-1.14l1.11-7.84z" id="menubar-feed-icon"></path>
+    <path d="M21.38 19.44a.13.13 0 01-.12.07H1.13a.12.12 0 01-.11-.07.33.33 0 01-.03-.09l3.27-4.15c.37-.59.57-1.27.57-1.97V7.67C4.83 4.09 7.6 1.1 11 1h.2c1.66 0 3.23.63 4.43 1.8a6.33 6.33 0 011.94 4.58v5.85c0 .7.2 1.38.6 2.01l3.2 4.05c.03.06.02.11 0 .15m-7.45 1.32a2.73 2.73 0 01-5.46 0c0-.09.03-.17.03-.25h5.4c.01.08.03.16.03.25m8.27-2.04L19 14.67a2.66 2.66 0 01-.42-1.44V7.38A7.36 7.36 0 0010.98 0C7.03.11 3.83 3.55 3.83 7.66v5.56c0 .51-.15 1-.39 1.4L.17 18.78c-.22.36-.23.79-.02 1.15.2.36.57.58.98.58H7.5c0 .08-.03.16-.03.25a3.73 3.73 0 007.46 0c0-.09-.02-.17-.03-.25h6.36a1.14 1.14 0 00.94-1.78" id="menubar-messages-icon" fill-rule="evenodd"></path>
+    <path fill-rule="evenodd" d="M11.43 19.7a9.02 9.02 0 008.93-9.1c0-5.03-4-9.1-8.93-9.1a9.02 9.02 0 00-8.93 9.1c0 5.03 4 9.1 8.93 9.1zm6.95-1.9l6 6.87c.44.5-.32 1.16-.76.66l-5.98-6.85a9.78 9.78 0 01-6.21 2.22c-5.49 0-9.93-4.52-9.93-10.1S5.94.5 11.43.5c5.48 0 9.93 4.52 9.93 10.1 0 2.82-1.14 5.37-2.98 7.2z" id="menubar-search-icon"></path>
+    <path d="M10.7 10.47l3.74 4.2c.44.5-.3 1.16-.75.66l-3.73-4.2c-.44-.5.3-1.16.75-.66zM6.6 11.7a5.1 5.1 0 100-10.2 5.1 5.1 0 000 10.2zm0 1A6.1 6.1 0 116.6.5a6.1 6.1 0 010 12.2z" id="menubar-search-input-icon"></path>
+    <g id="menubar-cart-icon" fill-rule="evenodd">
+        <path d="M21.5 25a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+        <circle cx="8.5" cy="23.5" r="1.5" opacity=".9"></circle>
+        <path fill-rule="nonzero" d="M4.57 2H.5a.5.5 0 010-1h4.48a.5.5 0 01.5.4l.5 2.7 18.52.18c.31 0 .54.28.5.58l-2.28 13.72a.5.5 0 01-.49.42H8.16a.5.5 0 01-.49-.4L4.57 2zm1.6 3.1L8.57 18h13.24l2.1-12.73L6.17 5.1z"></path>
+    </g>
+    <g id="menubar-phone-menu-icon">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 6.25H3V4.75H21V6.25Z" fill="#222222"></path>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 12.75H3V11.25H21V12.75Z" fill="#222222"></path>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 19.75L3 19.75V18.25H12L21 18.25V19.75Z" fill="#222222"></path>
+    </g>
+    <g id="bandcamp-logo-color-bcaqua">
+        <path d="M26.62 0h2.42v5.8h.04a3.96 3.96 0 013.28-1.78c3.46 0 5.14 2.73 5.14 6.05C37.5 13.12 36 16 32.76 16c-1.49 0-3.08-.37-3.8-1.87h-.05v1.57h-2.3V0m5.43 6c-2.04 0-3.08 1.6-3.08 4.02 0 2.29 1.12 4 3.08 4 2.2 0 3.04-2.02 3.04-4 0-2.06-1.05-4.02-3.04-4.02" id="b" fill="#333"></path>
+        <path d="M56.26 4.05c-1.44 0-2.7.77-3.42 2.03l-.04-.05V4.36h-2.3v9.68l-1.61.01c-.45 0-.58-.24-.58-.85V7.35c0-2.4-2.25-3.3-4.4-3.3-2.42 0-4.82.86-4.99 3.78h2.42c.11-1.23 1.07-1.8 2.43-1.8.97 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.87 1.38.4 0 1.17-.15 4.96-.28v-.03h.02v-6.7c0-1.67 1.04-2.99 2.65-2.99 1.42 0 2.1.77 2.15 2.55v7.14h2.42v-7.8c0-2.55-1.5-3.87-3.88-3.87zM45.9 11.9c0 1.58-1.66 2.15-2.72 2.15-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87z" id="an" fill="#333"></path>
+        <path d="M72.62 15.7h-2.29v-1.54h-.04c-.64 1.3-2.02 1.84-3.4 1.84-3.47 0-5.14-2.66-5.14-6.06 0-4.12 2.35-5.92 4.76-5.92 1.38 0 2.9.53 3.65 1.78h.04V0h2.43v15.7m-5.42-1.68c2.16 0 3.08-2.04 3.08-4.02 0-2.5-1.17-4-3.04-4-2.27 0-3.08 2.09-3.08 4.13 0 1.96.93 3.9 3.04 3.9" id="d" fill="#333"></path>
+        <path d="M82.25 8.16c-.19-1.38-1.17-2.13-2.5-2.13-1.26 0-3.02.68-3.02 4.13 0 1.9.8 3.9 2.9 3.9 1.41 0 2.39-.97 2.62-2.6h2.42c-.44 2.95-2.2 4.57-5.03 4.57-3.44 0-5.34-2.53-5.34-5.87 0-3.43 1.81-6.1 5.42-6.1 2.55 0 4.72 1.31 4.95 4.1h-2.41" id="c" fill="#333"></path>
+        <path d="M106.44 5.94c-.5-1.3-1.75-1.89-3.09-1.89-1.74 0-2.65.77-3.37 1.9l-.07-1.59h-2.3v9.68l-1.61.01c-.45 0-.57-.24-.57-.85V7.35c0-2.4-2.26-3.3-4.4-3.3-2.42 0-4.83.86-5 3.78h2.43c.1-1.23 1.06-1.8 2.42-1.8.98 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.88 1.38.4 0 1.16-.15 4.92-.28l.05-6.77c0-1.9 1.15-2.95 2.4-2.95 1.47 0 1.93.84 1.93 2.4v7.3h2.43V9.05c0-1.9.7-3.03 2.33-3.03 1.9 0 2 1.25 2 3.06v6.63h2.42V7.88c0-2.77-1.36-3.83-3.67-3.83-1.6 0-2.64.73-3.44 1.9zm-16.15 8.11c-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87c0 1.58-1.66 2.15-2.72 2.15z" id="am" fill="#333"></path>
+        <path d="M118.04 4.36V5.9h.04c.68-1.3 2-1.85 3.4-1.85 3.46 0 5.14 2.73 5.14 6.05 0 3.05-1.48 5.93-4.74 5.93-1.4 0-2.9-.53-3.67-1.78h-.05v5.67h-2.42V4.36h2.3zm.04 5.7c0 2.28 1.13 4 3.08 4 2.21 0 3.04-2.03 3.04-4 0-2.07-1.04-4.03-3.04-4.03-2.04 0-3.08 1.6-3.08 4.02z" id="p" fill="#333"></path>
+        <path id="rhomboid" fill="#1DA0C3" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"></path>
+    </g>
+    <g id="bandcamp-logo-color-white" fill="#FFF">
+        <path d="M26.62 0h2.42v5.8h.04a3.96 3.96 0 013.28-1.78c3.46 0 5.14 2.73 5.14 6.05C37.5 13.12 36 16 32.76 16c-1.49 0-3.08-.37-3.8-1.87h-.05v1.57h-2.3V0m5.43 6c-2.04 0-3.08 1.6-3.08 4.02 0 2.29 1.12 4 3.08 4 2.2 0 3.04-2.02 3.04-4 0-2.06-1.05-4.02-3.04-4.02" id="b"></path>
+        <path d="M56.26 4.05c-1.44 0-2.7.77-3.42 2.03l-.04-.05V4.36h-2.3v9.68l-1.61.01c-.45 0-.58-.24-.58-.85V7.35c0-2.4-2.25-3.3-4.4-3.3-2.42 0-4.82.86-4.99 3.78h2.42c.11-1.23 1.07-1.8 2.43-1.8.97 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.87 1.38.4 0 1.17-.15 4.96-.28v-.03h.02v-6.7c0-1.67 1.04-2.99 2.65-2.99 1.42 0 2.1.77 2.15 2.55v7.14h2.42v-7.8c0-2.55-1.5-3.87-3.88-3.87zM45.9 11.9c0 1.58-1.66 2.15-2.72 2.15-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87z" id="an"></path>
+        <path d="M72.62 15.7h-2.29v-1.54h-.04c-.64 1.3-2.02 1.84-3.4 1.84-3.47 0-5.14-2.66-5.14-6.06 0-4.12 2.35-5.92 4.76-5.92 1.38 0 2.9.53 3.65 1.78h.04V0h2.43v15.7m-5.42-1.68c2.16 0 3.08-2.04 3.08-4.02 0-2.5-1.17-4-3.04-4-2.27 0-3.08 2.09-3.08 4.13 0 1.96.93 3.9 3.04 3.9" id="d"></path>
+        <path d="M82.25 8.16c-.19-1.38-1.17-2.13-2.5-2.13-1.26 0-3.02.68-3.02 4.13 0 1.9.8 3.9 2.9 3.9 1.41 0 2.39-.97 2.62-2.6h2.42c-.44 2.95-2.2 4.57-5.03 4.57-3.44 0-5.34-2.53-5.34-5.87 0-3.43 1.81-6.1 5.42-6.1 2.55 0 4.72 1.31 4.95 4.1h-2.41" id="c"></path>
+        <path d="M106.44 5.94c-.5-1.3-1.75-1.89-3.09-1.89-1.74 0-2.65.77-3.37 1.9l-.07-1.59h-2.3v9.68l-1.61.01c-.45 0-.57-.24-.57-.85V7.35c0-2.4-2.26-3.3-4.4-3.3-2.42 0-4.83.86-5 3.78h2.43c.1-1.23 1.06-1.8 2.42-1.8.98 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.88 1.38.4 0 1.16-.15 4.92-.28l.05-6.77c0-1.9 1.15-2.95 2.4-2.95 1.47 0 1.93.84 1.93 2.4v7.3h2.43V9.05c0-1.9.7-3.03 2.33-3.03 1.9 0 2 1.25 2 3.06v6.63h2.42V7.88c0-2.77-1.36-3.83-3.67-3.83-1.6 0-2.64.73-3.44 1.9zm-16.15 8.11c-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87c0 1.58-1.66 2.15-2.72 2.15z" id="am"></path>
+        <path d="M118.04 4.36V5.9h.04c.68-1.3 2-1.85 3.4-1.85 3.46 0 5.14 2.73 5.14 6.05 0 3.05-1.48 5.93-4.74 5.93-1.4 0-2.9-.53-3.67-1.78h-.05v5.67h-2.42V4.36h2.3zm.04 5.7c0 2.28 1.13 4 3.08 4 2.21 0 3.04-2.03 3.04-4 0-2.07-1.04-4.03-3.04-4.03-2.04 0-3.08 1.6-3.08 4.02z" id="p"></path>
+        <path id="rhomboid" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"></path>
+    </g>
+    <g id="bandcamp-rhomboid-white">
+        <path id="rhomboid" fill="#FFF" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"></path>
+    </g>
+    <g id="mobile-cart-up">
+        <path fill="#fff" stroke="#eee" d="M5 12L16 1h0l11 11"></path>
+        <path fill="none" id="blocking" stroke="#fff" stroke-width="2" d="M4.5 12H27"></path>
+    </g>
+    <defs>
+        <linearGradient x1="50%" y1="100%" x2="50%" y2="0%" id="fanAppGradient">
+            <stop stop-color="#00BAEF" offset="0%"></stop>
+            <stop stop-color="#1DA0C3" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="fan-app-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mobileweb-fanartist-02" transform="translate(-86 -385)">
+            <g id="Group">
+                <g id="menu" transform="translate(58 39)">
+                    <g id="fan-app-icon" transform="translate(28 346)">
+                        <rect id="bg" fill="#FFF" x="0" y="0" width="23" height="23" rx="3"></rect>
+                        <path id="tent" fill="url(#fanAppGradient)" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g id="artist-app-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mobileweb-fanartist-02" transform="translate(-86 -334)">
+            <g id="Group">
+                <g id="menu" transform="translate(58 39)">
+                    <g id="artist-app-icon" transform="translate(28 295)">
+                        <rect id="bg" fill="#4999AD" x="0" y="0" width="23" height="23" rx="3"></rect>
+                        <path id="tent" fill="#FFF" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <path id="embed-icon" d="M16.9 2.3L22 6.97l-5.1 4.68c-.43.43-1 .43-1.43 0-.43-.43-.4-1.13.02-1.57l3.42-3.1-3.42-3.12a1.12 1.12 0 01-.02-1.56c.43-.43 1-.43 1.43 0zm-6.48 10.76c-.14.63-.62.98-1.2.87-.58-.12-.93-.72-.8-1.35L11.47.88c.14-.62.62-.97 1.2-.86.58.12.93.72.8 1.35l-2.8 10.77-.24.92zM5.1 2.3c.43-.43 1-.43 1.43 0 .43.43.43 1.13 0 1.56L3.1 6.97l3.44 3.11c.43.44.43 1.14 0 1.57-.42.43-1 .43-1.43 0L0 6.97 5.1 2.3z"></path>
+    <path id="email-link" d="M0 2C0 .9.9 0 2 0h14a2 2 0 012 2v8a2 2 0 01-2 2H2a2 2 0 01-2-2V2zm16.06 9l.94-.9-4.7-4.55L17 1.9 16.06 1 9.24 6.47h-.48L1.94 1 1 1.9l4.7 3.65L1 10.09l.94.91 4.7-4.55 2.12 1.82h.48l2.11-1.82 4.7 4.55z"></path>
+    <path id="reddit-share" d="M24 11.78a2.65 2.65 0 00-4.5-1.9 13.7 13.7 0 00-6.97-2.05l1.49-4.66 4.01.94v.05a2.17 2.17 0 004.34 0 2.17 2.17 0 00-4.2-.78l-4.32-1.02a.37.37 0 00-.44.25l-1.66 5.21c-2.83.03-5.4.8-7.3 2.03a2.64 2.64 0 10-3.13 4.2c-.06.28-.09.57-.09.86 0 3.9 4.8 7.09 10.72 7.09s10.72-3.18 10.72-7.1c0-.27-.03-.54-.08-.8A2.63 2.63 0 0024 11.78zM6.78 13.6a1.58 1.58 0 013.16 0 1.58 1.58 0 01-3.16 0zm9.06 4.66c-.8.8-2.05 1.18-3.83 1.18H12c-1.78 0-3.03-.38-3.83-1.18a.37.37 0 010-.52.37.37 0 01.53 0c.65.65 1.73.96 3.3.96H12c1.57 0 2.65-.31 3.3-.96a.37.37 0 01.53 0c.14.14.14.38 0 .52zm-.2-3.1c-.86 0-1.57-.7-1.57-1.57a1.58 1.58 0 013.16 0c0 .87-.71 1.58-1.58 1.58z"></path>
+    <path id="copy-icon" d="M16.95 7.05a1 1 0 010 1.41l-8.48 8.49a1 1 0 11-1.42-1.41l8.49-8.49a1 1 0 011.4 0zm-5.8 10.04A4.2 4.2 0 0110 19.2l-1.66 1.65c-1.56 1.56-3.99 1.67-5.41.24-1.43-1.43-1.33-3.86.23-5.42L4.82 14c.6-.6 1.33-.98 2.09-1.14l1.93-1.94c-1.82-.3-3.83.3-5.31 1.79l-1.66 1.66c-2.35 2.34-2.5 5.98-.36 8.12 2.15 2.15 5.79 1.99 8.12-.35l1.66-1.66a6.14 6.14 0 001.79-5.32l-1.94 1.93zm3.22-15.23L12.7 3.52a6.14 6.14 0 00-1.79 5.32l1.94-1.93c.16-.76.54-1.49 1.14-2.1l1.66-1.65c1.56-1.56 3.99-1.66 5.42-.24 1.43 1.43 1.32 3.86-.24 5.42L19.18 10c-.6.6-1.33.98-2.08 1.14l-1.94 1.94c1.82.3 3.83-.3 5.32-1.78l1.66-1.67c2.34-2.34 2.5-5.97.35-8.12-2.14-2.14-5.78-1.98-8.12.35z"></path>
+    <path id="share-icon" d="M6 17A15.24 15.24 0 0117 5.33V2l7 6.64-7 6.7V12s-6.17-.17-11 5zm12 .14V20H2V8h6.6a17 17 0 012.34-2H0v16h20v-6.77l-2 1.91z"></path>
+<!--hubs-->
+    <g transform="translate(-1036 -601)" fill-rule="nonzero" stroke="#323232" id="hub-page-next" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 602.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 624l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape"></path>
+    </g>
+    <g transform="translate(-1036 -655)" fill-rule="nonzero" stroke="#323232" id="hub-page-prev" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 656.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 678l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape" transform="matrix(-1 0 0 1 2100 0)"></path>
+    </g>
+    <g transform="translate(-1036 -601)" fill-rule="nonzero" stroke="#FFF" id="hub-page-next-light" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 602.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 624l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape"></path>
+    </g>
+    <g transform="translate(-1036 -655)" fill-rule="nonzero" stroke="#FFF" id="hub-page-prev-light" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 656.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 678l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape" transform="matrix(-1 0 0 1 2100 0)"></path>
+    </g>
+    <g id="material-close">
+        <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+        <path d="M0 0h24v24H0z" fill="none"></path>
+    </g>
+    <g id="material-add">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
+    </g>
+    <g id="material-arrow-fwd">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"></path>
+    </g>
+    <g id="material-done">
+        <path fill="none" d="M0 0h24v24H0z"></path>
+        <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"></svg>-->
+    <g id="material-queue">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M15 6H3v2h12V6zm0 4H3v2h12v-2zM3 16h8v-2H3v2zM17 6v8.18A3 3 0 1019 17V8h3V6h-5z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"></svg>-->
+    <g id="material-vol-up">
+        <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3A4.5 4.5 0 0014 7.97v8.05A4.47 4.47 0 0016.5 12zM14 3.23v2.06a7 7 0 010 13.42v2.06a9 9 0 000-17.54z" id="Shape" fill="#333" fill-rule="nonzero"></path>
+    </g>
+    <path fill="#333" d="M3 9v6h4l5 5V4L7 9z" id="material-vol-mute"></path>
+    <g id="material-unlock">
+        <path d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6A5 5 0 007 6h1.9a3.1 3.1 0 016.2 0v2H6a2 2 0 00-2 2v10c0 1.1.9 2 2 2h12a2 2 0 002-2V10a2 2 0 00-2-2zm0 12H6V10h12v10z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 128 128" > <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-heart"></use> </svg>-->
+    <path d="M25.75 36.06C10.4 51.72 18.82 70.11 41.2 90.41a249.17 249.17 0 0115.33 15.21c1.63 1.77 3.09 3.4 4.34 4.84.76.86 1.27 1.48 1.54 1.8l1.44 1.74 1.4-1.8 1.46-1.79A201.31 201.31 0 0185.85 90.4c23.11-21 31.63-39.47 15.27-54.3-11.46-10.04-22.82-8-32.73 1.29a44.91 44.91 0 00-4.78 5.28l-.1.13-.09-.13a41.46 41.46 0 00-4.48-5.45C53.8 32 48.12 29 42.04 29c-5.19 0-10.65 2.19-16.29 7.06z" id="material-heart"></path>
+<!--<svg width="16px" height="15px" viewBox="0 0 16 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="material-comment">
+        <path id="ic-comment" d="M14.93 0c.59 0 1.06.48 1.07 1.08v8.57c0 .59-.48 1.06-1.07 1.06H8V15l-4.27-4.29H1.07c-.59 0-1.06-.47-1.07-1.06V1.08C0 .48.48 0 1.07 0h13.86zM1.5 1.5V9.2h2.86l2.14 2.16V9.2h8V1.5h-13z"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-keyboard-up"></use></svg>-->
+    <g id="material-keyboard-up">
+        <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path>
+        <path d="M0 0h24v24H0z" fill="none"></path>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-keyboard-down"></use></svg>-->
+    <g id="material-keyboard-down">
+        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"></path>
+        <path fill="none" d="M0 0h24v24H0V0z"></path>
+    </g>
+    <defs>
+        <linearGradient id="pledge-processing-mask" x1="50%" x2="50%" y1="0%" y2="100%">
+            <stop offset="0%" stop-color="#F8E71C"></stop>
+            <stop offset="100%" stop-color="#4E8E25"></stop>
+        </linearGradient>
+    </defs>
+    <path d="M50.17 100.08l5.33 4.51c.49.69-.73 1.95-1.5 1.5l-8-7 8-7c.77-.44 1.99.82 1.5 1.5l-5.3 4.49a45 45 0 001.06-89.93l2.12-1.85a47 47 0 01-3.21 93.78zM45.46 6.12L40.1 1.59c-.48-.68.73-1.94 1.5-1.5l8 7-8 7c-.77.45-1.98-.81-1.5-1.5l5.29-4.47a45 45 0 00-1.03 89.9l-2.1 1.84a47 47 0 013.19-93.74zm1.14 71.27v-5.4a22.16 22.16 0 01-12.75-5.57l2.43-3.24c3.24 2.92 6.43 4.7 10.48 5.13v-13.5c-8-1.89-11.5-4.86-11.5-10.47v-.11c0-5.56 4.7-9.61 11.34-9.94v-3.13h3.45v3.24c4.05.38 7.18 1.9 10.32 4.32l-2.33 3.24c-2.59-2.21-5.29-3.4-8.15-3.89v13.29c8.2 1.89 11.66 5.02 11.66 10.47v.11c0 5.78-4.7 9.72-11.5 10.15v5.3H46.6zm.16-26.79V37.91c-4.54.16-7.35 2.76-7.35 6.05v.1c0 3.03 1.4 5.03 7.35 6.54zm3.13 17.88c4.59-.22 7.5-2.76 7.5-6.27v-.1c0-3.2-1.5-5.08-7.5-6.54v12.9z" transform="translate(0 .9)" id="pledge-processing"></path>
+<!--common icons-->
+    <g id="help" fill="none" fill-rule="evenodd">
+        <rect width="15" height="15" fill="#B8B8B8" rx="7.5"></rect>
+        <path fill="#FFF" d="M6.57 9.8h1.72v1.7H6.57V9.8zM4.79 6.19c.01-.4.08-.76.2-1.1.14-.32.32-.6.55-.85.23-.24.5-.43.83-.57a3.45 3.45 0 012.4.01c.35.15.63.32.84.54a1.93 1.93 0 01.6 1.37 2.14 2.14 0 01-.93 1.86l-.47.35c-.15.11-.28.24-.4.39-.1.14-.18.33-.2.55v.42H6.7v-.5a2.25 2.25 0 01.54-1.34c.13-.15.27-.28.42-.39.14-.1.28-.22.4-.33.13-.1.23-.23.3-.36a.9.9 0 00.1-.5c0-.33-.07-.58-.24-.74a.94.94 0 00-.69-.24c-.2 0-.36.03-.5.11-.15.08-.27.18-.36.3-.1.14-.16.29-.2.46-.05.17-.07.36-.07.56H4.8z"></path>
+    </g>
+    <g id="ic-add-video">
+        <path d="M88 32a8 8 0 018 8v19l24-24v69L96 80v16a8 8 0 01-8 8H16a8 8 0 01-8-8V40a8 8 0 018-8h72zM56 52h-8v12H36v8h12v12h8V72h12v-8H56V52z" id="ic-add-video"></path>
+    </g>
+    <g id="ic-add-photo">
+        <path d="M104 8H88a8 8 0 00-8-8H32a8 8 0 00-8 8H8a8 8 0 00-8 8v56a8 8 0 008 8h96a8 8 0 008-8V16a8 8 0 00-8-8zM56 68a24 24 0 110-48 24 24 0 010 48zm4-40h-8v12H40v8h12v12h8V48h12v-8H60V28z" id="ic-add-photo"></path>
+    </g>
+    <path fill="#1DA0C3" fill-rule="evenodd" d="M8.86 8.26H0L4.14.62H13L8.86 8.26" id="bc-logo-tent"></path>
+<!--<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="contextual-dots" stroke="none" fill="none" fill-rule="evenodd">
+        <g transform="translate(7 17)" fill="#818285">
+            <circle cx="3" cy="3" r="3"></circle>
+            <circle cx="13" cy="3" r="3"></circle>
+            <circle cx="23" cy="3" r="3"></circle>
+        </g>
+        <path d="M0 0h40v40H0z"></path>
+    </g>
+<!--<svg width="128px" height="128px" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="report-flag-icon">
+        <path fill="none" d="M0 0h128v128H0z"></path>
+        <path d="M34.56 20v95.7h-7.9V20h7.9zm7.78 5.01s9.54-10 19.34 0c21.28 21.72 40.61-.65 40.61-.65v46.58s-19.33 22.37-40.61.65c-9.8-10-19.34 0-19.34 0z"></path>
+    </g>
+
+
+    <!-- <svg id="icon-allow-comment" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="allow-comment-icon">
+        <polygon points="15.981 3 6.573 13.501 2.708 9.635 2 10.342 6.614 14.956 16.726 3.668"></polygon>
+    </g>
+
+    <!-- <svg class="live-calendar-icon" viewBox="0 0 12 11"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#live-calendar-icon"></use></svg> -->
+    <g id="live-calendar-icon" fill="none" fill-rule="evenodd">
+        <g id="live-calendar-icon-stroke" transform="translate(-1033 -482)" stroke-width=".9">
+            <g id="component/event-card/4-col" transform="translate(744 209.5)">
+                <g id="Group" transform="translate(289 272)">
+                    <rect id="Rectangle" x=".45" y="2.65" width="10.73" height="8.36" rx="1.8"></rect>
+                    <path id="Path" d="M2.91.66v3.08M8.72.66v3.08"></path>
+                    <path id="Path-4" d="M.83 5.67h10.8"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+
+    <!-- <svg class="live-clock-icon" viewBox="0 0 12 11"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#live-clock-icon"></use></svg> -->
+    <g id="live-clock-icon" fill="none" fill-rule="evenodd">
+        <g id="live-clock-icon-stroke" transform="translate(-1033 -499)">
+            <g id="component/event-card/4-col" transform="translate(744 209.5)">
+                <g id="icon/clock" transform="translate(289 289)">
+                    <circle id="Oval" cx="6" cy="6.5" r="5.5"></circle>
+                    <path id="Path-5" d="M6 2.53V7h3.03"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+
+
+
+    <!-- <svg id="icon-ban" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="ban-user-icon">
+        <path d="M8.0002,0.0002 C3.5822,0.0002 0.0002,3.5822 0.0002,8.0002 C0.0002,12.4182 3.5822,16.0002 8.0002,16.0002 C12.4182,16.0002 16.0002,12.4182 16.0002,8.0002 C16.0002,3.5822 12.4182,0.0002 8.0002,0.0002 L8.0002,0.0002 Z M8.0002,1.0002 C11.8602,1.0002 15.0002,4.1402 15.0002,8.0002 C15.0002,11.8592 11.8602,15.0002 8.0002,15.0002 C4.1402,15.0002 1.0002,11.8592 1.0002,8.0002 C1.0002,4.1402 4.1402,1.0002 8.0002,1.0002 L8.0002,1.0002 Z M8.7072,8.0002 L11.6472,10.9402 L10.9402,11.6472 L8.0002,8.7072 L5.0592,11.6472 L4.3522,10.9402 L7.2922,8.0002 L4.3522,5.0592 L5.0592,4.3522 L8.0002,7.2932 L10.9402,4.3522 L11.6472,5.0592 L8.7072,8.0002 Z"></path>
+    </g>
+
+
+    <!-- <svg id="icon-delete-comment" fill-rule="evenodd" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="delete-comment-icon" fill-rule="evenodd">
+        <path d="M10.5,14.518 L11.5,14.518 L11.5,5.37 L10.5,5.37 L10.5,14.518 Z M6.5,14.518 L7.5,14.518 L7.5,5.37 L6.5,5.37 L6.5,14.518 Z M4.017,16.002 L14.017,16.002 L14.017,3.887 L4.017,3.887 L4.017,16.002 Z M6.464,2.887 L11.536,2.887 L11.536,2 L6.464,2 L6.464,2.887 Z M14.001,2.887 L12.536,2.887 L12.536,1 L5.464,1 L5.464,2.887 L3.999,2.887 L1,2.887 L1,3.887 L3,3.887 L3,15.989 C3,16.541 3.447,16.988 3.999,16.988 L14.001,16.988 C14.553,16.988 15,16.541 15,15.989 L15,3.887 L17,3.887 L17,2.887 L14.001,2.887 Z"></path>
+    </g>
+
+    <!-- <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"></svg> -->
+    <g id="ic-edit">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="m12.02 6.27 1.06-1.07a.56.56 0 0 0 .17-.41c0-.16-.06-.3-.17-.41l-1.36-1.36a.56.56 0 0 0-.4-.17c-.17 0-.31.06-.42.17L9.83 4.08l2.19 2.19zm-7.09 7.08L11.4 6.9 9.2 4.7l-6.45 6.46v2.18h2.18z"></path>
+        </svg>
+    </g>
+
+    <!-- <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-tooltip">
+        <path d="M8 15.06a6.55 6.55 0 0 0 5.74-3.28c.61-1.04.92-2.16.92-3.38a6.55 6.55 0 0 0-3.28-5.74A6.55 6.55 0 0 0 8 1.74c-1.2 0-2.33.3-3.36.92-1 .58-1.8 1.38-2.38 2.38a6.52 6.52 0 0 0-.92 3.36c0 1.2.3 2.33.92 3.36A6.55 6.55 0 0 0 8 15.06zm0-1.32a5.2 5.2 0 0 1-2.69-.73 5.18 5.18 0 0 1-1.92-1.92 5.2 5.2 0 0 1 0-5.38A5.18 5.18 0 0 1 5.31 3.8a5.2 5.2 0 0 1 5.38 0c.8.47 1.45 1.11 1.92 1.92a5.2 5.2 0 0 1 0 5.38A5.18 5.18 0 0 1 10.69 13a5.2 5.2 0 0 1-2.69.73zm.66-3.34c0-.33.1-.64.32-.93.11-.16.34-.38.67-.68.33-.3.56-.53.69-.73.2-.3.32-.64.32-1A2.72 2.72 0 0 0 8 4.4a2.72 2.72 0 0 0-2.66 2.66h1.32c0-.37.13-.68.4-.93.26-.26.58-.39.94-.39s.68.13.94.39c.27.25.4.56.4.93 0 .24-.07.46-.2.65-.1.14-.27.3-.5.48l-.6.48a2.19 2.19 0 0 0-.7 1.73h1.32zm0 2v-1.34H7.34v1.34h1.32z" fill="#999"></path>
+    </g>
+
+    <!-- <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-camera-small">
+        <path d="M9.21 5.93H7.57v1.65h-.93V5.93H5V5h1.64V3.36h.93V5h1.64v.93zm-2.13 3.1A3.57 3.57 0 0 1 3.53 5.5c0-1.94 1.6-3.54 3.55-3.54 1.93 0 3.54 1.6 3.54 3.54s-1.6 3.54-3.54 3.54zm6.2-7.86h-2.75C10.53.53 10 0 9.36 0H4.68C4.03 0 3.5.53 3.5 1.17H.76a.77.77 0 0 0-.76.76v7.43c0 .4.35.76.76.76h12.46c.4 0 .76-.35.76-.76V1.93c.11-.41-.24-.76-.7-.76z"></path>
+    </g>
+
+    <!-- <svg width="326" height="324" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-spinny">
+        <g transform="translate(0 2)" opacity=".99" fill="none" fill-rule="evenodd">
+            <circle fill="#A4A4A5" cx="161" cy="287" r="35"></circle>
+            <circle fill="#606463" cx="161" cy="35" r="35"></circle>
+            <circle fill="#D2D2D1" transform="rotate(90 35 161)" cx="35" cy="161" r="35"></circle>
+            <circle fill="#7C7F7E" transform="rotate(90 287 161)" cx="287" cy="161" r="35"></circle>
+            <circle fill="#BBBAB9" transform="rotate(45 71.9 250.1)" cx="71.9" cy="250.1" r="35"></circle>
+            <circle fill="#717474" transform="rotate(45 250.1 71.9)" cx="250.1" cy="71.9" r="35"></circle>
+            <circle fill="#DCDCDC" transform="rotate(135 71.9 71.9)" cx="71.9" cy="71.9" r="35"></circle>
+            <circle fill="#8D8F8F" transform="rotate(135 250.1 250.1)" cx="250.1" cy="250.1" r="35"></circle>
+        </g>
+    </g>
+    <!-- <svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg> -->
+    <path id="discover-arrow" d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"></path>
+    <g id="fan-app-icon" fill="none" fill-rule="evenodd">
+        <rect fill="#FFF" width="23" height="23" rx="3"></rect>
+        <path fill="url(#fanAppGradient)" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"></path>
+    </g>
+
+    <!-- <svg width="22px" height="15px" viewBox="0 0 22 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"> -->
+    <g id="view-eyeball-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="adminControls---OFF-AIR-Copy" transform="translate(-823.000000, -743.000000)">
+            <g id="component/video/sound-check" transform="translate(134.000000, 222.000000)">
+                <g id="Group" transform="translate(689.000000, 521.000000)">
+                    <g transform="translate(0.000000, 0.000000)" id="Oval">
+                        <circle fill="currentColor" cx="11" cy="7.28" r="3"></circle>
+                        <path d="M11,1 C15.6667595,1 19.5502286,5.64619254 20.7714147,7.28017631 C19.5496534,8.91449561 15.6664139,13.56 11,13.56 C6.33324048,13.56 2.44977141,8.91380746 1.22858526,7.27982369 C2.45034662,5.64550439 6.33358609,1 11,1 Z" stroke="currentColor" stroke-width="2"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+
+    <path id="check" fill="none" stroke-width="1.5" d="M1.5 6.5l4 5 8-11"></path>
+    <g id="two-person-silhouette">
+        <path d="M12.81 8.64c-.244-.359-.808-.605-1.858-.986-1.046-.38-1.38-.701-1.38-1.388 0-.412.32-.277.46-1.032.058-.313.34-.005.394-.72 0-.285-.154-.357-.154-.357s.078-.42.109-.745c.037-.404-.042-1.579-1.494-1.579S6.971 3.008 7.01 3.413c.03.323.108.744.108.744s-.154.072-.154.357c.054.715.336.407.394.72.14.755.46.62.46 1.032 0 .467-.156.765-.583 1.027 2.284.995 2.24 1.2 2.24 2.09V11H13s-.028-2.12-.19-2.36zm-6.046-.7c-1.308-.518-1.726-.954-1.726-1.888 0-.56.399-.378.574-1.404.072-.426.426-.007.493-.98 0-.387-.192-.484-.192-.484s.098-.573.136-1.014C6.097 1.62 5.676 0 3.859 0 2.044 0 1.782 1.62 1.83 2.17c.039.441.136 1.014.136 1.014s-.192.097-.192.484c.067.973.42.554.493.98.175 1.026.575.843.575 1.404 0 .934-.418 1.37-1.727 1.887C.717 8.097 0 8.213 0 8.8V11h8.821V9.35c0-.536-.745-.892-2.057-1.41z"></path>
+    </g>
+
+    
+    <path id="read-more-arr" d="M10.815,3.12018899 C10.809,3.11518899 6.58,0.0611889922 6.58,0.0611889922 C6.427,-0.0388110078 6.221,-0.0138110078 6.097,0.124188992 C5.973,0.260188992 5.967,0.467188992 6.083,0.610188992 L7.863,3.00018899 L0.5,3.00018899 C0.224,3.00018899 0,3.22418899 0,3.50018899 C0,3.77618899 0.224,4.00018899 0.5,4.00018899 L7.863,4.00018899 L6.083,6.39018899 C5.967,6.53318899 5.973,6.74018899 6.097,6.87618899 C6.221,7.01418899 6.427,7.03918899 6.58,6.93918899 L10.802,3.89918899 C10.926,3.78818899 11,3.65518899 11,3.50018899 C11,3.34518899 10.926,3.21218899 10.815,3.12018899 Z"></path>
+    <path id="close-weekly-archive" d="M7.4,6l2.8-2.8c0.4-0.4,0.4-1,0-1.4c-0.4-0.4-1-0.4-1.4,0L6,4.6L3.2,1.8c-0.4-0.4-1-0.4-1.4,0 c-0.4,0.4-0.4,1,0,1.4L4.6,6L1.8,8.8c-0.4,0.4-0.4,1,0,1.4c0.4,0.4,1,0.4,1.4,0L6,7.4l2.8,2.8c0.4,0.4,1,0.4,1.4,0 c0.4-0.4,0.4-1,0-1.4L7.4,6z"></path>
+    <path id="nn-view-album" d="M1.43682992,0L0 1.44492059 9.03679561 10.0650366 0.00617548675 18.5439879 1.43065443 20 12 10.0771364z"></path>
+    <path id="nn-own-this" d="M18.1085095,1.66536531 C16.7611171,0.429117108 15.3262573,-0.0849663045 13.8432411,0.146575233 C12.1400821,0.40973698 10.7946553,1.62150502 9.97698178,2.57215133 C9.22220618,1.60722493 7.97112632,0.38423681 6.31317524,0.0741547518 C4.77610618,-0.210427137 3.24493381,0.32099639 1.70786476,1.71942567 C0.531476234,2.97709402 -0.0414849278,4.41734358 0.00274020481,6.00039409 C0.0725176362,8.52287084 1.68722637,11.252409 4.93728222,14.3481295 L4.93728222,14.3491495 C7.46106312,16.7492254 9.23596511,18.9850803 9.25365516,19.0075204 L10.0379142,19.999987 L10.791707,18.9840603 C10.8084143,18.9616201 12.4820898,16.7186252 14.973439,14.3450695 C18.3561702,11.1198081 20.0013452,8.32804954 20.0003624,5.81169284 C20.0003624,4.25516251 19.3674516,2.86489328 18.1085095,1.66536531"></path>
+    <path id="nn-wishlisted" d="M18.1081467,1.66537829 C16.7607543,0.429130081 15.3258944,-0.0849533313 13.8428783,0.146588206 C12.1397193,0.409749953 10.7942925,1.621518 9.97661895,2.57216431 C9.22184336,1.6072379 7.97076349,0.384249783 6.31281241,0.074167725 C4.77574336,-0.210414164 3.24457099,0.321009364 1.70750194,1.71943865 C0.531113412,2.977107 -0.0418477507,4.41735656 0.00237738193,6.00040707 C0.0721548134,8.52288381 1.68686354,11.2524219 4.9369194,14.3481425 L4.9369194,14.3491625 C7.4607003,16.7492384 9.23560229,18.9850933 9.25329234,19.0075334 L10.0375514,20 L10.7913442,18.9840733 C10.8080514,18.9616331 12.481727,16.7186382 14.9730762,14.3450825 C18.3558074,11.1198211 20.0009823,8.32806252 19.9999996,5.81170581 C19.9999996,4.25517548 19.3670888,2.86490625 18.1081467,1.66537829"></path>
+    <path id="nn-add-wishlist" d="M6.26532856,12.8438659 C7.90059563,14.4003455 9.21450913,15.8670674 9.99381609,16.7758637 C10.7485547,15.8548277 12.0251244,14.3840259 13.643685,12.8428459 C16.5574872,10.0634181 18.0355171,7.69911951 18.0345343,5.81216853 C18.0345343,4.83707385 17.6286658,3.97621622 16.793343,3.18165685 C15.9010218,2.36261813 15.0195107,2.02806682 14.1311204,2.16474327 C12.2285501,2.45747566 10.7858986,4.80953457 10.7711576,4.83299396 L9.87981911,6.33643491 L9.07004744,4.78403523 C9.05923738,4.76261579 7.80428783,2.42075662 5.95675052,2.08110544 C5.03494733,1.91178984 4.06302478,2.28714009 3.05965478,3.19797643 C2.31474346,3.99967561 1.93835687,4.91561181 1.96685611,5.94170516 C2.02090641,7.85619543 3.46650608,10.1786751 6.26532856,12.8448859 L6.26532856,12.8438659 Z M10.0370563,20 L9.2528357,19.0075658 C9.23514652,18.9851264 7.46033142,16.7493444 4.93667407,14.3483268 L4.93667407,14.3473068 C1.68677732,11.2516872 0.0731303674,8.52223813 0.00237361922,6.00086363 C-0.0418493484,4.41786474 0.532066498,2.97766215 1.7074147,1.72003482 C3.24440851,0.320631169 4.77452319,-0.209755055 6.31249973,0.07379758 C7.96938691,0.384889499 9.22138826,1.60681776 9.97612691,2.5717127 C10.7927777,1.62211736 12.1391214,0.409368864 13.842197,0.147235672 C15.3221923,-0.0822583664 16.7599301,0.42874836 18.1082393,1.66597622 C19.3671198,2.86444509 19.9990168,4.25568896 19.9999996,5.81216853 C20.0009823,8.32742319 18.3558879,11.1190907 14.9723395,14.3452669 C12.4811123,16.7177253 10.8085014,18.960647 10.7908122,18.9841064 L10.0370563,20 Z"></path>
+    <path id="bc-daily-expand" d="M9,4H6V1c0-0.6-0.4-1-1-1S4,0.4,4,1v3H1C0.4,4,0,4.4,0,5c0,0.6,0.4,1,1,1h3v3c0,0.6,0.4,1,1,1 s1-0.4,1-1V6h3c0.6,0,1-0.4,1-1C10,4.4,9.6,4,9,4z"></path>
+    
+</svg>
+
+
+
+
+
+<div id="pagedata" data-blob="{&quot;recaptcha_public_key&quot;:&quot;6LfhSPgSAAAAAPwto_qzHuwSmjgfrkg35xXXu_8K&quot;,&quot;invisible_recaptcha_public_key&quot;:&quot;6Ld7hz4UAAAAANlndw60vAheGUwN0Mb-qeWD_LHr&quot;,&quot;localize_page&quot;:true,&quot;locale&quot;:&quot;en&quot;,&quot;languages&quot;:{&quot;en&quot;:&quot;English&quot;,&quot;de&quot;:&quot;Deutsch&quot;,&quot;es&quot;:&quot;Español&quot;,&quot;fr&quot;:&quot;Français&quot;,&quot;pt&quot;:&quot;Português&quot;,&quot;ja&quot;:&quot;日本語&quot;},&quot;help_center_url&quot;:&quot;https://get.bandcamp.help/hc/en-us&quot;,&quot;templglobals&quot;:{&quot;endpoint_mobilized&quot;:true,&quot;is_phone&quot;:false},&quot;cfg&quot;:{&quot;stat_dl_json&quot;:true,&quot;mobile_app&quot;:true,&quot;gifting&quot;:true,&quot;open_signup&quot;:true,&quot;menubar_autocomplete_enabled&quot;:true,&quot;use_elasticsearch_backed_search&quot;:true,&quot;new_search_api_service&quot;:true,&quot;search_tracking&quot;:true,&quot;single_sign_up&quot;:true,&quot;fan_signup_use_captcha&quot;:true,&quot;gift_cards&quot;:true,&quot;order_history&quot;:true,&quot;header_rework_2018&quot;:true,&quot;search_discovery_one_filter_desktop_only&quot;:true,&quot;search_discovery_one_filter_rollout&quot;:true,&quot;community&quot;:true,&quot;login_use_captcha&quot;:true},&quot;identities&quot;:{&quot;user&quot;:{&quot;id&quot;:666909434},&quot;ip_country_code&quot;:null,&quot;fan&quot;:{&quot;id&quot;:5226501,&quot;username&quot;:&quot;[redacted-username]&quot;,&quot;name&quot;:&quot;[redacted-username]&quot;,&quot;photo&quot;:null,&quot;private&quot;:false,&quot;verified&quot;:true,&quot;url&quot;:&quot;https://bandcamp.com/[redacted-username]&quot;},&quot;is_page_band_member&quot;:null,&quot;subscribed_to_page_band&quot;:null,&quot;bands&quot;:[],&quot;partner&quot;:false,&quot;is_admin&quot;:false,&quot;labels&quot;:[]},&quot;digital_items&quot;:[{&quot;sale_id&quot;:347771046,&quot;item_type&quot;:&quot;p&quot;,&quot;item_id&quot;:907001619,&quot;sale_release_date&quot;:null,&quot;quantity&quot;:1,&quot;unit_price&quot;:30.0,&quot;currency&quot;:&quot;GBP&quot;,&quot;sold_date&quot;:&quot;05 Sep 2025 08:21:37 GMT&quot;,&quot;download_type&quot;:&quot;a&quot;,&quot;download_id&quot;:1776998060,&quot;sale_item_state&quot;:&quot;s&quot;,&quot;band_id&quot;:859041092,&quot;band_name&quot;:&quot;Arab Strap&quot;,&quot;genre_id&quot;:2,&quot;band_enabled&quot;:1,&quot;has_enhanced_seller&quot;:1,&quot;payment_id&quot;:4261422286,&quot;payment_type&quot;:&quot;paypal&quot;,&quot;buyer_type&quot;:&quot;u&quot;,&quot;buyer_id&quot;:666909434,&quot;payment_email&quot;:&quot;[redacted-email]&quot;,&quot;fulfillment_days&quot;:10,&quot;package_title&quot;:&quot;Limited Edition Double LP with Signed Postcard&quot;,&quot;package_type_id&quot;:15,&quot;options_title&quot;:null,&quot;is_live_ticket&quot;:null,&quot;live_event_id&quot;:null,&quot;live_event_title&quot;:null,&quot;live_event_description&quot;:null,&quot;live_event_scheduled_start_date&quot;:null,&quot;live_event_scheduled_end_date&quot;:null,&quot;live_event_end_date&quot;:null,&quot;live_event_timezone_sym_id&quot;:null,&quot;service_type&quot;:null,&quot;shippable&quot;:1,&quot;marked_shipped_date&quot;:&quot;10 Sep 2025 14:30:42 GMT&quot;,&quot;license_id&quot;:null,&quot;option_name&quot;:null,&quot;package_subdomain&quot;:&quot;arabstrap&quot;,&quot;package_custom_domain&quot;:null,&quot;package_custom_domain_verified&quot;:null,&quot;package_slug_text&quot;:null,&quot;package_slug_type&quot;:null,&quot;art_id&quot;:3728906191,&quot;package_image_id&quot;:40843206,&quot;release_date&quot;:&quot;05 Sep 2025 00:00:00 GMT&quot;,&quot;package_release_date&quot;:&quot;08 Aug 2025 00:00:00 GMT&quot;,&quot;tralbum_id&quot;:1776998060,&quot;download_pref&quot;:2,&quot;killed&quot;:null,&quot;gift_sender_note&quot;:null,&quot;gift_state&quot;:null,&quot;gift_redeemed_date&quot;:null,&quot;gift_recipient_email_hidden&quot;:null,&quot;gift_recipient_email&quot;:null,&quot;gift_sender_name&quot;:null,&quot;gift_recipient_name&quot;:null,&quot;gift_card_value&quot;:null,&quot;gift_card_art_id&quot;:null,&quot;gift_card_currency&quot;:null,&quot;gift_card_recipient_email&quot;:null,&quot;label_mailing_list_address&quot;:null,&quot;label_mailing_list_unsubscribe&quot;:null,&quot;subscriber_only&quot;:null,&quot;tax_system&quot;:null,&quot;type&quot;:&quot;package&quot;,&quot;is_preorder&quot;:null,&quot;package_type_name&quot;:&quot;2 x Vinyl LP&quot;,&quot;includes_digital&quot;:true,&quot;nodl_desc&quot;:null,&quot;desc&quot;:&quot;13 tracks&quot;,&quot;title&quot;:&quot;Philophobia Undressed&quot;,&quot;subtitle&quot;:&quot;This download is included with your purchase of “Limited Edition Double LP with Signed Postcard”.&quot;,&quot;is_tralbum_attached&quot;:false,&quot;track_count&quot;:13,&quot;desc_track_count&quot;:13,&quot;artist&quot;:&quot;Arab Strap&quot;,&quot;url_hints&quot;:{&quot;subdomain&quot;:&quot;arabstrap&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:&quot;philophobia-undressed&quot;,&quot;item_type&quot;:&quot;a&quot;},&quot;package_url_hints&quot;:{&quot;subdomain&quot;:&quot;arabstrap&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:null,&quot;item_type&quot;:null},&quot;estimated_ship_date&quot;:&quot;10 Sep 2025 14:30:42 GMT&quot;,&quot;estimated_ship_date_passed&quot;:true,&quot;arrival_date&quot;:&quot;24 Sep 2025 14:30:42 GMT&quot;,&quot;page_url&quot;:&quot;https://arabstrap.bandcamp.com/album/philophobia-undressed&quot;,&quot;gift_link&quot;:&quot;https://arabstrap.bandcamp.com/album/philophobia-undressed?action=gift&amp;buy_id=p907001619&quot;,&quot;image_id&quot;:40843206,&quot;thumb_title&quot;:&quot;&quot;,&quot;payment_amt&quot;:&quot;30 nicker&quot;,&quot;shareable&quot;:true,&quot;downloads&quot;:{&quot;mp3-v0&quot;:{&quot;size_mb&quot;:&quot;101.3MB&quot;,&quot;description&quot;:&quot;MP3 V0&quot;,&quot;encoding_name&quot;:&quot;mp3-v0&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-v0&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;mp3-320&quot;:{&quot;size_mb&quot;:&quot;137.8MB&quot;,&quot;description&quot;:&quot;MP3 320&quot;,&quot;encoding_name&quot;:&quot;mp3-320&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-320&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;flac&quot;:{&quot;size_mb&quot;:&quot;685.3MB&quot;,&quot;description&quot;:&quot;FLAC&quot;,&quot;encoding_name&quot;:&quot;flac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=flac&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;aac-hi&quot;:{&quot;size_mb&quot;:&quot;57.3MB&quot;,&quot;description&quot;:&quot;AAC&quot;,&quot;encoding_name&quot;:&quot;aac-hi&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aac-hi&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;vorbis&quot;:{&quot;size_mb&quot;:&quot;69.5MB&quot;,&quot;description&quot;:&quot;Ogg Vorbis&quot;,&quot;encoding_name&quot;:&quot;vorbis&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=vorbis&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;alac&quot;:{&quot;size_mb&quot;:&quot;697.3MB&quot;,&quot;description&quot;:&quot;ALAC&quot;,&quot;encoding_name&quot;:&quot;alac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=alac&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;wav&quot;:{&quot;size_mb&quot;:&quot;968MB&quot;,&quot;description&quot;:&quot;WAV&quot;,&quot;encoding_name&quot;:&quot;wav&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=wav&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;aiff-lossless&quot;:{&quot;size_mb&quot;:&quot;969.6MB&quot;,&quot;description&quot;:&quot;AIFF&quot;,&quot;encoding_name&quot;:&quot;aiff-lossless&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aiff-lossless&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;}},&quot;ready&quot;:false,&quot;notify_me&quot;:false,&quot;notify_me_label&quot;:false,&quot;min_price&quot;:0.5,&quot;is_pure_free&quot;:false,&quot;download_type_str&quot;:&quot;Album&quot;,&quot;physical_orders_url&quot;:&quot;/help/physical_orders?payment_id=4261422286&amp;sig=b5f49b451a224d9bb3f1a9303439fddf&quot;,&quot;paid_for&quot;:true,&quot;is_name_your_price&quot;:true}],&quot;fan_email&quot;:&quot;[redacted-email]&quot;,&quot;packages&quot;:[{&quot;sale_id&quot;:347771046,&quot;item_type&quot;:&quot;p&quot;,&quot;item_id&quot;:907001619,&quot;sale_release_date&quot;:null,&quot;quantity&quot;:1,&quot;unit_price&quot;:30.0,&quot;currency&quot;:&quot;GBP&quot;,&quot;sold_date&quot;:&quot;05 Sep 2025 08:21:37 GMT&quot;,&quot;download_type&quot;:&quot;a&quot;,&quot;download_id&quot;:1776998060,&quot;sale_item_state&quot;:&quot;s&quot;,&quot;band_id&quot;:859041092,&quot;band_name&quot;:&quot;Arab Strap&quot;,&quot;genre_id&quot;:2,&quot;band_enabled&quot;:1,&quot;has_enhanced_seller&quot;:1,&quot;payment_id&quot;:4261422286,&quot;payment_type&quot;:&quot;paypal&quot;,&quot;buyer_type&quot;:&quot;u&quot;,&quot;buyer_id&quot;:666909434,&quot;payment_email&quot;:&quot;[redacted-email]&quot;,&quot;fulfillment_days&quot;:10,&quot;package_title&quot;:&quot;Limited Edition Double LP with Signed Postcard&quot;,&quot;package_type_id&quot;:15,&quot;options_title&quot;:null,&quot;is_live_ticket&quot;:null,&quot;live_event_id&quot;:null,&quot;live_event_title&quot;:null,&quot;live_event_description&quot;:null,&quot;live_event_scheduled_start_date&quot;:null,&quot;live_event_scheduled_end_date&quot;:null,&quot;live_event_end_date&quot;:null,&quot;live_event_timezone_sym_id&quot;:null,&quot;service_type&quot;:null,&quot;shippable&quot;:1,&quot;marked_shipped_date&quot;:&quot;10 Sep 2025 14:30:42 GMT&quot;,&quot;license_id&quot;:null,&quot;option_name&quot;:null,&quot;package_subdomain&quot;:&quot;arabstrap&quot;,&quot;package_custom_domain&quot;:null,&quot;package_custom_domain_verified&quot;:null,&quot;package_slug_text&quot;:null,&quot;package_slug_type&quot;:null,&quot;art_id&quot;:3728906191,&quot;package_image_id&quot;:40843206,&quot;release_date&quot;:&quot;05 Sep 2025 00:00:00 GMT&quot;,&quot;package_release_date&quot;:&quot;08 Aug 2025 00:00:00 GMT&quot;,&quot;tralbum_id&quot;:1776998060,&quot;download_pref&quot;:2,&quot;killed&quot;:null,&quot;gift_sender_note&quot;:null,&quot;gift_state&quot;:null,&quot;gift_redeemed_date&quot;:null,&quot;gift_recipient_email_hidden&quot;:null,&quot;gift_recipient_email&quot;:null,&quot;gift_sender_name&quot;:null,&quot;gift_recipient_name&quot;:null,&quot;gift_card_value&quot;:null,&quot;gift_card_art_id&quot;:null,&quot;gift_card_currency&quot;:null,&quot;gift_card_recipient_email&quot;:null,&quot;label_mailing_list_address&quot;:null,&quot;label_mailing_list_unsubscribe&quot;:null,&quot;subscriber_only&quot;:null,&quot;tax_system&quot;:null,&quot;type&quot;:&quot;package&quot;,&quot;is_preorder&quot;:null,&quot;package_type_name&quot;:&quot;2 x Vinyl LP&quot;,&quot;includes_digital&quot;:true,&quot;nodl_desc&quot;:null,&quot;desc&quot;:&quot;13 tracks&quot;,&quot;title&quot;:&quot;Philophobia Undressed&quot;,&quot;subtitle&quot;:&quot;This download is included with your purchase of “Limited Edition Double LP with Signed Postcard”.&quot;,&quot;is_tralbum_attached&quot;:false,&quot;track_count&quot;:13,&quot;desc_track_count&quot;:13,&quot;artist&quot;:&quot;Arab Strap&quot;,&quot;url_hints&quot;:{&quot;subdomain&quot;:&quot;arabstrap&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:&quot;philophobia-undressed&quot;,&quot;item_type&quot;:&quot;a&quot;},&quot;package_url_hints&quot;:{&quot;subdomain&quot;:&quot;arabstrap&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:null,&quot;item_type&quot;:null},&quot;estimated_ship_date&quot;:&quot;10 Sep 2025 14:30:42 GMT&quot;,&quot;estimated_ship_date_passed&quot;:true,&quot;arrival_date&quot;:&quot;24 Sep 2025 14:30:42 GMT&quot;,&quot;page_url&quot;:&quot;https://arabstrap.bandcamp.com/album/philophobia-undressed&quot;,&quot;gift_link&quot;:&quot;https://arabstrap.bandcamp.com/album/philophobia-undressed?action=gift&amp;buy_id=p907001619&quot;,&quot;image_id&quot;:40843206,&quot;thumb_title&quot;:&quot;&quot;,&quot;payment_amt&quot;:&quot;30 nicker&quot;,&quot;shareable&quot;:true,&quot;downloads&quot;:{&quot;mp3-v0&quot;:{&quot;size_mb&quot;:&quot;101.3MB&quot;,&quot;description&quot;:&quot;MP3 V0&quot;,&quot;encoding_name&quot;:&quot;mp3-v0&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-v0&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;mp3-320&quot;:{&quot;size_mb&quot;:&quot;137.8MB&quot;,&quot;description&quot;:&quot;MP3 320&quot;,&quot;encoding_name&quot;:&quot;mp3-320&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-320&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;flac&quot;:{&quot;size_mb&quot;:&quot;685.3MB&quot;,&quot;description&quot;:&quot;FLAC&quot;,&quot;encoding_name&quot;:&quot;flac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=flac&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;aac-hi&quot;:{&quot;size_mb&quot;:&quot;57.3MB&quot;,&quot;description&quot;:&quot;AAC&quot;,&quot;encoding_name&quot;:&quot;aac-hi&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aac-hi&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;vorbis&quot;:{&quot;size_mb&quot;:&quot;69.5MB&quot;,&quot;description&quot;:&quot;Ogg Vorbis&quot;,&quot;encoding_name&quot;:&quot;vorbis&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=vorbis&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;alac&quot;:{&quot;size_mb&quot;:&quot;697.3MB&quot;,&quot;description&quot;:&quot;ALAC&quot;,&quot;encoding_name&quot;:&quot;alac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=alac&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;wav&quot;:{&quot;size_mb&quot;:&quot;968MB&quot;,&quot;description&quot;:&quot;WAV&quot;,&quot;encoding_name&quot;:&quot;wav&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=wav&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;aiff-lossless&quot;:{&quot;size_mb&quot;:&quot;969.6MB&quot;,&quot;description&quot;:&quot;AIFF&quot;,&quot;encoding_name&quot;:&quot;aiff-lossless&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aiff-lossless&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;}},&quot;ready&quot;:false,&quot;notify_me&quot;:false,&quot;notify_me_label&quot;:false,&quot;min_price&quot;:0.5,&quot;is_pure_free&quot;:false,&quot;download_type_str&quot;:&quot;Album&quot;,&quot;physical_orders_url&quot;:&quot;/help/physical_orders?payment_id=4261422286&amp;sig=b5f49b451a224d9bb3f1a9303439fddf&quot;,&quot;paid_for&quot;:true,&quot;is_name_your_price&quot;:true}],&quot;live_tickets&quot;:[],&quot;sent_gifts&quot;:[],&quot;download_formats&quot;:[{&quot;name&quot;:&quot;mp3-v0&quot;,&quot;db_column&quot;:&quot;mp3_v0&quot;,&quot;file_extension&quot;:&quot;.mp3&quot;,&quot;mime_type&quot;:&quot;audio/mpeg&quot;,&quot;description&quot;:&quot;MP3 V0&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;mp3-320&quot;,&quot;db_column&quot;:&quot;mp3_320&quot;,&quot;file_extension&quot;:&quot;.mp3&quot;,&quot;mime_type&quot;:&quot;audio/mpeg&quot;,&quot;description&quot;:&quot;MP3 320&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;flac&quot;,&quot;db_column&quot;:&quot;flac&quot;,&quot;file_extension&quot;:&quot;.flac&quot;,&quot;mime_type&quot;:&quot;audio/flac&quot;,&quot;description&quot;:&quot;FLAC&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;aac-hi&quot;,&quot;db_column&quot;:&quot;aac_hi&quot;,&quot;file_extension&quot;:&quot;.m4a&quot;,&quot;mime_type&quot;:&quot;audio/mp4&quot;,&quot;description&quot;:&quot;AAC&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;vorbis&quot;,&quot;db_column&quot;:&quot;vorbis&quot;,&quot;file_extension&quot;:&quot;.ogg&quot;,&quot;mime_type&quot;:&quot;application/ogg&quot;,&quot;description&quot;:&quot;Ogg Vorbis&quot;},{&quot;name&quot;:&quot;alac&quot;,&quot;db_column&quot;:&quot;alac&quot;,&quot;file_extension&quot;:&quot;.m4a&quot;,&quot;mime_type&quot;:&quot;audio/alac&quot;,&quot;description&quot;:&quot;ALAC&quot;,&quot;has_variants&quot;:true},{&quot;name&quot;:&quot;wav&quot;,&quot;db_column&quot;:&quot;wav&quot;,&quot;file_extension&quot;:&quot;.wav&quot;,&quot;mime_type&quot;:&quot;audio/x-wav&quot;,&quot;description&quot;:&quot;WAV&quot;},{&quot;name&quot;:&quot;aiff-lossless&quot;,&quot;db_column&quot;:&quot;aiff_lossless&quot;,&quot;file_extension&quot;:&quot;.aiff&quot;,&quot;mime_type&quot;:&quot;audio/x-aiff&quot;,&quot;description&quot;:&quot;AIFF&quot;,&quot;has_variants&quot;:true}],&quot;download_format&quot;:&quot;vorbis&quot;,&quot;multidownload&quot;:false,&quot;gift_download_page&quot;:false,&quot;logged_out_fan&quot;:false,&quot;app_tralbum_url&quot;:&quot;x-bandcamp://show_tralbum?tralbum_type=a&amp;tralbum_id=1776998060&amp;play=1&quot;,&quot;download_difficulty&quot;:&quot;easy&quot;,&quot;platform&quot;:&quot;nix&quot;,&quot;is_redownload&quot;:true,&quot;has_downloads&quot;:true,&quot;download_items&quot;:[{&quot;sale_id&quot;:347771046,&quot;item_type&quot;:&quot;p&quot;,&quot;item_id&quot;:907001619,&quot;sale_release_date&quot;:null,&quot;quantity&quot;:1,&quot;unit_price&quot;:30.0,&quot;currency&quot;:&quot;GBP&quot;,&quot;sold_date&quot;:&quot;05 Sep 2025 08:21:37 GMT&quot;,&quot;download_type&quot;:&quot;a&quot;,&quot;download_id&quot;:1776998060,&quot;sale_item_state&quot;:&quot;s&quot;,&quot;band_id&quot;:859041092,&quot;band_name&quot;:&quot;Arab Strap&quot;,&quot;genre_id&quot;:2,&quot;band_enabled&quot;:1,&quot;has_enhanced_seller&quot;:1,&quot;payment_id&quot;:4261422286,&quot;payment_type&quot;:&quot;paypal&quot;,&quot;buyer_type&quot;:&quot;u&quot;,&quot;buyer_id&quot;:666909434,&quot;payment_email&quot;:&quot;[redacted-email]&quot;,&quot;fulfillment_days&quot;:10,&quot;package_title&quot;:&quot;Limited Edition Double LP with Signed Postcard&quot;,&quot;package_type_id&quot;:15,&quot;options_title&quot;:null,&quot;is_live_ticket&quot;:null,&quot;live_event_id&quot;:null,&quot;live_event_title&quot;:null,&quot;live_event_description&quot;:null,&quot;live_event_scheduled_start_date&quot;:null,&quot;live_event_scheduled_end_date&quot;:null,&quot;live_event_end_date&quot;:null,&quot;live_event_timezone_sym_id&quot;:null,&quot;service_type&quot;:null,&quot;shippable&quot;:1,&quot;marked_shipped_date&quot;:&quot;10 Sep 2025 14:30:42 GMT&quot;,&quot;license_id&quot;:null,&quot;option_name&quot;:null,&quot;package_subdomain&quot;:&quot;arabstrap&quot;,&quot;package_custom_domain&quot;:null,&quot;package_custom_domain_verified&quot;:null,&quot;package_slug_text&quot;:null,&quot;package_slug_type&quot;:null,&quot;art_id&quot;:3728906191,&quot;package_image_id&quot;:40843206,&quot;release_date&quot;:&quot;05 Sep 2025 00:00:00 GMT&quot;,&quot;package_release_date&quot;:&quot;08 Aug 2025 00:00:00 GMT&quot;,&quot;tralbum_id&quot;:1776998060,&quot;download_pref&quot;:2,&quot;killed&quot;:null,&quot;gift_sender_note&quot;:null,&quot;gift_state&quot;:null,&quot;gift_redeemed_date&quot;:null,&quot;gift_recipient_email_hidden&quot;:null,&quot;gift_recipient_email&quot;:null,&quot;gift_sender_name&quot;:null,&quot;gift_recipient_name&quot;:null,&quot;gift_card_value&quot;:null,&quot;gift_card_art_id&quot;:null,&quot;gift_card_currency&quot;:null,&quot;gift_card_recipient_email&quot;:null,&quot;label_mailing_list_address&quot;:null,&quot;label_mailing_list_unsubscribe&quot;:null,&quot;subscriber_only&quot;:null,&quot;tax_system&quot;:null,&quot;type&quot;:&quot;package&quot;,&quot;is_preorder&quot;:null,&quot;package_type_name&quot;:&quot;2 x Vinyl LP&quot;,&quot;includes_digital&quot;:true,&quot;nodl_desc&quot;:null,&quot;desc&quot;:&quot;13 tracks&quot;,&quot;title&quot;:&quot;Philophobia Undressed&quot;,&quot;subtitle&quot;:&quot;This download is included with your purchase of “Limited Edition Double LP with Signed Postcard”.&quot;,&quot;is_tralbum_attached&quot;:false,&quot;track_count&quot;:13,&quot;desc_track_count&quot;:13,&quot;artist&quot;:&quot;Arab Strap&quot;,&quot;url_hints&quot;:{&quot;subdomain&quot;:&quot;arabstrap&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:&quot;philophobia-undressed&quot;,&quot;item_type&quot;:&quot;a&quot;},&quot;package_url_hints&quot;:{&quot;subdomain&quot;:&quot;arabstrap&quot;,&quot;custom_domain&quot;:null,&quot;custom_domain_verified&quot;:null,&quot;slug&quot;:null,&quot;item_type&quot;:null},&quot;estimated_ship_date&quot;:&quot;10 Sep 2025 14:30:42 GMT&quot;,&quot;estimated_ship_date_passed&quot;:true,&quot;arrival_date&quot;:&quot;24 Sep 2025 14:30:42 GMT&quot;,&quot;page_url&quot;:&quot;https://arabstrap.bandcamp.com/album/philophobia-undressed&quot;,&quot;gift_link&quot;:&quot;https://arabstrap.bandcamp.com/album/philophobia-undressed?action=gift&amp;buy_id=p907001619&quot;,&quot;image_id&quot;:40843206,&quot;thumb_title&quot;:&quot;&quot;,&quot;payment_amt&quot;:&quot;30 nicker&quot;,&quot;shareable&quot;:true,&quot;downloads&quot;:{&quot;mp3-v0&quot;:{&quot;size_mb&quot;:&quot;101.3MB&quot;,&quot;description&quot;:&quot;MP3 V0&quot;,&quot;encoding_name&quot;:&quot;mp3-v0&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-v0&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;mp3-320&quot;:{&quot;size_mb&quot;:&quot;137.8MB&quot;,&quot;description&quot;:&quot;MP3 320&quot;,&quot;encoding_name&quot;:&quot;mp3-320&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=mp3-320&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;flac&quot;:{&quot;size_mb&quot;:&quot;685.3MB&quot;,&quot;description&quot;:&quot;FLAC&quot;,&quot;encoding_name&quot;:&quot;flac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=flac&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;aac-hi&quot;:{&quot;size_mb&quot;:&quot;57.3MB&quot;,&quot;description&quot;:&quot;AAC&quot;,&quot;encoding_name&quot;:&quot;aac-hi&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aac-hi&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;vorbis&quot;:{&quot;size_mb&quot;:&quot;69.5MB&quot;,&quot;description&quot;:&quot;Ogg Vorbis&quot;,&quot;encoding_name&quot;:&quot;vorbis&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=vorbis&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;alac&quot;:{&quot;size_mb&quot;:&quot;697.3MB&quot;,&quot;description&quot;:&quot;ALAC&quot;,&quot;encoding_name&quot;:&quot;alac&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=alac&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;wav&quot;:{&quot;size_mb&quot;:&quot;968MB&quot;,&quot;description&quot;:&quot;WAV&quot;,&quot;encoding_name&quot;:&quot;wav&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=wav&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;},&quot;aiff-lossless&quot;:{&quot;size_mb&quot;:&quot;969.6MB&quot;,&quot;description&quot;:&quot;AIFF&quot;,&quot;encoding_name&quot;:&quot;aiff-lossless&quot;,&quot;url&quot;:&quot;https://popplers5.bandcamp.com/download/album?enc=aiff-lossless&amp;id=1776998060&amp;sig=985ca55722b40c9877620a1c029bdf93&amp;sitem_id=347771046&quot;}},&quot;ready&quot;:false,&quot;notify_me&quot;:false,&quot;notify_me_label&quot;:false,&quot;min_price&quot;:0.5,&quot;is_pure_free&quot;:false,&quot;download_type_str&quot;:&quot;Album&quot;,&quot;physical_orders_url&quot;:&quot;/help/physical_orders?payment_id=4261422286&amp;sig=b5f49b451a224d9bb3f1a9303439fddf&quot;,&quot;paid_for&quot;:true,&quot;is_name_your_price&quot;:true}],&quot;cancel_pledge_info&quot;:null,&quot;signup_params&quot;:{},&quot;fan_onboarding&quot;:{&quot;tooltips&quot;:null,&quot;num_tooltips&quot;:2,&quot;tooltip_number&quot;:null,&quot;current_index&quot;:null,&quot;complete&quot;:true,&quot;show_collection_banner&quot;:false,&quot;show_feed_banner&quot;:false,&quot;show_verify_banner&quot;:true,&quot;first_wishlisted_item_title&quot;:null,&quot;first_wishlisted_item_type&quot;:null,&quot;first_purchased_item_title&quot;:null,&quot;first_purchased_item_type&quot;:null,&quot;template&quot;:null,&quot;email&quot;:&quot;[redacted-email]&quot;,&quot;has_collection&quot;:1,&quot;has_seen_tooltips&quot;:false,&quot;show_first_wishlist_tooltip&quot;:false,&quot;deferred&quot;:false},&quot;currency_data&quot;:{&quot;info&quot;:{&quot;USD&quot;:{&quot;symbol&quot;:&quot;USD&quot;,&quot;long&quot;:&quot;US Dollar&quot;,&quot;plural&quot;:&quot;US Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;slang&quot;:[&quot;bucks&quot;,&quot;bones&quot;,&quot;clams&quot;,&quot;smackers&quot;],&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;AUD&quot;:{&quot;symbol&quot;:&quot;AUD&quot;,&quot;long&quot;:&quot;Australian Dollar&quot;,&quot;plural&quot;:&quot;Australian Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.5,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;GBP&quot;:{&quot;symbol&quot;:&quot;GBP&quot;,&quot;long&quot;:&quot;British Pound Sterling&quot;,&quot;plural&quot;:&quot;British Pounds Sterling&quot;,&quot;prefix_utf8&quot;:&quot;£&quot;,&quot;prefix&quot;:&quot;&amp;#xA3;&quot;,&quot;prefix_informal_utf8&quot;:&quot;£&quot;,&quot;prefix_informal&quot;:&quot;&amp;#xA3;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.25,&quot;medium_min_price&quot;:0.5,&quot;fixed_rate&quot;:1,&quot;slang&quot;:[&quot;quid&quot;,&quot;nicker&quot;],&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;CAD&quot;:{&quot;symbol&quot;:&quot;CAD&quot;,&quot;long&quot;:&quot;Canadian Dollar&quot;,&quot;plural&quot;:&quot;Canadian Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;CZK&quot;:{&quot;symbol&quot;:&quot;CZK&quot;,&quot;long&quot;:&quot;Czech Koruna&quot;,&quot;plural&quot;:&quot;Czech Koruna&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; Kc&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:20.0,&quot;small_min_price&quot;:10.0,&quot;medium_min_price&quot;:20.0,&quot;fixed_rate&quot;:20,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;DKK&quot;:{&quot;symbol&quot;:&quot;DKK&quot;,&quot;long&quot;:&quot;Danish Krone&quot;,&quot;plural&quot;:&quot;Danish Kroner&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;kr.&quot;,&quot;prefix_informal&quot;:&quot;kr.&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:6.0,&quot;small_min_price&quot;:2.5,&quot;medium_min_price&quot;:5.0,&quot;fixed_rate&quot;:5,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;EUR&quot;:{&quot;symbol&quot;:&quot;EUR&quot;,&quot;long&quot;:&quot;Euro&quot;,&quot;plural&quot;:&quot;Euros&quot;,&quot;prefix_utf8&quot;:&quot;€&quot;,&quot;prefix&quot;:&quot;&amp;#x20AC;&quot;,&quot;prefix_informal_utf8&quot;:&quot;€&quot;,&quot;prefix_informal&quot;:&quot;&amp;#x20AC;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.25,&quot;medium_min_price&quot;:0.5,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;HKD&quot;:{&quot;symbol&quot;:&quot;HKD&quot;,&quot;long&quot;:&quot;Hong Kong Dollar&quot;,&quot;plural&quot;:&quot;Hong Kong Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:8.0,&quot;small_min_price&quot;:2.5,&quot;medium_min_price&quot;:5.0,&quot;fixed_rate&quot;:8,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;HUF&quot;:{&quot;symbol&quot;:&quot;HUF&quot;,&quot;long&quot;:&quot;Hungarian Forint&quot;,&quot;plural&quot;:&quot;Hungarian Forint&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; Ft&quot;,&quot;places&quot;:0,&quot;a_dollar&quot;:200.0,&quot;small_min_price&quot;:100.0,&quot;medium_min_price&quot;:200.0,&quot;fixed_rate&quot;:200,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;ILS&quot;:{&quot;symbol&quot;:&quot;ILS&quot;,&quot;long&quot;:&quot;Israeli New Sheqel&quot;,&quot;plural&quot;:&quot;Israeli New Sheqalim&quot;,&quot;prefix_utf8&quot;:&quot;₪&quot;,&quot;prefix&quot;:&quot;&amp;#x20AA;&quot;,&quot;prefix_informal_utf8&quot;:&quot;₪&quot;,&quot;prefix_informal&quot;:&quot;&amp;#x20AA;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:4.0,&quot;small_min_price&quot;:1.5,&quot;medium_min_price&quot;:3.0,&quot;fixed_rate&quot;:5,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;JPY&quot;:{&quot;symbol&quot;:&quot;JPY&quot;,&quot;long&quot;:&quot;Japanese Yen&quot;,&quot;plural&quot;:&quot;Japanese Yen&quot;,&quot;prefix_utf8&quot;:&quot;¥&quot;,&quot;prefix&quot;:&quot;&amp;#x00A5;&quot;,&quot;prefix_informal_utf8&quot;:&quot;¥&quot;,&quot;prefix_informal&quot;:&quot;&amp;#x00A5;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:0,&quot;a_dollar&quot;:140.0,&quot;small_min_price&quot;:70.0,&quot;medium_min_price&quot;:140.0,&quot;fixed_rate&quot;:140,&quot;paypal&quot;:true,&quot;payflow&quot;:true},&quot;MXN&quot;:{&quot;symbol&quot;:&quot;MXN&quot;,&quot;long&quot;:&quot;Mexican Peso&quot;,&quot;plural&quot;:&quot;Mexican Pesos&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:12.0,&quot;small_min_price&quot;:5.0,&quot;medium_min_price&quot;:10.0,&quot;fixed_rate&quot;:10,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;NZD&quot;:{&quot;symbol&quot;:&quot;NZD&quot;,&quot;long&quot;:&quot;New Zealand Dollar&quot;,&quot;plural&quot;:&quot;New Zealand Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;NOK&quot;:{&quot;symbol&quot;:&quot;NOK&quot;,&quot;long&quot;:&quot;Norwegian Krone&quot;,&quot;plural&quot;:&quot;Norwegian Kroner&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;kr &quot;,&quot;prefix_informal&quot;:&quot;kr &quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:7.0,&quot;small_min_price&quot;:3.0,&quot;medium_min_price&quot;:6.0,&quot;fixed_rate&quot;:6,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;PLN&quot;:{&quot;symbol&quot;:&quot;PLN&quot;,&quot;long&quot;:&quot;Polish Zloty&quot;,&quot;plural&quot;:&quot;Polish Zlotych&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; zl&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:3.0,&quot;small_min_price&quot;:1.5,&quot;medium_min_price&quot;:3.0,&quot;fixed_rate&quot;:3,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;SGD&quot;:{&quot;symbol&quot;:&quot;SGD&quot;,&quot;long&quot;:&quot;Singapore Dollar&quot;,&quot;plural&quot;:&quot;Singapore Dollars&quot;,&quot;prefix_utf8&quot;:&quot;$&quot;,&quot;prefix&quot;:&quot;$&quot;,&quot;prefix_informal_utf8&quot;:&quot;$&quot;,&quot;prefix_informal&quot;:&quot;$&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;SEK&quot;:{&quot;symbol&quot;:&quot;SEK&quot;,&quot;long&quot;:&quot;Swedish Krona&quot;,&quot;plural&quot;:&quot;Swedish Kronor&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot; kr&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:8.0,&quot;small_min_price&quot;:3.0,&quot;medium_min_price&quot;:6.0,&quot;fixed_rate&quot;:7,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;CHF&quot;:{&quot;symbol&quot;:&quot;CHF&quot;,&quot;long&quot;:&quot;Swiss Franc&quot;,&quot;plural&quot;:&quot;Swiss Francs&quot;,&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;Sfr. &quot;,&quot;prefix_informal&quot;:&quot;Sfr. &quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1.0,&quot;small_min_price&quot;:0.5,&quot;medium_min_price&quot;:1.0,&quot;fixed_rate&quot;:1,&quot;paypal&quot;:true,&quot;payflow&quot;:false},&quot;ALL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lek&quot;,&quot;long&quot;:&quot;Lek&quot;,&quot;symbol&quot;:&quot;ALL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;DZD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;DZD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XCD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;XCD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ARS&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;ARS&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;AWG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Guilder&quot;,&quot;long&quot;:&quot;Guilder&quot;,&quot;symbol&quot;:&quot;AWG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SHP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;SHP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BSD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BSD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BHD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;BHD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BDT&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Taka&quot;,&quot;long&quot;:&quot;Taka&quot;,&quot;symbol&quot;:&quot;BDT&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BBD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BBD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BZD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BZD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XOF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;XOF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BMD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BMD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BTN&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ngultrum&quot;,&quot;long&quot;:&quot;Ngultrum&quot;,&quot;symbol&quot;:&quot;BTN&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BOB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Boliviano&quot;,&quot;long&quot;:&quot;Boliviano&quot;,&quot;symbol&quot;:&quot;BOB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BWP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pula&quot;,&quot;long&quot;:&quot;Pula&quot;,&quot;symbol&quot;:&quot;BWP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BRL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Real&quot;,&quot;long&quot;:&quot;Real&quot;,&quot;symbol&quot;:&quot;BRL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BND&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;BND&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;BIF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;BIF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KHR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Riels&quot;,&quot;long&quot;:&quot;Riels&quot;,&quot;symbol&quot;:&quot;KHR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XAF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;XAF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CVE&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Escudo&quot;,&quot;long&quot;:&quot;Escudo&quot;,&quot;symbol&quot;:&quot;CVE&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KYD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;KYD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CLP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;CLP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CNY&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Yuan Renminbi&quot;,&quot;long&quot;:&quot;Yuan Renminbi&quot;,&quot;symbol&quot;:&quot;CNY&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;COP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;COP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KMF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;KMF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;CRC&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Colon&quot;,&quot;long&quot;:&quot;Colon&quot;,&quot;symbol&quot;:&quot;CRC&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ANG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Guilder&quot;,&quot;long&quot;:&quot;Guilder&quot;,&quot;symbol&quot;:&quot;ANG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;DJF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;DJF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;DOP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;DOP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;EGP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;EGP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ETB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Birr&quot;,&quot;long&quot;:&quot;Birr&quot;,&quot;symbol&quot;:&quot;ETB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;FKP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;FKP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;XPF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;XPF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GMD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dalasi&quot;,&quot;long&quot;:&quot;Dalasi&quot;,&quot;symbol&quot;:&quot;GMD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GIP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;GIP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GTQ&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Quetzal&quot;,&quot;long&quot;:&quot;Quetzal&quot;,&quot;symbol&quot;:&quot;GTQ&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GNF&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Franc&quot;,&quot;long&quot;:&quot;Franc&quot;,&quot;symbol&quot;:&quot;GNF&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;GYD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;GYD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;HTG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Gourde&quot;,&quot;long&quot;:&quot;Gourde&quot;,&quot;symbol&quot;:&quot;HTG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;HNL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lempira&quot;,&quot;long&quot;:&quot;Lempira&quot;,&quot;symbol&quot;:&quot;HNL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;RUP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;RUP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ISK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Krona&quot;,&quot;long&quot;:&quot;Krona&quot;,&quot;symbol&quot;:&quot;ISK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;INR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;INR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;IDR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupiah&quot;,&quot;long&quot;:&quot;Rupiah&quot;,&quot;symbol&quot;:&quot;IDR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;IQD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;IQD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;JMD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;JMD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;JOD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;JOD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KZT&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Tenge&quot;,&quot;long&quot;:&quot;Tenge&quot;,&quot;symbol&quot;:&quot;KZT&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KES&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;KES&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KWD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;KWD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LAK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kip&quot;,&quot;long&quot;:&quot;Kip&quot;,&quot;symbol&quot;:&quot;LAK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LBP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;LBP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LSL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Loti&quot;,&quot;long&quot;:&quot;Loti&quot;,&quot;symbol&quot;:&quot;LSL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LRD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;LRD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LYD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;LYD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MOP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pataca&quot;,&quot;long&quot;:&quot;Pataca&quot;,&quot;symbol&quot;:&quot;MOP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MKD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Denar&quot;,&quot;long&quot;:&quot;Denar&quot;,&quot;symbol&quot;:&quot;MKD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MWK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kwacha&quot;,&quot;long&quot;:&quot;Kwacha&quot;,&quot;symbol&quot;:&quot;MWK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MYR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ringgit&quot;,&quot;long&quot;:&quot;Ringgit&quot;,&quot;symbol&quot;:&quot;MYR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MVR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rufiyaa&quot;,&quot;long&quot;:&quot;Rufiyaa&quot;,&quot;symbol&quot;:&quot;MVR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MRU&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ouguiya&quot;,&quot;long&quot;:&quot;Ouguiya&quot;,&quot;symbol&quot;:&quot;MRU&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MUR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;MUR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MDL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Leu&quot;,&quot;long&quot;:&quot;Leu&quot;,&quot;symbol&quot;:&quot;MDL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MNT&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Tugrik&quot;,&quot;long&quot;:&quot;Tugrik&quot;,&quot;symbol&quot;:&quot;MNT&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MAD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dirham&quot;,&quot;long&quot;:&quot;Dirham&quot;,&quot;symbol&quot;:&quot;MAD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;MMK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kyat&quot;,&quot;long&quot;:&quot;Kyat&quot;,&quot;symbol&quot;:&quot;MMK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NAD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;NAD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NPR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;NPR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NIO&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Cordoba&quot;,&quot;long&quot;:&quot;Cordoba&quot;,&quot;symbol&quot;:&quot;NIO&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;NGN&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Naira&quot;,&quot;long&quot;:&quot;Naira&quot;,&quot;symbol&quot;:&quot;NGN&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KPW&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Won&quot;,&quot;long&quot;:&quot;Won&quot;,&quot;symbol&quot;:&quot;KPW&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;OMR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;OMR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PKR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;PKR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PAB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Balboa&quot;,&quot;long&quot;:&quot;Balboa&quot;,&quot;symbol&quot;:&quot;PAB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PGK&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kina&quot;,&quot;long&quot;:&quot;Kina&quot;,&quot;symbol&quot;:&quot;PGK&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PYG&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Guarani&quot;,&quot;long&quot;:&quot;Guarani&quot;,&quot;symbol&quot;:&quot;PYG&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PEN&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Sol&quot;,&quot;long&quot;:&quot;Sol&quot;,&quot;symbol&quot;:&quot;PEN&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;PHP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;PHP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;QAR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;QAR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;RUB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Ruble&quot;,&quot;long&quot;:&quot;Ruble&quot;,&quot;symbol&quot;:&quot;RUB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;WST&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Tala&quot;,&quot;long&quot;:&quot;Tala&quot;,&quot;symbol&quot;:&quot;WST&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;STD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dobra&quot;,&quot;long&quot;:&quot;Dobra&quot;,&quot;symbol&quot;:&quot;STD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SAR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;SAR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SCR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;SCR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SLL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Leone&quot;,&quot;long&quot;:&quot;Leone&quot;,&quot;symbol&quot;:&quot;SLL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SBD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;SBD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SOS&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;SOS&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ZAR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rand&quot;,&quot;long&quot;:&quot;Rand&quot;,&quot;symbol&quot;:&quot;ZAR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;KRW&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Won&quot;,&quot;long&quot;:&quot;Won&quot;,&quot;symbol&quot;:&quot;KRW&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;LKR&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rupee&quot;,&quot;long&quot;:&quot;Rupee&quot;,&quot;symbol&quot;:&quot;LKR&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SZL&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lilangeni&quot;,&quot;long&quot;:&quot;Lilangeni&quot;,&quot;symbol&quot;:&quot;SZL&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;SYP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pound&quot;,&quot;long&quot;:&quot;Pound&quot;,&quot;symbol&quot;:&quot;SYP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TWD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;TWD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TZS&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;TZS&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;THB&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Baht&quot;,&quot;long&quot;:&quot;Baht&quot;,&quot;symbol&quot;:&quot;THB&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TOP&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Pa'anga&quot;,&quot;long&quot;:&quot;Pa'anga&quot;,&quot;symbol&quot;:&quot;TOP&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TTD&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dollar&quot;,&quot;long&quot;:&quot;Dollar&quot;,&quot;symbol&quot;:&quot;TTD&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TND&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dinar&quot;,&quot;long&quot;:&quot;Dinar&quot;,&quot;symbol&quot;:&quot;TND&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;TRY&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Lira&quot;,&quot;long&quot;:&quot;Lira&quot;,&quot;symbol&quot;:&quot;TRY&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;UGX&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Shilling&quot;,&quot;long&quot;:&quot;Shilling&quot;,&quot;symbol&quot;:&quot;UGX&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;UAH&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Hryvnia&quot;,&quot;long&quot;:&quot;Hryvnia&quot;,&quot;symbol&quot;:&quot;UAH&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;AED&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Dirham&quot;,&quot;long&quot;:&quot;Dirham&quot;,&quot;symbol&quot;:&quot;AED&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;UYU&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Peso&quot;,&quot;long&quot;:&quot;Peso&quot;,&quot;symbol&quot;:&quot;UYU&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;VUV&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Vatu&quot;,&quot;long&quot;:&quot;Vatu&quot;,&quot;symbol&quot;:&quot;VUV&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;YER&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Rial&quot;,&quot;long&quot;:&quot;Rial&quot;,&quot;symbol&quot;:&quot;YER&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false},&quot;ZMW&quot;:{&quot;prefix_utf8&quot;:&quot;&quot;,&quot;prefix&quot;:&quot;&quot;,&quot;prefix_informal_utf8&quot;:&quot;&quot;,&quot;prefix_informal&quot;:&quot;&quot;,&quot;suffix_informal&quot;:&quot;&quot;,&quot;places&quot;:2,&quot;a_dollar&quot;:1,&quot;small_min_price&quot;:1,&quot;medium_min_price&quot;:1,&quot;fixed_rate&quot;:1,&quot;plural&quot;:&quot;Kwacha&quot;,&quot;long&quot;:&quot;Kwacha&quot;,&quot;symbol&quot;:&quot;ZMW&quot;,&quot;paypal&quot;:false,&quot;payflow&quot;:false}},&quot;list&quot;:[&quot;USD&quot;,&quot;AUD&quot;,&quot;THB&quot;,&quot;PAB&quot;,&quot;ETB&quot;,&quot;BOB&quot;,&quot;GBP&quot;,&quot;CAD&quot;,&quot;CRC&quot;,&quot;NIO&quot;,&quot;CZK&quot;,&quot;GMD&quot;,&quot;DKK&quot;,&quot;MKD&quot;,&quot;DZD&quot;,&quot;BHD&quot;,&quot;IQD&quot;,&quot;JOD&quot;,&quot;KWD&quot;,&quot;LYD&quot;,&quot;TND&quot;,&quot;MAD&quot;,&quot;AED&quot;,&quot;STD&quot;,&quot;XCD&quot;,&quot;BSD&quot;,&quot;BBD&quot;,&quot;BZD&quot;,&quot;BMD&quot;,&quot;BND&quot;,&quot;KYD&quot;,&quot;GYD&quot;,&quot;JMD&quot;,&quot;LRD&quot;,&quot;NAD&quot;,&quot;SBD&quot;,&quot;TWD&quot;,&quot;TTD&quot;,&quot;CVE&quot;,&quot;EUR&quot;,&quot;XOF&quot;,&quot;BIF&quot;,&quot;XAF&quot;,&quot;KMF&quot;,&quot;DJF&quot;,&quot;XPF&quot;,&quot;GNF&quot;,&quot;HTG&quot;,&quot;PYG&quot;,&quot;AWG&quot;,&quot;ANG&quot;,&quot;HKD&quot;,&quot;UAH&quot;,&quot;HUF&quot;,&quot;ILS&quot;,&quot;JPY&quot;,&quot;PGK&quot;,&quot;LAK&quot;,&quot;ISK&quot;,&quot;MWK&quot;,&quot;ZMW&quot;,&quot;MMK&quot;,&quot;ALL&quot;,&quot;HNL&quot;,&quot;SLL&quot;,&quot;MDL&quot;,&quot;SZL&quot;,&quot;TRY&quot;,&quot;LSL&quot;,&quot;MXN&quot;,&quot;NGN&quot;,&quot;NZD&quot;,&quot;BTN&quot;,&quot;NOK&quot;,&quot;MRU&quot;,&quot;TOP&quot;,&quot;MOP&quot;,&quot;ARS&quot;,&quot;CLP&quot;,&quot;COP&quot;,&quot;DOP&quot;,&quot;PHP&quot;,&quot;UYU&quot;,&quot;PLN&quot;,&quot;SHP&quot;,&quot;EGP&quot;,&quot;FKP&quot;,&quot;GIP&quot;,&quot;LBP&quot;,&quot;SYP&quot;,&quot;BWP&quot;,&quot;GTQ&quot;,&quot;ZAR&quot;,&quot;BRL&quot;,&quot;OMR&quot;,&quot;QAR&quot;,&quot;SAR&quot;,&quot;YER&quot;,&quot;KHR&quot;,&quot;MYR&quot;,&quot;RUB&quot;,&quot;MVR&quot;,&quot;RUP&quot;,&quot;INR&quot;,&quot;MUR&quot;,&quot;NPR&quot;,&quot;PKR&quot;,&quot;SCR&quot;,&quot;LKR&quot;,&quot;IDR&quot;,&quot;KES&quot;,&quot;SOS&quot;,&quot;TZS&quot;,&quot;UGX&quot;,&quot;SGD&quot;,&quot;PEN&quot;,&quot;SEK&quot;,&quot;CHF&quot;,&quot;BDT&quot;,&quot;WST&quot;,&quot;KZT&quot;,&quot;MNT&quot;,&quot;VUV&quot;,&quot;KPW&quot;,&quot;KRW&quot;,&quot;CNY&quot;],&quot;rates&quot;:{&quot;USD&quot;:1.0,&quot;AUD&quot;:0.673677,&quot;THB&quot;:0.0322053,&quot;PAB&quot;:1.0,&quot;ETB&quot;:0.00641886,&quot;BOB&quot;:0.144787,&quot;GBP&quot;:1.34417,&quot;CAD&quot;:0.722697,&quot;CRC&quot;:0.00205188,&quot;NIO&quot;:0.0271893,&quot;CZK&quot;:0.0481861,&quot;GMD&quot;:0.0136054,&quot;DKK&quot;:0.156942,&quot;MKD&quot;:0.0190363,&quot;DZD&quot;:0.00770642,&quot;BHD&quot;:2.65232,&quot;IQD&quot;:0.000763699,&quot;JOD&quot;:1.41044,&quot;KWD&quot;:3.25217,&quot;LYD&quot;:0.184178,&quot;TND&quot;:0.342494,&quot;MAD&quot;:0.109181,&quot;AED&quot;:0.272267,&quot;STD&quot;:0.0000448797,&quot;XCD&quot;:0.370021,&quot;BSD&quot;:1.0,&quot;BBD&quot;:0.5,&quot;BZD&quot;:0.497475,&quot;BMD&quot;:1.0,&quot;BND&quot;:0.780255,&quot;KYD&quot;:1.20061,&quot;GYD&quot;:0.00478225,&quot;JMD&quot;:0.00635369,&quot;LRD&quot;:0.00541643,&quot;NAD&quot;:0.0608719,&quot;SBD&quot;:0.123098,&quot;TWD&quot;:0.0315596,&quot;TTD&quot;:0.147647,&quot;CVE&quot;:0.0106076,&quot;EUR&quot;:1.17254,&quot;XOF&quot;:0.00178752,&quot;BIF&quot;:0.000338325,&quot;XAF&quot;:0.00178752,&quot;KMF&quot;:0.00238095,&quot;DJF&quot;:0.00562549,&quot;XPF&quot;:0.00982584,&quot;GNF&quot;:0.000114259,&quot;HTG&quot;:0.00764246,&quot;PYG&quot;:0.000149805,&quot;AWG&quot;:0.555556,&quot;ANG&quot;:0.558659,&quot;HKD&quot;:0.128224,&quot;UAH&quot;:0.0231154,&quot;HUF&quot;:0.0030447,&quot;ILS&quot;:0.316138,&quot;JPY&quot;:0.00632281,&quot;PGK&quot;:0.234058,&quot;LAK&quot;:0.000046277,&quot;ISK&quot;:0.00801989,&quot;MWK&quot;:0.000576974,&quot;ZMW&quot;:0.0499634,&quot;MMK&quot;:0.000476213,&quot;ALL&quot;:0.0121642,&quot;HNL&quot;:0.0377453,&quot;SLL&quot;:0.0000476883,&quot;MDL&quot;:0.0588378,&quot;SZL&quot;:0.0608648,&quot;TRY&quot;:0.0231037,&quot;LSL&quot;:0.0608719,&quot;MXN&quot;:0.0568239,&quot;NGN&quot;:0.000704944,&quot;NZD&quot;:0.583256,&quot;BTN&quot;:0.0110039,&quot;NOK&quot;:0.100071,&quot;MRU&quot;:0.0251105,&quot;TOP&quot;:0.415324,&quot;MOP&quot;:0.124568,&quot;ARS&quot;:0.000697228,&quot;CLP&quot;:0.00112973,&quot;COP&quot;:0.000272677,&quot;DOP&quot;:0.0158208,&quot;PHP&quot;:0.0168433,&quot;UYU&quot;:0.0260453,&quot;PLN&quot;:0.277618,&quot;SHP&quot;:1.34417,&quot;EGP&quot;:0.0210651,&quot;FKP&quot;:1.34417,&quot;GIP&quot;:1.34417,&quot;LBP&quot;:0.0000111742,&quot;SYP&quot;:0.0000769112,&quot;BWP&quot;:0.074868,&quot;GTQ&quot;:0.130477,&quot;ZAR&quot;:0.0608955,&quot;BRL&quot;:0.185968,&quot;OMR&quot;:2.60082,&quot;QAR&quot;:0.274587,&quot;SAR&quot;:0.266672,&quot;YER&quot;:0.00419331,&quot;KHR&quot;:0.000248424,&quot;MYR&quot;:0.24653,&quot;RUB&quot;:0.0128156,&quot;MVR&quot;:0.0647249,&quot;RUP&quot;:1.0,&quot;INR&quot;:0.0109749,&quot;MUR&quot;:0.0216497,&quot;NPR&quot;:0.00687741,&quot;PKR&quot;:0.00357608,&quot;SCR&quot;:0.0716913,&quot;LKR&quot;:0.00323057,&quot;IDR&quot;:0.000058933,&quot;KES&quot;:0.00775531,&quot;SOS&quot;:0.00175368,&quot;TZS&quot;:0.00039604,&quot;UGX&quot;:0.00028917,&quot;SGD&quot;:0.778746,&quot;PEN&quot;:0.297909,&quot;SEK&quot;:0.109583,&quot;CHF&quot;:1.26602,&quot;BDT&quot;:0.00817858,&quot;WST&quot;:0.361298,&quot;KZT&quot;:0.00196949,&quot;MNT&quot;:0.000280899,&quot;VUV&quot;:0.00824402,&quot;KPW&quot;:0.00111111,&quot;KRW&quot;:0.000675408,&quot;CNY&quot;:0.143653},&quot;setting&quot;:null,&quot;current&quot;:null}}"></div>
+
+
+    <div class="menu-bar-wrapper">
+        <menu-bar page-context="[redacted]" color-scheme="dark" banners=""></menu-bar>
+    </div>
+    <div id="content"></div>
+
+
+
+    
+    
+
+
+
+
+
+
+
+    <div class="bannercontainer" data-banners="[]">
+
+
+
+
+
+
+
+
+    </div>
+
+    
+
+
+
+
+
+
+
+
+
+    
+    
+    
+    
+
+    
+<div class="corpbanner newsletter-invite-banner" style="display: none;">
+    <span class="tell-us-what-you-like">Get fresh music recommendations delivered to your inbox every Friday.</span> <svg class="dismiss" width="18" height="18" viewBox="0 0 24 24"><use xlink="http://www.w3.org/1999/xlink" xlink:href="#material-close"></use></svg>
+</div>
+
+
+
+
+
+    
+    
+    
+
+    
+
+    
+
+
+
+
+
+
+
+
+<!--  -->
+
+<div id="centerWrapper">
+    <div id="propOpenWrapper">
+        
+
+        
+
+        
+
+    
+    
+    
+
+    
+
+        <div id="pgBd" class="yui-skin-sam">
+            
+
+
+
+    
+    
+
+
+
+
+<div class="bd">
+    
+    <div id="customHeaderWrapper" class="bd-section">
+        
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+    <div id="customHeader">
+    
+        <div class="desktop-header">
+            <a href="https://arabstrap.bandcamp.com/" referrerpolicy="strict-origin-when-cross-origin"><img src="Bandcamp_files/0019318311_100.png" width="975" height="180"></a>
+            
+        </div>
+    
+    
+    </div>
+
+
+
+
+        
+
+
+
+
+
+
+
+    <div class="bannercontainer" data-banners="[]">
+
+
+
+
+
+
+
+
+    </div>
+
+    </div>
+    
+
+    <div id="post-checkout-info" class="bd-section post-checkout-container fan simplified redownload">
+        
+            
+    
+
+<div class="download-item-container free">
+    
+
+    <div class="download-artwork">
+
+
+    
+        
+            <a href="https://arabstrap.bandcamp.com/album/philophobia-undressed">
+        
+    
+
+    
+
+    
+    
+        <img class="download-thumbnail" src="Bandcamp_files/a3728906191_7.jpg" title="">
+    
+    
+        </a>
+    
+    
+
+</div>
+
+
+
+    <div class="free-download download" data-bind="with: downloadVMs()[0]">
+        
+        <div class="title">Philophobia Undressed</div>
+        <div class="artist">by Arab Strap</div>
+        <div class="type">
+            
+        </div>
+
+        
+
+            <!-- needs to be wrapped inside a container with data-bind="with: downloadVMs()[0] -->
+            <div class="download-format-tmp">
+                    <!--error handlers -->
+                    <div class="download-error" data-bind="visible: downloadError()" style="">
+                        <div data-bind="visible: genericError() &amp;&amp; !supportHighVolShow()" style="display: none;">
+                            <div class="error-text">Download error.</div>
+                            <div><a onclick="window.location.reload()">Click here</a> to reload this page and try again.</div>
+                            <div>If you keep getting this error, please <a data-bind="attr: {href: supportUrl}" href="https://bandcamp.com/contact?subj=Download%20error&amp;amp;msg=I%20keep%20seeing%20this%20error%20when%20I%20try%20to%20download%20stuff%3A%0A%0Aerror%20type%3A%20serverside_err_expired%0Abrowser%3A%20nix%20firefox%20147%2C0%0Aurl%3A%20https%3A%2F%2Fbandcamp.com%2Fdownload%3Ffrom%3Dcollection%26amp%3Bpayment_id%3D4261422286%26amp%3Bsig%3D1cf6df5a557374e148a828931ce97f79%26amp%3Bsitem_id%3D347771046%0Adate%3A%202026-01-20%2022%3A51%3A12%20UTC%0Ahost%3A%20scruffycentral-ns35-3%0A">contact support</a>.</div>
+                        </div>
+                        <div data-bind="visible: genericError() &amp;&amp; supportHighVolShow()" style="display: none;">
+                            <div class="error-text">Download error.</div>
+                            <div>We’re running a <a href="https://daily.bandcamp.com/features/bandcamp-covid-19-fundraiser">fundraiser</a> resulting in a high volume of downloads. You may experience slow download times. Please try again later.</div>
+                        </div>
+                        <div data-bind="visible: dropError()" style="display: none;">
+                            <div class="error-text">There was an error preparing your download.</div>
+                            <div><a onclick="window.location.reload()">Click here</a> to reload this page and try again.</div>
+                            <div>If you keep getting this error, please check out our <a href="https://bandcamp.com/troubleshooting">troubleshooting page</a>.</div>
+                        </div>
+                        <div data-bind="visible: cutoffError()" style="display: none;">
+                            <div class="error-text">You’ve requested this download too many times. You can try again in one hour.</div>
+                            <div>If you’re certain you’ve not made many requests, there could be an issue with your browser or device.</div>
+                            <div>Please read through our <a href="https://bandcamp.com/troubleshooting">troubleshooting guide</a> and give your download another try later.</div>
+                        </div>
+                        <div class="email-reauth-error" data-bind="visible: expiredError()" style="">
+                            <div data-bind="visible: !reauthEmailSent()">
+    <div class="error-text">Download expired.</div>
+    <div class="error-msg" data-bind="visible: !invalidEmail()">
+        
+            Please enter the email address you used to purchase this item:
+        
+    </div>
+    <div class="error-msg" data-bind="visible: invalidEmail()" style="display: none;">
+        
+            Sorry, that doesn’t seem to be the correct address. <a href="https://get.bandcamp.help/hc/articles/23020691083287">Here’s what to do next.</a>
+        
+    </div>
+    <form class="reauth-form" data-bind="submit: tryDownloadReauth">
+        <input class="reauth-email" type="text" data-bind="value: reauthEmail">
+        <input class="submit" type="submit" value="GO">
+    </form>
+</div>
+<div data-bind="visible: reauthEmailSent()" style="display: none;">
+    Thank you. We’ve sent a link to your download to <span data-bind="text: reauthEmail"></span>
+</div>
+
+                        </div>
+                    </div>
+
+                    <label for="format-type" class="no-wrap" data-bind="visible: hasDownload &amp;&amp; !downloadError()" style="display: none;">Choose format:</label>
+                    <select class="bc-select select-margins" id="format-type" data-bind="
+                    options: downloadFormatInfos,
+                    optionsText: (item) =&gt;  item.sizeMb? item.description + ' - ' + item.sizeMb : item.description,
+                    optionsValue:(item) =&gt; item.encodingName,
+                    value: $parent.formatVM.format().name,
+                    event: {change: changeFormat.bind($data, $parent.formatVM)},
+                    visible: hasDownload &amp;&amp; !downloadError()
+                    " style="display: none;"><option value="mp3-v0">MP3 V0 - 101.3MB</option><option value="mp3-320">MP3 320 - 137.8MB</option><option value="flac">FLAC - 685.3MB</option><option value="aac-hi">AAC - 57.3MB</option><option value="vorbis" selected="selected">Ogg Vorbis - 69.5MB</option><option value="alac">ALAC - 697.3MB</option><option value="wav">WAV - 968MB</option><option value="aiff-lossless">AIFF - 969.6MB</option>
+                    </select>
+
+                    <div class="download-button button preparing-wrapper" data-bind="visible: !downloadReady() &amp;&amp; !downloadError()" style="display: none;">
+                        <div class="download-button-inner">
+                            <div class="preparing-title"><em>Preparing</em></div>
+                        </div>
+                    </div>
+
+                    <a style="display: none" data-bind="attr: { href: downloadUrl }, visible: downloadReady() &amp;&amp; !downloadError()">Download</a> 
+                   
+                    <!-- hate this but with css and flex the box model is too large for a text sized divider-->
+                    <span class="text-divider">|</span>
+                    <a class="left-horizontal-break" href="https://bandcamp.com/help/downloading" data-bind="visible: !downloadError()" style="display: none;">Need download help?</a>
+                </div> 
+
+
+
+        
+        
+    </div>
+</div>
+
+    <div class="back-to">
+    
+    <div class="shipping">
+        Info about <a href="https://bandcamp.com/help/physical_orders?payment_id=4261422286&amp;sig=b5f49b451a224d9bb3f1a9303439fddf">shipping and returns</a>
+    </div>
+    
+
+    
+        
+            
+            
+                <div>
+                    Visit <a href="https://arabstrap.bandcamp.com/">Arab Strap</a>
+                </div>
+            
+        
+    
+
+    
+
+    
+
+</div>
+
+
+
+        
+    </div>
+</div>
+
+<div class="download-bottom-area">
+    <div class="bd-section download-bottom-area-inner">
+        
+            
+            <div id="recommendations-container" class="recommendations-container">
+            
+
+<div id="recommended-by-text">Recommended by <a href="https://arabstrap.bandcamp.com/" target="_blank">Arab Strap</a></div>
+
+
+
+
+
+
+
+    
+        
+    
+    
+    
+    
+
+
+
+
+<div id="recommendation_0" class="recommended-item-container">
+    <div class="recommended-item-thumbnail-container">
+        <a href="https://aidanjohnmoffat.bandcamp.com/album/vagrants-09-14?from=ditem-arabstrap" target="_blank" class="recommended-artist-dl-link-click">
+            <img class="recommended-item-thumbnail" src="Bandcamp_files/a1522123359_3.jpg" alt="VAGRANTS_09_14 Cover Art">
+        </a>
+    </div>
+    <div class="recommended-item">
+        <h3 class="recommendation-title"><a target="_blank" href="https://aidanjohnmoffat.bandcamp.com/album/vagrants-09-14?from=ditem-arabstrap" class="recommended-artist-dl-link-click">VAGRANTS_09_14</a></h3>
+        <h4 class="recommendation-artist secondaryText">Aidan John Moffat</h4>
+        <div class="recommendation-why secondaryText">Vagrants_09_14</div>
+        
+    </div>
+</div>
+
+
+<div id="recommendation_1" class="recommended-item-container">
+    <div class="recommended-item-thumbnail-container">
+        <a href="https://malcolmmiddleton.bandcamp.com/album/guitar-variations?from=ditem-arabstrap" target="_blank" class="recommended-artist-dl-link-click">
+            <img class="recommended-item-thumbnail" src="Bandcamp_files/a1317549431_3.jpg" alt="Guitar Variations Cover Art">
+        </a>
+    </div>
+    <div class="recommended-item">
+        <h3 class="recommendation-title"><a target="_blank" href="https://malcolmmiddleton.bandcamp.com/album/guitar-variations?from=ditem-arabstrap" class="recommended-artist-dl-link-click">Guitar Variations</a></h3>
+        <h4 class="recommendation-artist secondaryText">Malcolm Middleton</h4>
+        <div class="recommendation-why secondaryText">Guitar Variations by HUMAN DON'T BE ANGRY</div>
+        
+            
+            
+
+            
+            
+            
+                <span class="also-recommended-by">
+                    
+                        Also recommended by
+                            <a target="_blank" class="also-recommended-by-artist-link" href="https://the-aliens.bandcamp.com/?from=dartistalso">The Aliens</a> and
+                            <a target="_blank" class="also-recommended-by-artist-link" href="https://teamclermont.bandcamp.com/?from=dartistalso">teamClermont</a>.
+                        
+                    
+                </span>
+            
+            
+        
+    </div>
+</div>
+
+
+
+
+
+
+            </div>
+        
+
+        
+        
+        <div class="discover-container">
+            <div class="discover-content">
+                <h3><a href="https://bandcamp.com/discover?g=alternative&amp;from=dlpage">
+            
+                Explore more alternative music on Bandcamp
+            
+         <span class="discover-go bc-ui"></span></a></h3>
+            </div>
+        </div>
+        
+
+        <div class="bcweekly-container">
+            
+<div class="bcweekly-content">
+    <h3>Don’t miss the latest <nobr>Bandcamp Weekly!</nobr></h3>
+    <div class="bcweekly-image-wrapper">
+        <a href="http://bandcamp.com/?from=bcwdwnlds&amp;play=1">
+            <div class="play-btn">
+                <div class="icon"> </div>
+            </div>
+            <img src="Bandcamp_files/0042408944_0.jpg">
+        </a>
+    </div>
+    <div class="bcweekly-blurb">
+        <div class="bcweekly-title">
+            <span class="date">Jan 19, 2026</span>:
+            <span class="title">Fuzzy Logic</span>
+        </div>
+        <span class="desc">DJ Harrison stops by to talk about his new record Electrosoul.</span>
+    </div>
+    <h3 class="listen-now"><a href="http://bandcamp.com/?from=bcwdwnlds&amp;play=1">Listen now <span class="bcweekly-go bc-ui"></span></a></h3>
+</div>
+
+
+        </div>
+    </div>
+</div>
+
+            <div style="clear:both"></div>
+        </div>
+
+        
+
+        
+            <span id="webapp-selector-ui" class="webapp-selector-ui" style="display:none" data-webapps="[&quot;flexotest01-1&quot;,&quot;flexotest01-2&quot;,&quot;flexotest01-3&quot;,&quot;flexotest01-4&quot;,&quot;flexotest01-5&quot;,&quot;flexotest01-6&quot;,&quot;flexotest01-7&quot;,&quot;flexotest01-8&quot;,&quot;flexotest01-9&quot;,&quot;flexotest01-10&quot;,&quot;flexotest01-11&quot;,&quot;flexotest01-12&quot;,&quot;flexotest01-13&quot;,&quot;flexotest01-14&quot;,&quot;flexotest01-15&quot;,&quot;flexotest01-16&quot;]" data-backendid="c2flexocentral-mqf8-7" data-bccookie="" data-cookiename="bc_webapp3"></span>
+
+            <page-footer page-context="[redacted]" color-scheme="dark"></page-footer>
+            
+        
+    </div>
+</div>
+
+<div id="global-invisible-recaptcha" style="position: absolute; top: 0;"></div>
+<div id="fan-signup-addnl-bundle" data-url="https://s4.bcbits.com/client-bundle/1/trackpipe/masonry-04ea5cb823ea04af8b7afb16dfe2338e.js"></div>
+
+
+
+
+<script type="text/javascript" src="Bandcamp_files/tko_trackpipe-525ac32695cf93110d7d35f736fd51e7.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp_files/global_foot1-427109551f7206160fa1cc083773672b.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp_files/global_foot2-2402c1c464c97f49f690a4abf5775aae.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp_files/time-c6f294f92b5c3a7bd018b03b3c71f372.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp_files/fraud_js-2dae71c049a60b82b63f4cd24b1b062f.js" crossorigin="anonymous" nonce="" data-enterprise-recaptcha="{&quot;render_url&quot;:&quot;https://www.recaptcha.net/recaptcha/enterprise.js?render=6LeBNSocAAAAADrhkgX9-hQq4E4K1P_HVzB7IDFD&quot;,&quot;public_site_key&quot;:&quot;6LeBNSocAAAAADrhkgX9-hQq4E4K1P_HVzB7IDFD&quot;}"></script>
+
+
+
+<script type="text/javascript" src="Bandcamp_files/download_2016-c7b4d7b612dc7e11af95036a536cd8ab.js" crossorigin="anonymous" nonce=""></script>
+<script type="text/javascript" src="Bandcamp_files/web_components-bbaf82c832d0268e3b0a18a2f7665387.js" crossorigin="anonymous" nonce=""></script>
+
+
+<script type="text/javascript" src="Bandcamp_files/analytics-f6d7fd2522940544d7e5f73a03ca3c4f.js" crossorigin="anonymous" nonce="" data-data="{&quot;env&quot;:2,&quot;domain_match&quot;:true,&quot;bandGoogleAnalyticsId&quot;:null}" data-items="[]"></script>
+<script type="text/javascript" src="Bandcamp_files/impl-2fd8d3e0ca4ebe03fd7a3b7d60fa3671.js" crossorigin="anonymous" nonce="" data-enabled="true" data-transport="&quot;beacon&quot;" data-record-url="&quot;https://bandcamp.com/api/tracker/1/record&quot;" data-send-delay="5" data-auto-track-clicks="true" data-auto-track-filters="null"></script>
+ 
+
+
+
+
+
+<iframe name="__privateStripeMetricsController2870" frameborder="0" allowtransparency="true" scrolling="no" role="presentation" src="Bandcamp_files/m-outer-3437aaddcdf6922d623e172c2d6f9278.html" aria-hidden="true" tabindex="-1" style="border: medium !important; margin: 0px !important; padding: 0px !important; width: 1px !important; min-width: 100% !important; overflow: hidden !important; display: block !important; visibility: hidden !important; position: fixed !important; height: 1px !important; pointer-events: none !important; user-select: none !important;"></iframe></body></html>
+<!-- c2flexocentral-mqf8-7 2026-01-20 22:51:11 UTC -->

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+
+import pytest
+from bandcampsync.bandcamp import Bandcamp, BandcampItem
+
+
+def _load_payload(name):
+    fixture_path = Path(__file__).resolve().parent / "data" / name
+    return json.loads(fixture_path.read_text(encoding="utf-8", errors="ignore"))
+
+
+def _create_bandcamp():
+    bandcamp = Bandcamp("identity=test")
+    bandcamp.is_authenticated = True
+    bandcamp.user_id = 1
+    return bandcamp
+
+
+def _download_key(item):
+    return f"{item['sale_item_type']}{item['sale_item_id']}"
+
+
+@pytest.fixture
+def bandcamp():
+    return _create_bandcamp()
+
+
+@pytest.fixture
+def digital_payload():
+    return _load_payload("collection-item-digital-only.json")
+
+
+@pytest.fixture
+def physical_payload():
+    return _load_payload("collection-item-physical-only.json")
+
+
+@pytest.fixture
+def digital_item(digital_payload):
+    return digital_payload["items"][0]
+
+
+@pytest.fixture
+def physical_item(physical_payload):
+    return physical_payload["items"][0]
+
+
+# Tests if an item is a physical purchase (though may also include a digital component).
+def test_is_physical_purchase_true(physical_item):
+    assert BandcampItem(physical_item).is_physical_purchase() is True
+
+# Tests if an item is _not_ a physical purchase (though doesn't necessarily include a digital component).
+def test_is_physical_purchase_false(digital_item):
+    assert BandcampItem(digital_item).is_physical_purchase() is False
+
+# Tests if a download URL can be retrieved for a digital purchase.
+def test_resolve_download_url_digital(bandcamp, digital_payload, digital_item):
+    item = BandcampItem(digital_item)
+    download_url = bandcamp._resolve_download_url(
+        item,
+        digital_payload["redownload_urls"],
+    )
+    expected_key = _download_key(digital_item)
+    assert download_url == digital_payload["redownload_urls"][expected_key]
+
+# Tests that no download URL can be retrieved for a physical-only purchase.
+def test_resolve_download_url_physical(bandcamp, physical_payload, physical_item):
+    item = BandcampItem(physical_item)
+    download_url = bandcamp._resolve_download_url(
+        item,
+        physical_payload["redownload_urls"],
+    )
+    assert download_url is None

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from bandcampsync.download import _is_expired_download_page
+
+
+def _load_fixture(name):
+    html_path = Path(__file__).resolve().parent / "data" / name
+    return html_path.read_text(encoding="utf-8", errors="ignore")
+
+
+def test_expired_download_page():
+    html = _load_fixture("download-expired.html")
+    assert _is_expired_download_page(html) is True
+
+
+def test_non_expired_download_page():
+    html = _load_fixture("download-choose-format.html")
+    assert _is_expired_download_page(html) is False


### PR DESCRIPTION
Addresses a few corner-cases (issue #53)

Physical-only items (i.e. those without downloads) are now correctly skipped. 

Expired downloads where email confirmation from the user are now detected and skipped.

Multiple collection items sharing the same artist and title names are now treated as distinct entities by adding their item ID as suffix to the folder-name.


Handling of these missing/expired downloads is handled more explicitly. New BandcampDownloadUnavailable and DownloadExpired errors can be raised.

Sync flow has been changed to create item directories only after an item has been successfully downloaded.

pytests added around the handling of duplicate, expired and physical/digital items. Some refactoring was performed in order to support this.