### PR TITLE
Handle invalid bandcamp_item_id files and make ID writes atomic

### DIFF
--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -1,3 +1,5 @@
+import os
+from tempfile import NamedTemporaryFile
 from unicodedata import normalize
 from bandcampsync.bandcamp import BandcampItem
 from .logger import get_logger
@@ -114,8 +116,29 @@ class LocalMedia:
         return local_path / self._clean_path(file_name)
 
     def write_bandcamp_id(self, item, dirpath):
+        try:
+            item_id = int(item.item_id)
+        except Exception as e:
+            raise ValueError(
+                f'Failed to cast item ID for "{dirpath}" "{item.item_id}" as an int: {e}'
+            ) from e
+
         outfile = dirpath / self.ITEM_INDEX_FILENAME
-        log.info(f"Writing bandcamp item id:{item.item_id} to: {outfile}")
-        with open(outfile, "wt") as f:
-            f.write(f"{item.item_id}\n")
+        log.info(f"Writing bandcamp item id:{item_id} to: {outfile}")
+
+        tmp_outfile = None
+        try:
+            with NamedTemporaryFile(
+                mode="wt",
+                delete=False,
+                dir=dirpath,
+                encoding="utf-8",
+            ) as f:
+                tmp_outfile = f.name
+                f.write(f"{item_id}\n")
+            os.replace(tmp_outfile, outfile)
+        except Exception:
+            if tmp_outfile and os.path.exists(tmp_outfile):
+                os.remove(tmp_outfile)
+            raise
         return True

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -56,7 +56,14 @@ class LocalMedia:
                     if child2.is_dir():
                         for child3 in child2.iterdir():
                             if child3.name == self.ITEM_INDEX_FILENAME:
-                                item_id = self.read_item_id(child3)
+                                self.item_names.add((child2.parent.name, child2.name))
+                                try:
+                                    item_id = self.read_item_id(child3)
+                                except ValueError as e:
+                                    log.warning(
+                                        f"Skipping invalid item index file {child3}: {e}"
+                                    )
+                                    continue
                                 if self.sync_ignore_file:
                                     item = BandcampItem(
                                         {
@@ -68,7 +75,6 @@ class LocalMedia:
                                     if not self.ignores.is_ignored(item):
                                         self.ignores.add(item)
                                 self.media[item_id] = child2
-                                self.item_names.add((child2.parent.name, child2.name))
                                 log.info(
                                     f"Detected locally downloaded media: {item_id} = {child2}"
                                 )

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -191,7 +191,13 @@ class Syncer:
                             # on the items downloaded in the current session.
                             self.ignores.add(item)
                         else:
-                            self.local_media.write_bandcamp_id(item, local_path)
+                            try:
+                                self.local_media.write_bandcamp_id(item, local_path)
+                            except (OSError, ValueError) as e:
+                                log.error(
+                                    f'Failed to write bandcamp item id for "{item.band_name} / {item.item_title}" '
+                                    f'(id:{item.item_id}) to "{local_path}": {e}'
+                                )
 
                         self.new_items_downloaded = True
                         return True

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,13 +1,16 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from bandcampsync.media import LocalMedia
 
 
-def _create_local_media(tmp_path):
+def _create_local_media(tmp_path, skip_item_index=False):
+    ignore_ids = {1} if skip_item_index else set()
     return LocalMedia(
         media_dir=tmp_path,
-        ignores=Mock(ids=set()),
-        skip_item_index=False,
+        ignores=Mock(ids=ignore_ids),
+        skip_item_index=skip_item_index,
         sync_ignore_file=False,
     )
 
@@ -51,3 +54,36 @@ def test_index_loads_valid_item_id_file(tmp_path):
 
     assert local_media.media == {123: item_dir}
     assert ("Band", "Album") in local_media.item_names
+
+
+def test_write_bandcamp_id_skips_empty_item_id(tmp_path):
+    item_dir = tmp_path / "Band" / "Album"
+    item_dir.mkdir(parents=True)
+    local_media = _create_local_media(tmp_path, skip_item_index=True)
+
+    with patch("bandcampsync.media.NamedTemporaryFile") as mock_tempfile:
+        with pytest.raises(ValueError):
+            local_media.write_bandcamp_id(Mock(item_id=""), item_dir)
+
+    assert not (item_dir / LocalMedia.ITEM_INDEX_FILENAME).exists()
+    mock_tempfile.assert_not_called()
+
+
+def test_write_bandcamp_id_preserves_existing_file_on_write_failure(tmp_path):
+    item_dir = tmp_path / "Band" / "Album"
+    item_dir.mkdir(parents=True)
+    outfile = item_dir / LocalMedia.ITEM_INDEX_FILENAME
+    outfile.write_text("123\n")
+    local_media = _create_local_media(tmp_path, skip_item_index=True)
+
+    mock_tempfile = Mock()
+    mock_tempfile.__enter__ = Mock(return_value=Mock(name="/tmp/bad-temp"))
+    mock_tempfile.__exit__ = Mock(return_value=False)
+    mock_tempfile.__enter__.return_value.name = str(item_dir / "tmp-id-file")
+    mock_tempfile.__enter__.return_value.write.side_effect = OSError("disk full")
+
+    with patch("bandcampsync.media.NamedTemporaryFile", return_value=mock_tempfile):
+        with pytest.raises(OSError):
+            local_media.write_bandcamp_id(Mock(item_id=456), item_dir)
+
+    assert outfile.read_text() == "123\n"

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock, patch
+
+from bandcampsync.media import LocalMedia
+
+
+def _create_local_media(tmp_path):
+    return LocalMedia(
+        media_dir=tmp_path,
+        ignores=Mock(ids=set()),
+        skip_item_index=False,
+        sync_ignore_file=False,
+    )
+
+
+def test_index_skips_empty_item_id_file(tmp_path):
+    item_dir = tmp_path / "Band" / "Album"
+    item_dir.mkdir(parents=True)
+    (item_dir / LocalMedia.ITEM_INDEX_FILENAME).write_text("")
+
+    with patch("bandcampsync.media.log.warning") as mock_warning:
+        local_media = _create_local_media(tmp_path)
+
+    assert local_media.media == {}
+    assert ("Band", "Album") in local_media.item_names
+    assert local_media.is_locally_downloaded(Mock(item_id=123), item_dir)
+    mock_warning.assert_called_once()
+    assert "Skipping invalid item index file" in mock_warning.call_args[0][0]
+
+
+def test_index_skips_non_numeric_item_id_file(tmp_path):
+    item_dir = tmp_path / "Band" / "Album"
+    item_dir.mkdir(parents=True)
+    (item_dir / LocalMedia.ITEM_INDEX_FILENAME).write_text("not-an-int\n")
+
+    with patch("bandcampsync.media.log.warning") as mock_warning:
+        local_media = _create_local_media(tmp_path)
+
+    assert local_media.media == {}
+    assert ("Band", "Album") in local_media.item_names
+    assert local_media.is_locally_downloaded(Mock(item_id=123), item_dir)
+    mock_warning.assert_called_once()
+    assert "Skipping invalid item index file" in mock_warning.call_args[0][0]
+
+
+def test_index_loads_valid_item_id_file(tmp_path):
+    item_dir = tmp_path / "Band" / "Album"
+    item_dir.mkdir(parents=True)
+    (item_dir / LocalMedia.ITEM_INDEX_FILENAME).write_text("123\n")
+
+    local_media = _create_local_media(tmp_path)
+
+    assert local_media.media == {123: item_dir}
+    assert ("Band", "Album") in local_media.item_names

--- a/tests/test_sync_item.py
+++ b/tests/test_sync_item.py
@@ -164,3 +164,36 @@ def test_sync_item_track_success(syncer, mock_bandcamp, tmp_path):
         # Check if copy_file was called with expected destination name (using slug)
         args, _ = mock_copy.call_args
         assert "track-slug.flac" in str(args[1])
+
+
+def test_sync_item_continues_if_writing_item_id_fails(syncer, mock_bandcamp):
+    item = Mock(
+        is_preorder=False,
+        band_name="Artist",
+        item_title="TrackTitle",
+        item_id="",
+        item_type="track",
+        url_hints={"slug": "track-slug"},
+        download_url="http://example.com/download",
+    )
+
+    mock_bandcamp.get_download_file_url.return_value = "http://example.com/file"
+    mock_bandcamp.check_download_stat.return_value = "http://example.com/file_ok"
+
+    with (
+        patch("bandcampsync.sync.download_file"),
+        patch("bandcampsync.sync.is_zip_file", return_value=False),
+        patch("bandcampsync.sync.copy_file"),
+        patch.object(
+            syncer.local_media,
+            "write_bandcamp_id",
+            side_effect=ValueError("bad item id"),
+        ) as mock_write_id,
+        patch("bandcampsync.sync.log.error") as mock_log_error,
+    ):
+        result = syncer.sync_item(item)
+
+        assert result is True
+        assert syncer.new_items_downloaded is True
+        mock_write_id.assert_called_once()
+        assert "Failed to write bandcamp item id" in mock_log_error.call_args[0][0]


### PR DESCRIPTION
https://github.com/meeb/bandcampsync/issues/61

Handle invalid `bandcamp_item_id.txt` files gracefully and make item ID writes more robust.

This changes the local media indexer so empty or non-numeric `bandcamp_item_id.txt` files no longer abort startup. Invalid files are skipped with a warning, while the enclosing album directory is still tracked by name so already-downloaded media is not immediately re-downloaded.

It also hardens `bandcamp_item_id.txt` writes by validating the item ID before writing and replacing the file atomically from a temporary file. If writing the ID file fails after media download, sync now logs the error and continues instead of terminating the whole run.

Tests added.