### PR TITLE
Add two new flags: `--sync-ignore-file` and `--skip-item-index`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ When `--sync-ignore-file` is passed, any downloaded items found in the filesyste
 are not already present in the ignore file will be appended to the ignore file. This
 option requires that you pass a path to an ignore file with `-I / --ignore-file`.
 
-When `--skip-item-index` is passed only the ignore file will be used to determine which
+When `--skip-item-index` is passed, only the ignore file will be used to determine which
 items have been downloaded already; bandcampsync will not traverse your filesystem and
 read the bandcamp_item_id.txt files. This option requires that you pass a path to an
 ignore file with `-I / --ignore-file`.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ items have been loaded, same as the `--notify-url` CLI argument.
 
 `CONCURRENCY` can be set to the number of concurrent downloads, defaults to `1`.
 
+`SKIP_ITEM_INDEX` can be set to true to rely exclusively on the ignore file to determine which items
+have been downloaded already, same as the `--skip-item-index` CLI argument.
+
 
 ## Configuration
 
@@ -217,6 +220,15 @@ time you run the script those items will not be re-downloaded.
 This means you can use media managers such as Lidarr to rename artist, album,
 and track names automatically, rename the directory, or even move the items out
 of the download directory without issues.
+
+When `--sync-ignore-file` is passed, any downloaded items found in the filesystem that
+are not already present in the ignore file will be appended to the ignore file. This
+option requires that you pass a path to an ignore file with `-I / --ignore-file`.
+
+When `--skip-item-index` is passed only the ignore file will be used to determine which
+items have been downloaded already; bandcampsync will not traverse your filesystem and
+read the bandcamp_item_id.txt files. This option requires that you pass a path to an
+ignore file with `-I / --ignore-file`.
 
 
 You can notify an external HTTP server when new items have been loaded with `-n` or

--- a/bandcampsync/__init__.py
+++ b/bandcampsync/__init__.py
@@ -17,6 +17,7 @@ def do_sync(
     max_retries=3,
     retry_wait=5,
     skip_filesystem=False,
+    sync_ignore_file=False,
 ):
     Syncer(
         cookies,
@@ -29,7 +30,8 @@ def do_sync(
         concurrency,
         max_retries,
         retry_wait,
-        skip_filesystem
+        skip_filesystem,
+        sync_ignore_file,
     )
 
     return True

--- a/bandcampsync/__init__.py
+++ b/bandcampsync/__init__.py
@@ -16,6 +16,7 @@ def do_sync(
     concurrency=1,
     max_retries=3,
     retry_wait=5,
+    skip_filesystem=False,
 ):
     Syncer(
         cookies,
@@ -28,6 +29,7 @@ def do_sync(
         concurrency,
         max_retries,
         retry_wait,
+        skip_filesystem
     )
 
     return True

--- a/bandcampsync/__init__.py
+++ b/bandcampsync/__init__.py
@@ -16,7 +16,7 @@ def do_sync(
     concurrency=1,
     max_retries=3,
     retry_wait=5,
-    skip_filesystem=False,
+    skip_item_index=False,
     sync_ignore_file=False,
 ):
     Syncer(
@@ -30,7 +30,7 @@ def do_sync(
         concurrency,
         max_retries,
         retry_wait,
-        skip_filesystem,
+        skip_item_index,
         sync_ignore_file,
     )
 

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -1,6 +1,4 @@
-import pickle
 from unicodedata import normalize
-
 from bandcampsync.bandcamp import BandcampItem
 from .logger import get_logger
 
@@ -22,7 +20,7 @@ class LocalMedia:
 
     ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
 
-    def __init__(self, media_dir, skip_filesystem, ignores, sync_ignore_file):
+    def __init__(self, media_dir, ignores, skip_filesystem, sync_ignore_file):
         self.media_dir = media_dir
         self.ignores = ignores
         self.media = {}

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -1,5 +1,7 @@
 import pickle
 from unicodedata import normalize
+
+from bandcampsync.bandcamp import BandcampItem
 from .logger import get_logger
 
 
@@ -20,31 +22,17 @@ class LocalMedia:
 
     ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
 
-    def __init__(self, media_dir, skip_filesystem):
+    def __init__(self, media_dir, skip_filesystem, ignores, sync_ignore_file):
         self.media_dir = media_dir
+        self.ignores = ignores
         self.media = {}
         self.item_names = set()
+        self.sync_ignore_file = sync_ignore_file
         log.info(f"Local media directory: {self.media_dir}")
-        self.found_data = False
 
-        self.load_data()
-
-        if not skip_filesystem or not self.found_data:
+        # If the ignores file is empty, we need to traverse the filesystem anyway
+        if not skip_filesystem or len(self.ignores.ids) < 1:
             self.index()
-
-    def load_data(self):
-        try:
-            with open("media.pickle", "rb") as f:
-                self.media = pickle.load(f)
-            self.found_data = True
-        except FileNotFoundError:
-            log.info(
-                "No persisted data file found; will traverse filesystem to find downloaded albums."
-            )
-
-    def persist_data(self):
-        with open("media.pickle", "wb") as f:
-            pickle.dump(self.media, f)
 
     def _clean_path(self, path_str):
         path_str = str(path_str)
@@ -70,20 +58,21 @@ class LocalMedia:
                     if child2.is_dir():
                         for child3 in child2.iterdir():
                             if child3.name == self.ITEM_INDEX_FILENAME:
-                                if child2 not in self.media.values():
-                                    item_id = self.read_item_id(child3)
-                                    self.media[item_id] = child2
-                                    self.item_names.add(
-                                        (child2.parent.name, child2.name)
+                                item_id = self.read_item_id(child3)
+                                if self.sync_ignore_file:
+                                    item = BandcampItem(
+                                        {
+                                            "item_id": item_id,
+                                            "band_name": child2.parent.name,
+                                            "item_title": child2.name,
+                                        }
                                     )
-                                    self.persist_data()
-                                    log.info(
-                                        f"Detected locally downloaded media: {item_id} = {child2}"
-                                    )
-                                else:
-                                    log.info(
-                                        f"Skipping {child2} as it's already present in database"
-                                    )
+                                    self.ignores.add(item)
+                                self.media[item_id] = child2
+                                self.item_names.add((child2.parent.name, child2.name))
+                                log.info(
+                                    f"Detected locally downloaded media: {item_id} = {child2}"
+                                )
         return True
 
     def read_item_id(self, filepath):
@@ -123,7 +112,6 @@ class LocalMedia:
         outfile = dirpath / self.ITEM_INDEX_FILENAME
         log.info(f"Writing bandcamp item id:{item.item_id} to: {outfile}")
         self.media[item.item_id] = dirpath
-        self.persist_data()
         with open(outfile, "wt") as f:
             f.write(f"{item.item_id}\n")
         return True

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -20,7 +20,7 @@ class LocalMedia:
 
     ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
 
-    def __init__(self, media_dir, ignores, skip_filesystem, sync_ignore_file):
+    def __init__(self, media_dir, ignores, skip_item_index, sync_ignore_file):
         self.media_dir = media_dir
         self.ignores = ignores
         self.media = {}
@@ -29,7 +29,7 @@ class LocalMedia:
         log.info(f"Local media directory: {self.media_dir}")
 
         # If the ignores file is empty, we need to traverse the filesystem anyway
-        if not skip_filesystem or len(self.ignores.ids) < 1:
+        if not skip_item_index or len(self.ignores.ids) < 1:
             self.index()
 
     def _clean_path(self, path_str):

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -65,7 +65,8 @@ class LocalMedia:
                                             "item_title": child2.name,
                                         }
                                     )
-                                    self.ignores.add(item)
+                                    if not self.ignores.is_ignored(item):
+                                        self.ignores.add(item)
                                 self.media[item_id] = child2
                                 self.item_names.add((child2.parent.name, child2.name))
                                 log.info(

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -111,7 +111,6 @@ class LocalMedia:
     def write_bandcamp_id(self, item, dirpath):
         outfile = dirpath / self.ITEM_INDEX_FILENAME
         log.info(f"Writing bandcamp item id:{item.item_id} to: {outfile}")
-        self.media[item.item_id] = dirpath
         with open(outfile, "wt") as f:
             f.write(f"{item.item_id}\n")
         return True

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -228,6 +228,7 @@ class Syncer:
             # Wait for all tasks to complete
             await asyncio.gather(*tasks)
 
+        # We don't need to show this warning if we're running the ignorefile sync script
         if self.show_id_file_warning and not self.sync_ignore_file:
             log.warning(
                 f"The {self.ign_file_path} file is tracking already downloaded items, "

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -35,7 +35,7 @@ class Syncer:
         concurrency=1,
         max_retries=3,
         retry_wait=5,
-        skip_filesystem=False,
+        skip_item_index=False,
         sync_ignore_file=False,
     ):
         self.ignores = Ignores(ign_file_path=ign_file_path, ign_patterns=ign_patterns)
@@ -43,7 +43,7 @@ class Syncer:
         self.local_media = LocalMedia(
             media_dir=dir_path,
             ignores=self.ignores,
-            skip_filesystem=skip_filesystem,
+            skip_item_index=skip_item_index,
             sync_ignore_file=sync_ignore_file,
         )
         self.media_format = media_format

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -36,10 +36,15 @@ class Syncer:
         max_retries=3,
         retry_wait=5,
         skip_filesystem=False,
+        sync_ignore_file=False,
     ):
         self.ignores = Ignores(ign_file_path=ign_file_path, ign_patterns=ign_patterns)
+        self.sync_ignore_file = sync_ignore_file
         self.local_media = LocalMedia(
-            media_dir=dir_path, skip_filesystem=skip_filesystem
+            media_dir=dir_path,
+            skip_filesystem=skip_filesystem,
+            ignores=self.ignores,
+            sync_ignore_file=sync_ignore_file,
         )
         self.media_format = media_format
         self.temp_dir_root = temp_dir_root
@@ -223,7 +228,7 @@ class Syncer:
             # Wait for all tasks to complete
             await asyncio.gather(*tasks)
 
-        if self.show_id_file_warning:
+        if self.show_id_file_warning and not self.sync_ignore_file:
             log.warning(
                 f"The {self.ign_file_path} file is tracking already downloaded items, "
                 f"but some directories are using bandcamp_item_id.txt files. "

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -234,6 +234,7 @@ class Syncer:
                 f"The {self.ign_file_path} file is tracking already downloaded items, "
                 f"but some directories are using bandcamp_item_id.txt files. "
                 f"If you want to get migrate from ID files to using the {self.ign_file_path} file, "
+                f"pass the '--sync-ignore-file' flag, or"
                 f"run the following script inside the downloads directory, then append the "
                 f"content of the new ignores.txt file to the ignores file in your "
                 f"config directory:\n"

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -35,9 +35,12 @@ class Syncer:
         concurrency=1,
         max_retries=3,
         retry_wait=5,
+        skip_filesystem=False,
     ):
         self.ignores = Ignores(ign_file_path=ign_file_path, ign_patterns=ign_patterns)
-        self.local_media = LocalMedia(media_dir=dir_path)
+        self.local_media = LocalMedia(
+            media_dir=dir_path, skip_filesystem=skip_filesystem
+        )
         self.media_format = media_format
         self.temp_dir_root = temp_dir_root
         self.ign_file_path = ign_file_path

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -42,8 +42,8 @@ class Syncer:
         self.sync_ignore_file = sync_ignore_file
         self.local_media = LocalMedia(
             media_dir=dir_path,
-            skip_filesystem=skip_filesystem,
             ignores=self.ignores,
+            skip_filesystem=skip_filesystem,
             sync_ignore_file=sync_ignore_file,
         )
         self.media_format = media_format

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -7,115 +7,78 @@ from pathlib import Path
 from bandcampsync import version, logger, do_sync
 
 
-log = logger.get_logger("run")
+log = logger.get_logger('run')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        prog="bandcampsync",
-        description="Syncs media purcahsed on bandcamp.com with a local directory",
+        prog='bandcampsync',
+        description='Syncs media purcahsed on bandcamp.com with a local directory',
     )
-    parser.add_argument(
-        "-v",
-        "--version",
-        action="store_true",
-        help="Displays the bandcampsync version and exits",
-    )
-    parser.add_argument(
-        "-c", "--cookies", required=True, help="Path to the cookies file"
-    )
-    parser.add_argument(
-        "-d",
-        "--directory",
-        required=True,
-        help="Path to the directory to download media to",
-    )
-    parser.add_argument(
-        "-I", "--ignore-file", default="", help="Path to the ignore file"
-    )
-    parser.add_argument(
-        "-i",
-        "--ignore",
-        default="",
-        help="A space-delimited list of patterns matching artists to bypass",
-    )
-    parser.add_argument(
-        "-f",
-        "--format",
-        default="flac",
-        help='Media format to download, defaults to "flac"',
-    )
-    parser.add_argument(
-        "-x",
-        "--no-filesystem",
-        action="store_true",
-        help="Don't traverse filesystem; rely on database for already downloaded items",
-    )
-    parser.add_argument(
-        "-t", "--temp-dir", default="", help="Path to use for temporary downloads"
-    )
-    parser.add_argument(
-        "-n",
-        "--notify-url",
-        default="",
-        help="URL to notify with a GET request when any new downloads have completed",
-    )
-    parser.add_argument(
-        "-j",
-        "--concurrency",
-        type=int,
-        default=1,
-        help="Number of concurrent downloads (default: 1)",
-    )
-    parser.add_argument(
-        "--max-retries",
-        type=int,
-        default=3,
-        help="Maximum number of retries for a download (default: 3)",
-    )
-    parser.add_argument(
-        "--retry-wait",
-        type=int,
-        default=5,
-        help="Number of seconds to wait between retries (default: 5)",
-    )
+    parser.add_argument('-v', '--version', action='store_true',
+        help='Displays the bandcampsync version and exits')
+    parser.add_argument('-c', '--cookies', required=True,
+        help='Path to the cookies file')
+    parser.add_argument('-d', '--directory', required=True,
+        help='Path to the directory to download media to')
+    parser.add_argument('-I', '--ignore-file', default='',
+        help='Path to the ignore file')
+    parser.add_argument('-i', '--ignore', default='',
+        help='A space-delimited list of patterns matching artists to bypass')
+    parser.add_argument('-f', '--format', default='flac',
+        help='Media format to download, defaults to "flac"')
+    parser.add_argument('-t', '--temp-dir', default='',
+        help='Path to use for temporary downloads')
+    parser.add_argument('-n', '--notify-url', default='',
+        help='URL to notify with a GET request when any new downloads have completed')
+    parser.add_argument('-j', '--concurrency', type=int, default=1,
+        help='Number of concurrent downloads (default: 1)')
+    parser.add_argument('--max-retries', type=int, default=3,
+        help='Maximum number of retries for a download (default: 3)')
+    parser.add_argument('--retry-wait', type=int, default=5,
+        help='Number of seconds to wait between retries (default: 5)')
+    parser.add_argument('--skip-filesystem', action='store_true',
+        help='Only use ignore-file for to determine downloaded items')
+    parser.add_argument('--sync-ignore-file', action='store_true',
+        help='Add already downloaded items to ignore-file')
     args = parser.parse_args()
     if args.version:
-        print(f"BandcampSync version: {version}", file=sys.stdout)
+        print(f'BandcampSync version: {version}', file=sys.stdout)
         sys.exit(0)
     cookies_path = Path(args.cookies).resolve()
     ign_file_path = Path(args.ignore_file).resolve() if args.ignore_file else None
     dir_path = Path(args.directory).resolve()
     ign_patterns = args.ignore
-    skip_filesystem = args.no_filesystem
+    skip_filesystem = args.skip_filesystem
+    sync_ignore_file = args.sync_ignore_file
     media_format = args.format
     if not cookies_path.is_file():
-        raise ValueError(f"Cookies file does not exist: {cookies_path}")
+        raise ValueError(f'Cookies file does not exist: {cookies_path}')
     if not dir_path.is_dir():
-        raise ValueError(f"Directory does not exist: {dir_path}")
+        raise ValueError(f'Directory does not exist: {dir_path}')
     if args.ignore:
         patterns = args.ignore
-        log.warning(f"BandcampSync is bypassing: {patterns}")
+        log.warning(f'BandcampSync is bypassing: {patterns}')
     if args.temp_dir:
         temp_dir = Path(args.temp_dir).resolve()
         if not temp_dir.is_dir():
-            raise ValueError(f"Temporary directory does not exist: {temp_dir}")
+            raise ValueError(f'Temporary directory does not exist: {temp_dir}')
     else:
         temp_dir = None
     if args.notify_url:
         notify_url = args.notify_url
-        log.info(f"BandcampSync will notify: {notify_url}")
+        log.info(f'BandcampSync will notify: {notify_url}')
     else:
         notify_url = None
     concurrency = args.concurrency
     max_retries = args.max_retries
     retry_wait = args.retry_wait
     if concurrency > 1:
-        log.info(f"BandcampSync will use {concurrency} concurrent downloads")
-    log.info(f"BandcampSync v{version} starting")
-    with open(cookies_path, "rt") as f:
+        log.info(f'BandcampSync will use {concurrency} concurrent downloads')
+    log.info(f'BandcampSync v{version} starting')
+    with open(cookies_path, 'rt') as f:
         cookies = f.read().strip()
-    log.info(f'Loaded cookies from "{cookies_path}"')
+    log.info(f'Loaded cookies from '{cookies_path}'')
     do_sync(
         cookies,
         dir_path,
@@ -128,5 +91,6 @@ if __name__ == "__main__":
         max_retries,
         retry_wait,
         skip_filesystem,
+        sync_ignore_file
     )
-    log.info(f"Done")
+    log.info(f'Done')

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     dir_path = Path(args.directory).resolve()
     ign_patterns = args.ignore
     media_format = args.format
-    skip_filesystem = args.skip_filesystem
+    skip_item_index = args.skip_item_index
     sync_ignore_file = args.sync_ignore_file
     if not cookies_path.is_file():
         raise ValueError(f'Cookies file does not exist: {cookies_path}')
@@ -90,7 +90,7 @@ if __name__ == '__main__':
         concurrency,
         max_retries,
         retry_wait,
-        skip_filesystem,
+        skip_item_index,
         sync_ignore_file
     )
     log.info(f'Done')

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -7,71 +7,126 @@ from pathlib import Path
 from bandcampsync import version, logger, do_sync
 
 
-log = logger.get_logger('run')
+log = logger.get_logger("run")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        prog='bandcampsync',
-        description='Syncs media purcahsed on bandcamp.com with a local directory',
+        prog="bandcampsync",
+        description="Syncs media purcahsed on bandcamp.com with a local directory",
     )
-    parser.add_argument('-v', '--version', action='store_true',
-        help='Displays the bandcampsync version and exits')
-    parser.add_argument('-c', '--cookies', required=True,
-        help='Path to the cookies file')
-    parser.add_argument('-d', '--directory', required=True,
-        help='Path to the directory to download media to')
-    parser.add_argument('-I', '--ignore-file', default='',
-        help='Path to the ignore file')
-    parser.add_argument('-i', '--ignore', default='',
-        help='A space-delimited list of patterns matching artists to bypass')
-    parser.add_argument('-f', '--format', default='flac',
-        help='Media format to download, defaults to "flac"')
-    parser.add_argument('-t', '--temp-dir', default='',
-        help='Path to use for temporary downloads')
-    parser.add_argument('-n', '--notify-url', default='',
-        help='URL to notify with a GET request when any new downloads have completed')
-    parser.add_argument('-j', '--concurrency', type=int, default=1,
-        help='Number of concurrent downloads (default: 1)')
-    parser.add_argument('--max-retries', type=int, default=3,
-        help='Maximum number of retries for a download (default: 3)')
-    parser.add_argument('--retry-wait', type=int, default=5,
-        help='Number of seconds to wait between retries (default: 5)')
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        help="Displays the bandcampsync version and exits",
+    )
+    parser.add_argument(
+        "-c", "--cookies", required=True, help="Path to the cookies file"
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        required=True,
+        help="Path to the directory to download media to",
+    )
+    parser.add_argument(
+        "-I", "--ignore-file", default="", help="Path to the ignore file"
+    )
+    parser.add_argument(
+        "-i",
+        "--ignore",
+        default="",
+        help="A space-delimited list of patterns matching artists to bypass",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        default="flac",
+        help='Media format to download, defaults to "flac"',
+    )
+    parser.add_argument(
+        "-x",
+        "--no-filesystem",
+        action="store_true",
+        help="Don't traverse filesystem; rely on database for already downloaded items",
+    )
+    parser.add_argument(
+        "-t", "--temp-dir", default="", help="Path to use for temporary downloads"
+    )
+    parser.add_argument(
+        "-n",
+        "--notify-url",
+        default="",
+        help="URL to notify with a GET request when any new downloads have completed",
+    )
+    parser.add_argument(
+        "-j",
+        "--concurrency",
+        type=int,
+        default=1,
+        help="Number of concurrent downloads (default: 1)",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=3,
+        help="Maximum number of retries for a download (default: 3)",
+    )
+    parser.add_argument(
+        "--retry-wait",
+        type=int,
+        default=5,
+        help="Number of seconds to wait between retries (default: 5)",
+    )
     args = parser.parse_args()
     if args.version:
-        print(f'BandcampSync version: {version}', file=sys.stdout)
+        print(f"BandcampSync version: {version}", file=sys.stdout)
         sys.exit(0)
     cookies_path = Path(args.cookies).resolve()
     ign_file_path = Path(args.ignore_file).resolve() if args.ignore_file else None
     dir_path = Path(args.directory).resolve()
     ign_patterns = args.ignore
+    skip_filesystem = args.no_filesystem
     media_format = args.format
     if not cookies_path.is_file():
-        raise ValueError(f'Cookies file does not exist: {cookies_path}')
+        raise ValueError(f"Cookies file does not exist: {cookies_path}")
     if not dir_path.is_dir():
-        raise ValueError(f'Directory does not exist: {dir_path}')
+        raise ValueError(f"Directory does not exist: {dir_path}")
     if args.ignore:
         patterns = args.ignore
-        log.warning(f'BandcampSync is bypassing: {patterns}')
+        log.warning(f"BandcampSync is bypassing: {patterns}")
     if args.temp_dir:
         temp_dir = Path(args.temp_dir).resolve()
         if not temp_dir.is_dir():
-            raise ValueError(f'Temporary directory does not exist: {temp_dir}')
+            raise ValueError(f"Temporary directory does not exist: {temp_dir}")
     else:
         temp_dir = None
     if args.notify_url:
         notify_url = args.notify_url
-        log.info(f'BandcampSync will notify: {notify_url}')
+        log.info(f"BandcampSync will notify: {notify_url}")
     else:
         notify_url = None
     concurrency = args.concurrency
     max_retries = args.max_retries
     retry_wait = args.retry_wait
     if concurrency > 1:
-        log.info(f'BandcampSync will use {concurrency} concurrent downloads')
-    log.info(f'BandcampSync v{version} starting')
-    with open(cookies_path, 'rt') as f:
+        log.info(f"BandcampSync will use {concurrency} concurrent downloads")
+    log.info(f"BandcampSync v{version} starting")
+    with open(cookies_path, "rt") as f:
         cookies = f.read().strip()
     log.info(f'Loaded cookies from "{cookies_path}"')
-    do_sync(cookies, dir_path, media_format, temp_dir, ign_file_path, ign_patterns, notify_url, concurrency, max_retries, retry_wait)
-    log.info(f'Done')
+    do_sync(
+        cookies,
+        dir_path,
+        media_format,
+        temp_dir,
+        ign_file_path,
+        ign_patterns,
+        notify_url,
+        concurrency,
+        max_retries,
+        retry_wait,
+        skip_filesystem,
+    )
+    log.info(f"Done")

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -37,8 +37,8 @@ if __name__ == '__main__':
         help='Maximum number of retries for a download (default: 3)')
     parser.add_argument('--retry-wait', type=int, default=5,
         help='Number of seconds to wait between retries (default: 5)')
-    parser.add_argument('--skip-filesystem', action='store_true',
-        help='Only use ignore-file for to determine downloaded items')
+    parser.add_argument('--skip-item-index', action='store_true',
+        help='Skip indexing downloaded items in the filesystem; only use ignore-file for to determining which items are downloaded already')
     parser.add_argument('--sync-ignore-file', action='store_true',
         help='Add already downloaded items to ignore-file')
     args = parser.parse_args()

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -38,9 +38,9 @@ if __name__ == '__main__':
     parser.add_argument('--retry-wait', type=int, default=5,
         help='Number of seconds to wait between retries (default: 5)')
     parser.add_argument('--skip-item-index', action='store_true',
-        help='Skip indexing downloaded items in the filesystem; only use ignore-file for to determining which items are downloaded already')
+        help='Skip indexing downloaded items in the filesystem; only use ignore file for to determining which items are downloaded already')
     parser.add_argument('--sync-ignore-file', action='store_true',
-        help='Add already downloaded items found in filesystem to ignore-file')
+        help='Add already downloaded items found in filesystem to ignore file')
     args = parser.parse_args()
     if args.version:
         print(f'BandcampSync version: {version}', file=sys.stdout)
@@ -52,6 +52,12 @@ if __name__ == '__main__':
     media_format = args.format
     skip_item_index = args.skip_item_index
     sync_ignore_file = args.sync_ignore_file
+
+    if skip_item_index and not ign_file_path:
+        raise ValueError("--skip-item-index was passed, but no ignore file path was passed. --skip-item-index requires an ignore file path (--ignore-file/-I)")
+    if sync_ignore_file and not ign_file_path:
+        raise ValueError("--sync-ignore-file was passed, but no ignore file path was passed. --sync-ignore-file requires an ignore file path (--ignore-file/-I)")
+
     if not cookies_path.is_file():
         raise ValueError(f'Cookies file does not exist: {cookies_path}')
     if not dir_path.is_dir():

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     parser.add_argument('--skip-item-index', action='store_true',
         help='Skip indexing downloaded items in the filesystem; only use ignore-file for to determining which items are downloaded already')
     parser.add_argument('--sync-ignore-file', action='store_true',
-        help='Add already downloaded items to ignore-file')
+        help='Add already downloaded items found in filesystem to ignore-file')
     args = parser.parse_args()
     if args.version:
         print(f'BandcampSync version: {version}', file=sys.stdout)

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -49,9 +49,9 @@ if __name__ == '__main__':
     ign_file_path = Path(args.ignore_file).resolve() if args.ignore_file else None
     dir_path = Path(args.directory).resolve()
     ign_patterns = args.ignore
+    media_format = args.format
     skip_filesystem = args.skip_filesystem
     sync_ignore_file = args.sync_ignore_file
-    media_format = args.format
     if not cookies_path.is_file():
         raise ValueError(f'Cookies file does not exist: {cookies_path}')
     if not dir_path.is_dir():
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     log.info(f'BandcampSync v{version} starting')
     with open(cookies_path, 'rt') as f:
         cookies = f.read().strip()
-    log.info(f'Loaded cookies from '{cookies_path}'')
+    log.info(f'Loaded cookies from "{cookies_path}"')
     do_sync(
         cookies,
         dir_path,

--- a/bin/bandcampsync-service
+++ b/bin/bandcampsync-service
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     max_retries_env = os.getenv('MAX_RETRIES', '3')
     retry_wait_env = os.getenv('RETRY_WAIT', '5')
     concurrency_env = os.getenv('CONCURRENCY', '1')
+    skip_item_index_env = os.getenv('SKIP_ITEM_INDEX', False)
     try:
         max_retries = int(max_retries_env)
     except (ValueError, TypeError):
@@ -51,9 +52,17 @@ if __name__ == '__main__':
         concurrency = int(concurrency_env)
     except (ValueError, TypeError):
         concurrency = 1
+    try:
+        skip_item_index = bool(skip_item_index_env)
+    except (ValueError, TypeError):
+        skip_item_index = False
+
+
     cookies_path = Path(cookies_path_env).resolve()
     ign_file_path = Path(ign_file_path_env).resolve()
     dir_path = Path(dir_path_env).resolve()
+    if skip_item_index and not ign_file_path:
+        raise ValueError("--skip-item-index was passed, but no ignore file path was passed. --skip-item-index requires an ignore file path (--ignore-file/-I)")
     if not cookies_path.is_file():
         raise ValueError(f'Cookies file does not exist: {cookies_path}')
     if not dir_path.is_dir():
@@ -95,7 +104,7 @@ if __name__ == '__main__':
     try:
         while not catch_shutdown.shutdown:
             log.info(f'Starting synchronisation')
-            do_sync(cookies, dir_path, media_format_env, temp_dir, ign_file_path, ign_patterns, notify_url, concurrency, max_retries, retry_wait)
+            do_sync(cookies, dir_path, media_format_env, temp_dir, ign_file_path, ign_patterns, notify_url, concurrency, max_retries, retry_wait, skip_item_index)
             random_delay = randrange(0, 3600)
             time_now = datetime.now(tz).replace(microsecond=0)
             time_tomorrow = time_now + timedelta(days=1)


### PR DESCRIPTION
- `--skip-item-index` uses the ignore.txt file as the source of truth for what's already downloaded, rather than looking through the filesystem. On my machine (~85 items in my Bandcamp collection, stored on a shared drive mounted via SMB), this option speeds up a single run from ~29.9s to ~0.9s.
- `--sync-ignore-file` appends any downloaded items found in the filesystem to the ignore.txt file - just a slightly more convenient way to do this.

This PR doesn't alter any existing functionality; new code is only touched if you pass one of the new flags.