### PR TITLE
Add encoding param to sync_item() and auto_run param to Syncer.__init__()

### DIFF
--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -38,6 +38,7 @@ class Syncer:
         retry_wait=5,
         skip_item_index=False,
         sync_ignore_file=False,
+        auto_run=True,
     ):
         self.ignores = Ignores(ign_file_path=ign_file_path, ign_patterns=ign_patterns)
         self.sync_ignore_file = sync_ignore_file
@@ -62,18 +63,21 @@ class Syncer:
         self.bandcamp.verify_authentication()
         self.bandcamp.load_purchases()
 
-        asyncio.run(self.sync_items())
-        self.notify()
+        if auto_run:
+            asyncio.run(self.sync_items())
+            self.notify()
 
     def sync_item(
         self,
         item,
+        encoding=None,
     ) -> bool:
         """Syncs a single item (purchase).
 
         Returns:
             bool: indicating new media was downloaded
         """
+        media_format = encoding or self.media_format
 
         local_path = self.local_media.get_path_for_purchase(item)
 
@@ -102,13 +106,13 @@ class Syncer:
         else:
             log.info(
                 f'New media item, will download: "{item.band_name} / {item.item_title}" '
-                f'(id:{item.item_id}) in "{self.media_format}"'
+                f'(id:{item.item_id}) in "{media_format}"'
             )
 
             for attempt in range(self.max_retries):
                 try:
                     initial_download_url = self.bandcamp.get_download_file_url(
-                        item, encoding=self.media_format
+                        item, encoding=media_format
                     )
                     download_file_url = self.bandcamp.check_download_stat(
                         item, initial_download_url
@@ -156,7 +160,7 @@ class Syncer:
                             if item.url_hints and isinstance(item.url_hints, dict):
                                 slug = item.url_hints.get("slug", item.item_title)
                             format_extension = self.local_media.clean_format(
-                                self.media_format
+                                media_format
                             )
                             try:
                                 local_path.mkdir(parents=True, exist_ok=True)

--- a/tests/test_sync_item.py
+++ b/tests/test_sync_item.py
@@ -166,6 +166,42 @@ def test_sync_item_track_success(syncer, mock_bandcamp, tmp_path):
         assert "track-slug.flac" in str(args[1])
 
 
+def test_sync_item_uses_encoding_parameter(syncer, mock_bandcamp):
+    """sync_item uses the encoding kwarg, not self.media_format, when provided."""
+    item = Mock(
+        is_preorder=False,
+        band_name="Artist",
+        item_title="Album",
+        item_id=1,
+        item_type="album",
+        folder_suffix="",
+    )
+    mock_bandcamp.get_download_file_url.side_effect = BandcampError("stop after first call")
+
+    syncer.sync_item(item, encoding="mp3-320")
+
+    _, kwargs = mock_bandcamp.get_download_file_url.call_args
+    assert kwargs["encoding"] == "mp3-320"
+
+
+def test_sync_item_falls_back_to_media_format_when_no_encoding(syncer, mock_bandcamp):
+    """When encoding=None, self.media_format is used as the encoding."""
+    item = Mock(
+        is_preorder=False,
+        band_name="Artist",
+        item_title="Album",
+        item_id=1,
+        item_type="album",
+        folder_suffix="",
+    )
+    mock_bandcamp.get_download_file_url.side_effect = BandcampError("stop after first call")
+
+    syncer.sync_item(item)  # no encoding kwarg
+
+    _, kwargs = mock_bandcamp.get_download_file_url.call_args
+    assert kwargs["encoding"] == syncer.media_format  # "flac" from fixture
+
+
 def test_sync_item_continues_if_writing_item_id_fails(syncer, mock_bandcamp):
     item = Mock(
         is_preorder=False,


### PR DESCRIPTION
## Summary

Two small additions to support external consumers of `Syncer` that need finer-grained control over the sync process:

- **`auto_run=True` on `Syncer.__init__()`**: wraps the existing `asyncio.run()` and `self.notify()` calls in `if auto_run:`. Passing `auto_run=False` lets callers instantiate a `Syncer` to inspect purchases before deciding what to sync, without triggering a full sync immediately.

- **`encoding=None` on `sync_item()`**: uses `encoding or self.media_format` throughout the method instead of `self.media_format` directly. This allows per-item format overrides and avoids a potential race condition when concurrent threads call `sync_item()` with different formats.

Both changes are backwards-compatible. Default behavior is unchanged.

## Tests

Two new tests in `tests/test_sync_item.py`:

- `test_sync_item_uses_encoding_parameter` -- verifies the `encoding` kwarg is passed through to the download URL call
- `test_sync_item_falls_back_to_media_format_when_no_encoding` -- verifies default behavior is preserved