### PR TITLE
Strip |, < and > from album directory names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,21 @@ cookies.txt
 docker-config/
 docker-downloads/
 /bcs
+
+# Exported browser cookies - session credentials, never commit
+*cookies*.txt
+*cookies*.json
+
+# Google OAuth client secret and token for the Gmail integration
+client_secret*.json
+token.json
+
+# Real label configuration contains an email address and postcode
+labels.yaml
+bandcampfree-state.json
+
+# Local run output
+report_stdout.txt
+report_stderr.txt
+sync_stdout.txt
+sync_stderr.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+BandcampSync is a Python CLI tool (and Docker service) that synchronizes music purchased on Bandcamp with a local directory. It authenticates via exported session cookies, indexes local media and remote purchases, then downloads missing items (defaulting to FLAC format).
+
+## Common Commands
+
+```bash
+make test          # Run all tests (uv run python -m pytest -v)
+make lint          # Lint with ruff (uvx ruff check)
+make format        # Format with ruff (uvx ruff format)
+make build         # Build package (uv build)
+make container     # Build Docker image
+
+# Run a single test
+uv run python -m pytest tests/test_syncer.py::test_skips_preorder -v
+```
+
+Package manager is `uv`. Dev dependencies (pytest, pytest-mock, ruff) are in `pyproject.toml` under `[dependency-groups] dev`.
+
+## Architecture
+
+**Entry points:**
+- `bin/bandcampsync` — CLI script that parses args, reads cookies, calls `do_sync()`
+- `bin/bandcampsync-service` — Docker service runner (scheduled daily sync)
+- `bandcampsync/__init__.py` — Public API exposing `do_sync()` and `Syncer`
+
+**Core modules:**
+- `sync.py` — `Syncer` class orchestrates the entire sync flow in `__init__`: indexes local media, authenticates to Bandcamp, loads purchases, syncs items (with async concurrency support), then sends notifications. All work happens during construction.
+- `bandcamp.py` — `Bandcamp` class handles HTTP sessions (curl-cffi with Chrome impersonation), cookie parsing (SimpleCookie and Netscape formats), purchase loading via HTML scraping (BeautifulSoup), and download URL resolution. `BandcampItem` is the data class for purchases.
+- `media.py` — `LocalMedia` indexes the local filesystem (`Artist/Album/` structure), tracks downloads via `bandcamp_item_id.txt` files, and handles path sanitization.
+- `download.py` — Streaming file download, ZIP extraction, file move/copy operations. Custom exceptions: `DownloadBadStatusCode`, `DownloadInvalidContentType`, `DownloadExpired`.
+- `ignores.py` — `Ignores` manages an ignore file (alternative to `bandcamp_item_id.txt`) and substring-based ignore patterns.
+- `notify.py` — `NotifyURL` sends HTTP GET/POST notifications (e.g., to trigger Plex/Jellyfin library refresh).
+
+**Sync flow:** Authenticate → index local media → load all Bandcamp purchases → for each purchase: check ignored/preorder/already-downloaded → download archive → extract/copy to `Artist/Album/` → write tracking file or update ignore file → optionally notify external service.
+
+**Deduplication:** Two strategies — `bandcamp_item_id.txt` files in each album directory (default), or a centralized ignore file (`--ignore-file`). The `--skip-item-index` flag skips filesystem traversal entirely, relying solely on the ignore file.
+
+## Testing
+
+Tests are in `tests/` using pytest with pytest-mock. Test fixtures (JSON payloads) are in `tests/data/`. Tests mock HTTP responses and verify sync logic, Bandcamp API parsing, and download behavior.
+
+## Key Details
+
+- Python 3.10+ required (`.python-version` specifies 3.10)
+- Only two runtime dependencies: `beautifulsoup4` and `curl-cffi`
+- `Syncer.__init__` performs all work (sync + notify) — it's not a two-step init-then-run pattern
+- Concurrency uses `asyncio.run()` with `run_in_executor` for blocking I/O

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,33 @@ Package manager is `uv`. Dev dependencies (pytest, pytest-mock, ruff) are in `py
 
 Tests are in `tests/` using pytest with pytest-mock. Test fixtures (JSON payloads) are in `tests/data/`. Tests mock HTTP responses and verify sync logic, Bandcamp API parsing, and download behavior.
 
+## Sync Operations (Erik's Setup)
+
+When asked to sync Bandcamp purchases, use these settings:
+
+```bash
+# Report mode (check what's new without downloading)
+uv run python bin/bandcampsync \
+  -c "bandcamp.com_cookies (1).txt" \
+  -d "N:/Bandcamp (FLAC)" \
+  -I "N:/Bandcamp (FLAC)/.bandcamp-ignore" \
+  --dir-format zip --report
+
+# Full sync (download missing items)
+uv run python bin/bandcampsync \
+  -c "bandcamp.com_cookies (1).txt" \
+  -d "N:/Bandcamp (FLAC)" \
+  -I "N:/Bandcamp (FLAC)/.bandcamp-ignore" \
+  --dir-format zip -f flac -j 3
+```
+
+- **Cookies file:** `bandcamp.com_cookies (1).txt` (exported from browser)
+- **Music directory:** `N:\Bandcamp (FLAC)`
+- **Directory format:** `zip` — "Artist - Album" for regular artists, label subdirectory for compilations/label releases
+- **Ignore file:** `N:\Bandcamp (FLAC)\.bandcamp-ignore` — contains IDs of non-downloadable pages (e.g. submission forms, placeholder pages)
+- **Format:** FLAC
+- **Concurrency:** 3
+
 ## Key Details
 
 - Python 3.10+ required (`.python-version` specifies 3.10)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,31 @@ uv run python bin/bandcampfree -C labels.yaml --limit 5 --max-gb 10
   mtime, which updates on download and would hide older un-fetched releases. Wanted-but-not-
   downloaded albums are kept in `state.pending` and reconsidered regardless of cutoff.
 
+**Adding new labels (the recurring task):** Erik hands over batches of ~10-12 label names.
+Vet each with `C:/Users/erik/.bandcampfree/probe_labels.py "Name" ...` (resolves subdomain
+from the search API's `item_url_root`, band_id, catalogue size, VA count, a newest-~14
+sample, and the FULL comp-ish title list), show him counts + samples to catch wrong pages,
+then add with a per-label comment and scan with `--report -l "Name"`. Full operational
+detail (with the gotchas) is in the project memory `adding-new-labels-workflow.md`.
+
+**Match-rule selection** (rules live in `labelconfig.py`; all ANDed; empty = take all free):
+- `min_track_artists: N, min_tracks: M` — multi-artist comps whose tracks carry real
+  per-track artists (most comps). Lower `min_tracks` to ~6 for short comps.
+- `track_artists_vary: true` — small comps/splits (2-4 distinct artists) that `min_track_artists: 5` would reject.
+- `various_artists: true` — comps credited to "Various Artists"; **prefilters** on cheap
+  `band_details`, so essential for large catalogues.
+- `title_regex: "(?i)..."` — label-credited comp *series* (tracks show `distinct == 1`, so
+  artist-count rules fail): samplers, tributes, "compilation". Also prefilters.
+- empty `{}` — every release is a comp, or comps are label-credited (distinct=1) and can't
+  be told apart by rule.
+
+**Two more verified gotchas:**
+- "free download" / "(Free Sampler)" in a *title* does NOT imply `price == 0` — several
+  labels title samplers that way but charge for them. Gate on price, never the title.
+- Same-titled comp series (e.g. Wiretap's ~15 identical "ATTENTION!" titles) collide in the
+  `Artist - Title` folder scheme and overwrite each other on extract — never bulk-download
+  them; watch-for-new via a high-water mark instead (see `wiretap-same-title-collision.md`).
+
 ## Key Details
 
 - Python 3.10+ required (`.python-version` specifies 3.10)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,32 @@ uv run python bin/bandcampsync \
 - **Manually downloaded items:** The report auto-detects them by name/ID match; no manual tracking needed before syncing.
 - **Report runtime:** ~5 minutes (indexes all local media first). Always run report before full sync.
 
+**The report is lenient, the sync is strict — `Missing: N` UNDERCOUNTS what a sync will fetch.**
+In zip mode `report.classify_item` accepts three ways of being "downloaded" (id file/ignore
+file, then `get_expected_name_for_zip` against `item_names`, then `find_zip_item_by_title`),
+but `sync.sync_item` only accepts the first. Anything matched by name alone is reported as
+downloaded and then re-downloaded. Verified 2026-08-03: report said `Missing: 1`, the sync
+that followed a minute later fetched 3.
+The two extras landed as near-duplicate folders because the on-disk name differed from what
+zip mode derives — `Opium Warlock and Green Hog Band - …` vs `Green Hog Band and Opium
+Warlock - …` (artist order), and a label-subdir copy `Stargazing at Blank Skies\… Bring the
+Noise` vs a new root-level `… Bring The Noise` (case). Self-limiting: the fetch writes the id
+to the ignore file, so each such item duplicates at most once.
+
+**Scheduled: task "BandcampSync Weekly Collection"** runs `N:\bandcampsync\weekly-sync.ps1`
+daily at 04:45 — after the 03:15 free sweep, and it skips if any bandcampsync *or*
+bandcampfree process is running (they share the media root and the NAS link). Same
+daily-trigger/6.5-day-due/`logs\.last-success` shape as the free sweep, so an unmounted N:
+retries tomorrow. Unlike the free sweep it **downloads** (items are already paid for; no
+approval step). Quiet weeks write only a one-line `logs\sync.log` entry; a dated file in
+`N:\bandcampsync\logs\` means something happened. `-ReportOnly` and `-Force` are for testing —
+`-ReportOnly` deliberately writes no success stamp.
+**`Start-Process -ArgumentList` does not quote**, so `N:\Bandcamp (FLAC)` splits into three
+arguments and argparse dies with `unrecognized arguments: (FLAC)`. The script's `Format-Arg`
+handles it; the free sweep never hit this because none of its paths contain spaces.
+Stale cookies are the expected failure mode — the script greps the tail for
+`cookies|identity|authenticat` and says so in the log.
+
 ## Free / Pay-What-You-Want Label Downloader (`bandcampfree`)
 
 A second, independent tool that watches record label pages for free albums. It cannot reuse

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Package manager is `uv`. Dev dependencies (pytest, pytest-mock, ruff) are in `py
 **Entry points:**
 - `bin/bandcampsync` — CLI script that parses args, reads cookies, calls `do_sync()`
 - `bin/bandcampsync-service` — Docker service runner (scheduled daily sync)
+- `bin/bandcampfree` — CLI for the free/pay-what-you-want label watcher (see below)
 - `bandcampsync/__init__.py` — Public API exposing `do_sync()` and `Syncer`
 
 **Core modules:**
@@ -70,6 +71,51 @@ uv run python bin/bandcampsync \
 - **Ignore file:** `N:\Bandcamp (FLAC)\.bandcamp-ignore` — contains IDs of non-downloadable pages (e.g. submission forms, placeholder pages)
 - **Format:** FLAC
 - **Concurrency:** 3
+- **Manually downloaded items:** The report auto-detects them by name/ID match; no manual tracking needed before syncing.
+- **Report runtime:** ~5 minutes (indexes all local media first). Always run report before full sync.
+
+## Free / Pay-What-You-Want Label Downloader (`bandcampfree`)
+
+A second, independent tool that watches record label pages for free albums. It cannot reuse
+the collection sync: **claiming an album at $0 does not add it to the Bandcamp collection**
+(Bandcamp requires ~€0.50 minimum), so `load_purchases()` never sees these items.
+
+**Modules:** `labels.py` (mobile API client, `FreeAlbum`, classification), `labelconfig.py`
+(YAML + match predicates), `freesync.py` (scan orchestration, `FreeState`, `LabelIndex`,
+report), `freedownload.py` (acquisition + download), `gmail.py` (emailed link retrieval).
+
+```bash
+# Report what would be downloaded (no side effects)
+uv run python bin/bandcampfree -C labels.yaml --report
+
+# One-time Gmail authorisation
+uv run python bin/bandcampfree --gmail-auth
+
+# Download, bounded
+uv run python bin/bandcampfree -C labels.yaml --limit 5 --max-gb 10
+```
+
+**Non-obvious details, all verified against live Bandcamp:**
+
+- Discovery uses the undocumented mobile API (`bandcamp.com/api/mobile/24/band_details` and
+  `tralbum_details`). No HTML scraping — it returns prices, per-track artists and release
+  dates as clean JSON. Scraping `/music` requires unioning static `<li>` elements with a
+  disjoint `data-client-items` blob, and `?page=2` is a no-op.
+- **Free detection:** `price == 0.0 and not is_set_price`. Do **not** gate on
+  `free_download` — that maps to `download_pref == 1` and is False for ordinary
+  name-your-price-at-$0 albums.
+- **`/email_download` requires `country` and `postcode`.** Omitting them returns
+  `"Sorry, this item is no longer available for free."`, which means bad location data, not
+  quota exhaustion. No cookies or reCAPTCHA token are needed.
+- **Compilation detection is per-label; no signal generalises.** Future Avenue uses
+  `Various Artists` with per-track artists; Tadpole Records uses the label as album artist,
+  leaves every track artist null, and encodes it in the title as `Artist : Title`.
+- **Rate limiting is real** — a full scan of a 674-album label hits HTTP 429. `prefilter()`
+  rejects albums using the artist/title from the single `band_details` call before spending
+  a per-album request (674 → 70 for Future Avenue). Keep `request_delay` at 1s or higher.
+- **Scan cutoff is the newest release date already examined**, stored in state — never file
+  mtime, which updates on download and would hide older un-fetched releases. Wanted-but-not-
+  downloaded albums are kept in `state.pending` and reconsidered regardless of cutoff.
 
 ## Key Details
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,15 @@ from the search API's `item_url_root`, band_id, catalogue size, VA count, a newe
 sample, and the FULL comp-ish title list), show him counts + samples to catch wrong pages,
 then add with a per-label comment and scan with `--report -l "Name"`. Full operational
 detail (with the gotchas) is in the project memory `adding-new-labels-workflow.md`.
+**Run probes SERIALLY** — two concurrent probes hit HTTP 429, which surfaces as
+`JSONDecodeError: Expecting value: line 1 column 1` (an HTML error page) and silently truncates
+a label's output. Recover with `deepcheck.py`, which retries with backoff. Do not pass `--url`
+for a label search can already find: that path leaves `band_id=None` and every fetch fails.
+**For a BULK unvetted list (30+ scraped names), triage first:** `triage_labels.py <file>` spends
+2 requests/label (vs ~15) and marks SKIP for labels with no comp-ish titles and no VA credits;
+then price only survivors with `deepcheck.py --max 6`. Expect near-zero yield — a 66-label
+post-punk/goth list gave 1 usable label, because commercial vinyl labels sell their comps
+($7 flat at Echozone, $10 at Goth City). See `commercial-labels-have-no-free-comps.md`.
 
 **Match-rule selection** (rules live in `labelconfig.py`; all ANDed; empty = take all free):
 - `min_track_artists: N, min_tracks: M` — multi-artist comps whose tracks carry real
@@ -141,6 +150,10 @@ detail (with the gotchas) is in the project memory `adding-new-labels-workflow.m
   free title absent from the comp-ish list, use `{}` or `title_regex` instead (Sahel: 14 VA comps
   all paid, the one free item label-credited, so the rule returned nothing).
   Labels often credit comps several ways at once (`Various Artists`/`V/A`/`V.A.`/label) — match on title.
+  **The predicate is anchored and English-only**: it matches only `Various Artists`/`Various Artist`/
+  `V/A`/`V.A.` — NOT bare `Various`, `VA`, `VARIOUS ARTISTS!` (trailing punctuation), `VV.AA.`,
+  `Varios Artistas`, or `AAVV`. Read the probe's actual credit string; use `title_regex` when it
+  is any of those (hit on Paranoia Musique, pomogite, WORLD END COLLAPSE, Munster, Dorog).
 - `title_regex: "(?i)..."` — label-credited comp *series* (tracks show `distinct == 1`, so
   artist-count rules fail): samplers, tributes, "compilation". Also prefilters.
   **Anchor short generic alternatives** — a bare `dark` matched a solo EP "N3.0_Dark"; use `dark4`.
@@ -152,11 +165,34 @@ detail (with the gotchas) is in the project memory `adding-new-labels-workflow.m
 report 37/39 or 68/79 already downloaded. Always `--report` first, and check the label directory on
 disk (with a *loose* substring) before quoting any size estimate.
 
-**Estimate runtime from the `[needs email]` count, not item count or GB.** An emailed-link item
-costs ~5-8 min of Gmail polling before any bytes move; direct links take ~1-2 min. Measured: 18
-items/4 email = 23 min; 6 items/3 email = 46 min.
+**Estimate runtime from ITEM COUNT at 1-6 min each — the spread is Bandcamp-side, so quote a
+range.** Measured: 9 items/50 min and 8/53 min one evening, 12 items/18 min the next morning,
+same machine. `[needs email]` is no longer the driver (Gmail resolves in <1 min now); GB and
+track count predict nothing (a 6-track album was 1.15 GB, a 20-track comp 0.46 GB).
 
-**Two more verified gotchas:**
+**Recurring sweep (set up 2026-07-28).** Scheduled task **"BandcampFree Weekly Sweep"** runs
+`N:\bandcampfree\weekly-report.ps1` daily at 03:15; it does a report-only scan of all labels
+only when ~7 days have passed (`reports\.last-success` stamp). Report-only by design — Erik
+approves before any download. Output lands in `N:\bandcampfree\reports\`, one summary line per
+run in `sweep.log`, and **a sweep that finds nothing writes no report file**. A daily trigger
+plus the due-check is the retry mechanism: when N: is unmounted the run logs a SKIP, exits 0
+and leaves the stamp alone, so it retries tomorrow. Guards: share reachable, sweep due, and no
+other bandcampfree process running (`scan_all()` rewrites `state.json`, so an overlapping
+manual download would corrupt the pending queue). Downloads stay manual:
+`--pending-only --max-gb N`.
+
+**`--report` writes state.** `generate_free_report()` has no `state.save()`, but `scan_all()`
+inside it does — a report advances each label's `newest_release_seen` cutoff and fills
+`state.pending`. That is what lets a later `--pending-only` run download without rescanning.
+
+**More verified gotchas:**
+- **Directory names truncate at 64 chars and zero-width spaces count.** Cityman's
+  `ＩＳＵＺＵ　ＰＩＡＺＺＡ` landed with 28 U+200B of its 64 chars, cut mid-word. Cosmetic only —
+  `bandcamp_item_id.txt` still keys dedup, so it will not re-download (the My Grito duplicate
+  happened because the *pre-existing* copy had no id file). Shell globs can't match these dirs.
+- Free **pre-releases** (future release date) download fine; `freedownload` needs no
+  `is_preorder` check, unlike the collection syncer. Transient `curl (56)` failures leave the
+  item in `pending` — just re-run `--pending-only`.
 - "free download" / "(Free Sampler)" in a *title* does NOT imply `price == 0` — several
   labels title samplers that way but charge for them. Gate on price, never the title.
 - Same-titled comp series (e.g. Wiretap's ~15 identical "ATTENTION!" titles) collide in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,15 +85,15 @@ the collection sync: **claiming an album at $0 does not add it to the Bandcamp c
 report), `freedownload.py` (acquisition + download), `gmail.py` (emailed link retrieval).
 
 ```bash
-# Report what would be downloaded (no side effects)
-uv run python bin/bandcampfree -C labels.yaml --report
+# Config/state/creds/scripts live on N: — pass all four flags or they default back to C:
+FREE="-C N:/bandcampfree/labels.yaml -s N:/bandcampfree/state.json \
+  --client-secret N:/bandcampfree/client_secret.json --token N:/bandcampfree/token.json"
 
-# One-time Gmail authorisation
-uv run python bin/bandcampfree --gmail-auth
-
-# Download, bounded
-uv run python bin/bandcampfree -C labels.yaml --limit 5 --max-gb 10
+uv run python bin/bandcampfree $FREE -t N:/_bcf_temp --report        # no side effects
+uv run python bin/bandcampfree $FREE -t N:/_bcf_temp --pending-only --max-gb 15
+uv run python bin/bandcampfree --gmail-auth                          # one-time
 ```
+`-t N:/_bcf_temp` is required for any sizeable run — C: fills unpredictably.
 
 **Non-obvious details, all verified against live Bandcamp:**
 
@@ -116,9 +116,14 @@ uv run python bin/bandcampfree -C labels.yaml --limit 5 --max-gb 10
 - **Scan cutoff is the newest release date already examined**, stored in state — never file
   mtime, which updates on download and would hide older un-fetched releases. Wanted-but-not-
   downloaded albums are kept in `state.pending` and reconsidered regardless of cutoff.
+- **Label directory names must be derived by `media.clean_label_dir_name` on BOTH sides** —
+  `freesync.LabelIndex.__init__` and `freedownload._target_path`. It is narrower than
+  `clean_path_component` (which `LocalMedia` shares — do not widen that one). Diverging made
+  a label's whole catalogue re-download. Keep every label `name:` path-safe (no `? : * " < > |`).
 
 **Adding new labels (the recurring task):** Erik hands over batches of ~10-12 label names.
-Vet each with `C:/Users/erik/.bandcampfree/probe_labels.py "Name" ...` (resolves subdomain
+Vet each with `N:/bandcampfree/probe_labels.py "Name" ...` (deep-check candidates with
+`N:/bandcampfree/deepcheck.py "Label=BAND_ID"`; resolves subdomain
 from the search API's `item_url_root`, band_id, catalogue size, VA count, a newest-~14
 sample, and the FULL comp-ish title list), show him counts + samples to catch wrong pages,
 then add with a per-label comment and scan with `--report -l "Name"`. Full operational
@@ -127,13 +132,29 @@ detail (with the gotchas) is in the project memory `adding-new-labels-workflow.m
 **Match-rule selection** (rules live in `labelconfig.py`; all ANDed; empty = take all free):
 - `min_track_artists: N, min_tracks: M` — multi-artist comps whose tracks carry real
   per-track artists (most comps). Lower `min_tracks` to ~6 for short comps.
+  **False-positives on crew albums** where each track credits a different permutation of the same
+  3-4 people (distinct=11 off a 3-person roster) — inspect per-track `band_name`s before downloading.
 - `track_artists_vary: true` — small comps/splits (2-4 distinct artists) that `min_track_artists: 5` would reject.
 - `various_artists: true` — comps credited to "Various Artists"; **prefilters** on cheap
   `band_details`, so essential for large catalogues.
+  Because it prefilters it **hides free comps that are not VA-credited** — if the probe shows a
+  free title absent from the comp-ish list, use `{}` or `title_regex` instead (Sahel: 14 VA comps
+  all paid, the one free item label-credited, so the rule returned nothing).
+  Labels often credit comps several ways at once (`Various Artists`/`V/A`/`V.A.`/label) — match on title.
 - `title_regex: "(?i)..."` — label-credited comp *series* (tracks show `distinct == 1`, so
   artist-count rules fail): samplers, tributes, "compilation". Also prefilters.
+  **Anchor short generic alternatives** — a bare `dark` matched a solo EP "N3.0_Dark"; use `dark4`.
+  In YAML, single-quote regexes containing backslashes: `'(?i)e\.b\.m\.'` (double quotes reject `\.`).
 - empty `{}` — every release is a comp, or comps are label-credited (distinct=1) and can't
   be told apart by rule.
+
+**Expect near-total dedup.** Erik's collection already holds most free comps — batches routinely
+report 37/39 or 68/79 already downloaded. Always `--report` first, and check the label directory on
+disk (with a *loose* substring) before quoting any size estimate.
+
+**Estimate runtime from the `[needs email]` count, not item count or GB.** An emailed-link item
+costs ~5-8 min of Gmail polling before any bytes move; direct links take ~1-2 min. Measured: 18
+items/4 email = 23 min; 6 items/3 email = 46 min.
 
 **Two more verified gotchas:**
 - "free download" / "(Free Sampler)" in a *title* does NOT imply `price == 0` — several

--- a/bandcampsync/__init__.py
+++ b/bandcampsync/__init__.py
@@ -1,8 +1,9 @@
 from .config import VERSION as version
 from .sync import Syncer
+from .report import generate_report
 
 
-__all__ = ["version", "do_sync", "Syncer"]
+__all__ = ["version", "do_sync", "generate_report", "Syncer"]
 
 
 def do_sync(
@@ -18,6 +19,7 @@ def do_sync(
     retry_wait=5,
     skip_item_index=False,
     sync_ignore_file=False,
+    dir_format="artist-album",
 ):
     Syncer(
         cookies,
@@ -32,6 +34,7 @@ def do_sync(
         retry_wait,
         skip_item_index,
         sync_ignore_file,
+        dir_format,
     )
 
     return True

--- a/bandcampsync/bandcamp.py
+++ b/bandcampsync/bandcamp.py
@@ -2,6 +2,7 @@ import json
 import re
 from time import time
 from http.cookies import SimpleCookie
+from urllib.parse import unquote
 from html import unescape as html_unescape
 from urllib.parse import urlsplit, urlunsplit
 from bs4 import BeautifulSoup
@@ -50,12 +51,31 @@ class Bandcamp:
         for cookie_name, morsel in self.cookies.items():
             self.session.cookies.set(cookie_name, morsel.value)
 
+    def _set_cookie(self, name, value):
+        """Set a cookie value, working around SimpleCookie's strict parsing."""
+        self.cookies[name] = value
+
     def load_cookies(self, cookies_str):
         self.cookies = SimpleCookie()
         try:
             self.cookies.load(cookies_str)
-        except Exception as e:
-            raise BandcampError(f"Failed to parse cookies string: {e}") from e
+        except Exception:
+            self.cookies = SimpleCookie()
+        # If SimpleCookie failed or parsed nothing, try plain key=value/key:value format
+        if len(self.cookies) == 0:
+            for line in cookies_str.strip().split("\n"):
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "\t" not in line:
+                    # Support both key=value and key:value separators
+                    for sep in ("=", ":"):
+                        if sep in line:
+                            name, value = line.split(sep, 1)
+                            value = value.strip().strip('"')
+                            value = unquote(value)
+                            self._set_cookie(name.strip(), value)
+                            break
         if len(self.cookies) == 0:
             # Failed to load any cookies, attempt to parse the cookies string as a Netscape cookies export
             lines = cookies_str.strip().split("\n")
@@ -68,10 +88,7 @@ class Bandcamp:
                 parts = line.split("\t")
                 if len(parts) == 7:
                     domain, tailmatch, path, secure, expires, name, value = parts
-                    cookie_string = f"{name.strip()}={value.strip()}; Domain={domain.strip()}; Path={path.strip()}"
-                    if secure == "TRUE":
-                        cookie_string += "; Secure"
-                    self.cookies.load(cookie_string)
+                    self._set_cookie(name.strip(), value.strip())
         return True
 
     @property
@@ -204,7 +221,7 @@ class Bandcamp:
             raise BandcampError(
                 f'Failed to parse pagedata JSON, "identity.fan" seems invalid: {identity}'
             ) from e
-        self.is_authenticated = self.user_id > 0
+        self.is_authenticated = (self.user_id or 0) > 0
         log.info(
             f"Loaded page data, session is authenticated for user id: {self.user_id})"
         )

--- a/bandcampsync/bandcamp.py
+++ b/bandcampsync/bandcamp.py
@@ -30,7 +30,12 @@ class Bandcamp:
         "collection_items": "/api/fancollection/1/collection_items",
     }
 
-    def __init__(self, cookies=""):
+    def __init__(self, cookies="", require_auth=True):
+        """
+        Set require_auth=False for anonymous use. Free and pay-what-you-want downloads
+        are served from signed URLs that do not need an authenticated session, so the
+        free label downloader has no cookies to supply.
+        """
         self.is_authenticated = False
         self.user_id = 0
         self.user_verified = False
@@ -38,14 +43,17 @@ class Bandcamp:
         self.purchases = []
         self.load_cookies(cookies)
         identity = self.cookies.get("identity")
-        if not identity:
+        if not identity and require_auth:
             raise BandcampError(
                 "Cookie data does not contain an identity value, make sure your "
                 "cookies.txt file is valid and you copied it from an "
                 "authenticated browser"
             )
-        identity_snip = identity.value[:20]
-        log.info(f"Located Bandcamp identity in cookies: {identity_snip}...")
+        if identity:
+            identity_snip = identity.value[:20]
+            log.info(f"Located Bandcamp identity in cookies: {identity_snip}...")
+        else:
+            log.info("Using an anonymous Bandcamp session")
         # Create a requests session and map our SimpleCookie to it
         self.session = requests.Session(impersonate="chrome")
         for cookie_name, morsel in self.cookies.items():
@@ -114,18 +122,29 @@ class Bandcamp:
         return cookies
 
     def _request(
-        self, method, url, data=None, json_data=None, is_json=False, as_raw=False
+        self,
+        method,
+        url,
+        data=None,
+        json_data=None,
+        is_json=False,
+        as_raw=False,
+        timeout=None,
     ):
         try:
             # The debug logs do not mask the URL which may be a security issue if you run
             # with level=logging.DEBUG
             log.debug(f"Making {method} request to {url}")
+            kwargs = {}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
             response = self.session.request(
                 method,
                 url,
                 cookies=self._plain_cookies(),
                 data=data,
                 json=json_data,
+                **kwargs,
             )
         except Exception as e:
             raise BandcampError(
@@ -329,7 +348,6 @@ class Bandcamp:
                     continue
                 if item.item_id is None:
                     log.error(
-                        f"Failed to locate download URL for {band_name} / {title} "
                         f'Failed to locate item id for "{item.band_name} / {item.item_title}", skipping item...'
                     )
                     continue
@@ -339,7 +357,9 @@ class Bandcamp:
                 item.download_url = download_url
                 item_key = (item.band_name, item.item_title)
                 items_by_title_key.setdefault(item_key, []).append(item)
-                log.info(f"Found item: {item.band_name} / {item.item_title} (id:{item.item_id})")
+                log.info(
+                    f"Found item: {item.band_name} / {item.item_title} (id:{item.item_id})"
+                )
                 self.purchases.append(item)
 
         # De-duplicate multiple purchases sharing the same artist and title.
@@ -393,11 +413,15 @@ class Bandcamp:
                 return download_url
         raise BandcampDownloadUnavailable("No download available for item")
 
-    def check_download_stat(self, item, file_download_url):
+    def check_download_stat(self, item, file_download_url, timeout=None):
         """
         Constructs the download "stat" URL and verifies the state of the download.
         If the state is OK, return the existing URL (download is OK) otherwise wait
         for the stat to complete and return the new download URL.
+
+        Pass a longer timeout for large archives: bandcamp builds the zip server-side
+        while this request is open, and a multi-gigabyte compilation takes well over the
+        default 30 seconds.
         """
         download_url_parts = urlsplit(file_download_url)
         path = download_url_parts.path
@@ -413,7 +437,7 @@ class Bandcamp:
                 "",
             )
         )
-        body = self._request("get", stat_url, as_raw=True)
+        body = self._request("get", stat_url, as_raw=True, timeout=timeout)
         return self._get_js_stat_url(body, file_download_url)
 
 

--- a/bandcampsync/bandcamp.py
+++ b/bandcampsync/bandcamp.py
@@ -395,10 +395,20 @@ class Bandcamp:
                         "Failed to parse pagedata JSON, does not contain an "
                         '"digital_items.downloads" key'
                     ) from e
+                if not downloads:
+                    # An empty downloads dict means the release itself is not available
+                    # for download right now - bandcamp serves the page but the item is
+                    # marked not-ready / "currently unavailable". That can be temporary
+                    # (a label can re-enable it), so it is distinct from a release that
+                    # offers other formats but not the one requested.
+                    raise BandcampDownloadUnavailable(
+                        f"Release offers no downloads (id {digital_item_id}); it may be "
+                        f"temporarily unavailable"
+                    )
                 try:
                     download_format = downloads[encoding]
                 except KeyError as e:
-                    encodings = downloads.keys()
+                    encodings = list(downloads.keys())
                     raise BandcampError(
                         f"Download formats does not contain requested encoding: {encoding} "
                         f"(available encodings: {encodings})"

--- a/bandcampsync/download.py
+++ b/bandcampsync/download.py
@@ -1,5 +1,7 @@
 import math
+import re
 import shutil
+from urllib.parse import unquote
 from zipfile import ZipFile
 from bs4 import BeautifulSoup
 from curl_cffi import requests
@@ -74,6 +76,29 @@ def _read_html_body(response):
     return html_body
 
 
+def _parse_content_disposition_filename(header_value):
+    """Parse filename from a Content-Disposition header value.
+
+    Handles quoted, unquoted, and RFC 5987 UTF-8 encoded forms.
+    Returns the filename string or None if not found.
+    """
+    if not header_value:
+        return None
+    # Try RFC 5987 filename* first (e.g. filename*=UTF-8''Artist%20-%20Album.zip)
+    match = re.search(r"filename\*\s*=\s*UTF-8''(.+?)(?:;|$)", header_value, re.IGNORECASE)
+    if match:
+        return unquote(match.group(1).strip())
+    # Try quoted filename (e.g. filename="Artist - Album.zip")
+    match = re.search(r'filename\s*=\s*"(.+?)"', header_value)
+    if match:
+        return match.group(1).strip()
+    # Try unquoted filename (e.g. filename=Artist - Album.zip)
+    match = re.search(r"filename\s*=\s*([^;]+)", header_value)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
 def download_file(
     url,
     target,
@@ -90,6 +115,7 @@ def download_file(
     text = True if "t" in mode else False
     data_streamed = 0
     last_log = 0
+    content_filename = None
     r = requests.get(url, stream=True, impersonate="chrome")
     try:
         # r.raise_for_status()
@@ -109,6 +135,11 @@ def download_file(
                 f"Invalid content type: {major_content_type}"
             )
         try:
+            cd_header = r.headers.get("Content-Disposition", "")
+        except (ValueError, KeyError):
+            cd_header = ""
+        content_filename = _parse_content_disposition_filename(cd_header)
+        try:
             content_length = int(r.headers.get("Content-Length", "0"))
         except (ValueError, KeyError):
             content_length = 0
@@ -124,7 +155,7 @@ def download_file(
                     last_log = percent_complete
     finally:
         r.close()
-    return True
+    return content_filename
 
 
 def is_zip_file(file_path):

--- a/bandcampsync/download.py
+++ b/bandcampsync/download.py
@@ -31,7 +31,6 @@ class DownloadInvalidContentType(ValueError):
     pass
 
 
-
 class DownloadExpired(ValueError):
     pass
 
@@ -85,7 +84,9 @@ def _parse_content_disposition_filename(header_value):
     if not header_value:
         return None
     # Try RFC 5987 filename* first (e.g. filename*=UTF-8''Artist%20-%20Album.zip)
-    match = re.search(r"filename\*\s*=\s*UTF-8''(.+?)(?:;|$)", header_value, re.IGNORECASE)
+    match = re.search(
+        r"filename\*\s*=\s*UTF-8''(.+?)(?:;|$)", header_value, re.IGNORECASE
+    )
     if match:
         return unquote(match.group(1).strip())
     # Try quoted filename (e.g. filename="Artist - Album.zip")
@@ -130,7 +131,9 @@ def download_file(
         if major_content_type == disallow_content_type:
             html_body = _read_html_body(r)
             if _is_expired_download_page(html_body):
-                raise DownloadExpired("Download expired and requires email confirmation on Bandcamp")
+                raise DownloadExpired(
+                    "Download expired and requires email confirmation on Bandcamp"
+                )
             raise DownloadInvalidContentType(
                 f"Invalid content type: {major_content_type}"
             )

--- a/bandcampsync/freedownload.py
+++ b/bandcampsync/freedownload.py
@@ -321,17 +321,22 @@ def repair_album(album, spec, config, local_path, gmail_reader=None, temp_dir=No
 
 
 def acquire_album(album, spec, config, gmail_reader=None, temp_dir=None):
-    """Request, retrieve and download one free album. Returns the local path."""
+    """Request, retrieve and download one free album. Returns the local path.
+
+    gmail_reader may be a GmailReader or a zero-argument callable returning one, so the
+    caller can defer authorising Gmail until an album actually needs an emailed link.
+    """
     url = request_download(
         spec.subdomain_url, album, config.email, config.country, config.postcode
     )
     if url is None:
-        if gmail_reader is None:
+        reader = gmail_reader() if callable(gmail_reader) else gmail_reader
+        if reader is None:
             raise AcquireError(
                 f"{album.title!r} requires an emailed download link but Gmail is not "
                 f"configured. Run with --gmail-auth first."
             )
-        url = gmail_reader.wait_for_link(album.item_id)
+        url = reader.wait_for_link(album.item_id)
     return resolve_and_download(
         url,
         album,

--- a/bandcampsync/freedownload.py
+++ b/bandcampsync/freedownload.py
@@ -26,7 +26,7 @@ from urllib.parse import urlsplit
 from curl_cffi import requests
 
 from .bandcamp import Bandcamp, BandcampError, BandcampItem
-from .download import download_file, is_zip_file, unzip_file
+from .download import download_file, is_zip_file, move_file, unzip_file
 from .logger import get_logger
 from .media import parse_zip_filename
 
@@ -54,6 +54,11 @@ def _endpoint_for(album, label_url):
     return f"{label_url.rstrip('/')}/email_download"
 
 
+def _item_type_name(album):
+    """bandcamp wants the word, not its letter: "album" or "track"."""
+    return "track" if getattr(album, "item_type", "a") in ("t", "track") else "album"
+
+
 def request_download(label_url, album, email, country, postcode):
     """Ask bandcamp for a free download. Returns a URL, or None if it was emailed."""
     if not email:
@@ -68,9 +73,7 @@ def request_download(label_url, album, email, country, postcode):
     payload = {
         "encoding_name": "none",
         "item_id": str(album.item_id),
-        "item_type": "album"
-        if getattr(album, "item_type", "a") in ("a", "album")
-        else "track",
+        "item_type": _item_type_name(album),
         "address": email,
         "country": country,
         "postcode": str(postcode),
@@ -125,7 +128,7 @@ def resolve_and_download(
             "item_id": album.item_id,
             "band_name": label_name,
             "item_title": album.title,
-            "item_type": "album",
+            "item_type": _item_type_name(album),
         }
     )
     item.download_url = download_page_url
@@ -140,14 +143,18 @@ def resolve_and_download(
         size_mb = tmp_file.stat().st_size / (1024 * 1024)
         log.info(f"Downloaded {content_filename!r} ({size_mb:.1f} MB)")
 
-        if not is_zip_file(tmp_file):
-            raise AcquireError(
-                f"Downloaded file for {album.title!r} is not a zip archive"
-            )
         local_path = _target_path(media_dir, label_name, album, content_filename)
-        log.info(f"Extracting to {local_path}")
         local_path.mkdir(parents=True, exist_ok=True)
-        unzip_file(tmp_file, local_path)
+        if is_zip_file(tmp_file):
+            log.info(f"Extracting to {local_path}")
+            unzip_file(tmp_file, local_path)
+        else:
+            # A standalone track is served as the audio file itself, not an archive.
+            # Give it a directory of its own so it matches the rest of the collection
+            # and can carry the item id file.
+            name = content_filename or f"{album.title}.{media_format}"
+            log.info(f"Single track, moving {name!r} into {local_path}")
+            move_file(str(tmp_file), str(local_path / name))
 
     id_file = local_path / ITEM_INDEX_FILENAME
     id_file.write_text(f"{album.item_id}\n")
@@ -156,13 +163,17 @@ def resolve_and_download(
 
 
 def _target_path(media_dir, label_name, album, content_filename):
-    """Place the album under media_dir/<label>/<zip stem>.
+    """Place the release under media_dir/<label>/<name>.
 
     Mirrors LocalMedia.get_path_for_zip_purchase for the label case: the zip filename is
     "Artist - Album.zip" where Artist is the real album artist, and the label name is the
-    grouping directory.
+    grouping directory. A standalone track arrives as a bare audio file rather than an
+    archive, so its directory is built from the metadata instead.
     """
     media_dir = Path(media_dir)
+    if getattr(album, "item_type", "a") in ("t", "track"):
+        name = f"{album.artist} - {album.title}".strip(" -") or str(album.item_id)
+        return media_dir / label_name / name
     if content_filename:
         zip_artist, zip_album = parse_zip_filename(content_filename)
         if zip_artist and zip_album:

--- a/bandcampsync/freedownload.py
+++ b/bandcampsync/freedownload.py
@@ -1,0 +1,342 @@
+"""
+Acquisition and download of free / pay-what-you-want albums.
+
+Flow, verified against Future Avenue:
+
+  1. POST <label>/email_download with the item id and an address. Plain HTTP: no cookies,
+     no reCAPTCHA token. country and postcode are mandatory - omitting them returns
+     {"ok": false, "error": "Sorry, this item is no longer available for free."}, which
+     means "bad location data" rather than anything about availability.
+  2. The response either carries download_url directly, or is {"ok": true} and bandcamp
+     emails the link. Both branches must be handled.
+  3. The resulting bandcamp.com/download page is parsed by the existing
+     Bandcamp.get_download_file_url(), which already picks the requested format out of
+     digital_items[].downloads.
+"""
+
+import json
+import os
+import shutil
+import time
+import tempfile
+import zipfile
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from curl_cffi import requests
+
+from .bandcamp import Bandcamp, BandcampError, BandcampItem
+from .download import download_file, is_zip_file, unzip_file
+from .logger import get_logger
+from .media import parse_zip_filename
+
+log = get_logger("freedownload")
+
+ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
+
+
+class AcquireError(ValueError):
+    pass
+
+
+def _endpoint_for(album, label_url):
+    """Return the email_download endpoint for an album.
+
+    A label's discography can include releases hosted on the artist's own subdomain
+    (Children of Vapor lists albums living on eccosystem.bandcamp.com), and the endpoint
+    must be on the same subdomain as the album or the request fails. Derive it from the
+    album URL, falling back to the configured label URL.
+    """
+    source = album.url or label_url
+    parts = urlsplit(source)
+    if parts.scheme and parts.netloc:
+        return f"{parts.scheme}://{parts.netloc}/email_download"
+    return f"{label_url.rstrip('/')}/email_download"
+
+
+def request_download(label_url, album, email, country, postcode):
+    """Ask bandcamp for a free download. Returns a URL, or None if it was emailed."""
+    if not email:
+        raise AcquireError("No email address configured (defaults.email)")
+    if not country or not postcode:
+        # Worth failing loudly: bandcamp's error for missing location data is misleading.
+        raise AcquireError(
+            "Both defaults.country and defaults.postcode are required; bandcamp rejects "
+            "the request with a misleading 'no longer available for free' error without them"
+        )
+    endpoint = _endpoint_for(album, label_url)
+    payload = {
+        "encoding_name": "none",
+        "item_id": str(album.item_id),
+        "item_type": "album"
+        if getattr(album, "item_type", "a") in ("a", "album")
+        else "track",
+        "address": email,
+        "country": country,
+        "postcode": str(postcode),
+    }
+    log.info(f"Requesting free download of {album.title!r} from {endpoint}")
+    try:
+        response = requests.post(
+            endpoint,
+            data=payload,
+            headers={
+                "X-Requested-With": "XMLHttpRequest",
+                "Referer": album.url or label_url,
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            impersonate="chrome",
+            timeout=60,
+        )
+    except Exception as e:
+        raise AcquireError(f"Failed to POST to {endpoint}: {e}") from e
+    if response.status_code != 200:
+        raise AcquireError(
+            f"Unexpected status code from {endpoint}: {response.status_code}"
+        )
+    try:
+        data = json.loads(response.text)
+    except Exception as e:
+        raise AcquireError(f"Could not parse response from {endpoint}: {e}") from e
+    if not data.get("ok"):
+        raise AcquireError(
+            f"bandcamp refused the free download of {album.title!r}: "
+            f"{data.get('error') or data}"
+        )
+    url = data.get("download_url")
+    if url:
+        log.info("bandcamp returned a download URL directly, no email needed")
+        return url
+    log.info(f"bandcamp emailed the download link for {album.title!r}")
+    return None
+
+
+def resolve_and_download(
+    download_page_url, album, label_name, media_dir, media_format="flac", temp_dir=None
+):
+    """Download and extract an album from its bandcamp download page.
+
+    Returns the local directory the album was extracted to.
+    """
+    # Anonymous session: free download URLs are signed and need no account.
+    bc = Bandcamp("", require_auth=False)
+    item = BandcampItem(
+        {
+            "item_id": album.item_id,
+            "band_name": label_name,
+            "item_title": album.title,
+            "item_type": "album",
+        }
+    )
+    item.download_url = download_page_url
+
+    file_url = bc.get_download_file_url(item, encoding=media_format)
+    file_url = stat_download(bc, item, file_url)
+
+    with tempfile.TemporaryDirectory(dir=temp_dir) as td:
+        tmp_file = Path(td) / "download.bin"
+        with open(tmp_file, "wb") as fh:
+            content_filename = download_file(file_url, fh)
+        size_mb = tmp_file.stat().st_size / (1024 * 1024)
+        log.info(f"Downloaded {content_filename!r} ({size_mb:.1f} MB)")
+
+        if not is_zip_file(tmp_file):
+            raise AcquireError(
+                f"Downloaded file for {album.title!r} is not a zip archive"
+            )
+        local_path = _target_path(media_dir, label_name, album, content_filename)
+        log.info(f"Extracting to {local_path}")
+        local_path.mkdir(parents=True, exist_ok=True)
+        unzip_file(tmp_file, local_path)
+
+    id_file = local_path / ITEM_INDEX_FILENAME
+    id_file.write_text(f"{album.item_id}\n")
+    log.info(f"Wrote {id_file}")
+    return local_path
+
+
+def _target_path(media_dir, label_name, album, content_filename):
+    """Place the album under media_dir/<label>/<zip stem>.
+
+    Mirrors LocalMedia.get_path_for_zip_purchase for the label case: the zip filename is
+    "Artist - Album.zip" where Artist is the real album artist, and the label name is the
+    grouping directory.
+    """
+    media_dir = Path(media_dir)
+    if content_filename:
+        zip_artist, zip_album = parse_zip_filename(content_filename)
+        if zip_artist and zip_album:
+            stem = content_filename
+            if stem.lower().endswith(".zip"):
+                stem = stem[:-4]
+            return media_dir / label_name / stem
+    fallback = f"{album.artist} - {album.title}".strip(" -")
+    return media_dir / label_name / fallback
+
+
+def stat_download(bc, item, file_url, attempts=3, timeout=300, wait=20):
+    """Refresh a download URL via the stat endpoint, tolerating slow archive builds.
+
+    Bandcamp assembles the zip server-side while this request is open, so a large
+    compilation (a 120-track, 7.5GB Weedian album, say) blows past the default 30 second
+    timeout. Retry with a generous timeout, and if it still will not answer, fall back to
+    the original URL - which is what the stat call returns anyway when it succeeds with
+    an "ok" result, so the download is usually still fine.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return bc.check_download_stat(item, file_url, timeout=timeout)
+        except BandcampError as e:
+            log.warning(
+                f"statdownload attempt {attempt}/{attempts} failed "
+                f"(bandcamp may still be building the archive): {e}"
+            )
+            if attempt < attempts:
+                time.sleep(wait * attempt)
+    log.warning("Proceeding with the un-refreshed download URL")
+    return file_url
+
+
+def _common_prefix(names):
+    """Longest common leading string across names, trimmed to a sane boundary."""
+    if len(names) < 2:
+        return ""
+    prefix = os.path.commonprefix(list(names))
+    # Only trust a prefix that ends at a separator, so track numbers are not eaten.
+    cut = max(prefix.rfind(" - "), prefix.rfind("_"), prefix.rfind("/"))
+    return (
+        prefix[: cut + 3]
+        if prefix.rfind(" - ") == cut and cut != -1
+        else (prefix[: cut + 1] if cut != -1 else "")
+    )
+
+
+def _track_keys(names):
+    """Map each name to a comparison key with the shared album-title prefix removed.
+
+    Bandcamp embeds the album title in every filename, so when a label renames an album
+    ("Trip to Poland" -> "Trip to Poland II") every local file mismatches every archive
+    entry even though the tracks are the same. Comparing the part after the shared prefix
+    identifies tracks across a rename.
+    """
+    prefix = _common_prefix(names)
+    return {
+        (n[len(prefix) :] if prefix and n.startswith(prefix) else n): n for n in names
+    }
+
+
+def extract_missing(zip_path, local_path, max_additions=None):
+    """Extract only entries that are not already present locally.
+
+    Used to repair a directory that is complete apart from tracks the label added after
+    the original download. Bandcamp does not allow downloading an individual track of a
+    compilation (has_digital_download is false on them), so the whole archive must be
+    fetched even to recover one file - but there is no reason to rewrite the rest.
+
+    max_additions guards against a silent duplicate explosion: if far more files look
+    missing than expected, the naming has drifted in a way this cannot reconcile and it
+    is safer to stop than to double the directory.
+    """
+    local_path = Path(local_path)
+    existing_names = [p.name for p in local_path.iterdir() if p.is_file()]
+    with zipfile.ZipFile(zip_path) as zf:
+        entries = [i for i in zf.infolist() if not i.is_dir() and Path(i.filename).name]
+        entry_names = [Path(i.filename).name for i in entries]
+
+        local_keys = set(_track_keys(existing_names))
+        entry_keys = _track_keys(entry_names)
+        missing = {k: n for k, n in entry_keys.items() if k not in local_keys}
+
+        if max_additions is not None and len(missing) > max_additions:
+            raise AcquireError(
+                f"Repair would add {len(missing)} files but only {max_additions} were "
+                f"expected to be missing. The local filenames probably no longer match "
+                f"the archive (the label may have renamed the album). Refusing to "
+                f"duplicate the directory; inspect it manually."
+            )
+
+        added = []
+        by_name = {Path(i.filename).name: i for i in entries}
+        for _key, name in sorted(missing.items()):
+            info = by_name[name]
+            with zf.open(info) as src, open(local_path / name, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            added.append(name)
+
+    log.info(
+        f"Repair: added {len(added)} file(s), left "
+        f"{len(existing_names)} existing file(s) alone"
+    )
+    return added
+
+
+def repair_album(album, spec, config, local_path, gmail_reader=None, temp_dir=None):
+    """Fetch an album's archive and add only the files missing from local_path."""
+    url = request_download(
+        spec.subdomain_url, album, config.email, config.country, config.postcode
+    )
+    if url is None:
+        if gmail_reader is None:
+            raise AcquireError(
+                f"{album.title!r} requires an emailed download link but Gmail is not "
+                f"configured. Run with --gmail-auth first."
+            )
+        url = gmail_reader.wait_for_link(album.item_id)
+
+    bc = Bandcamp("", require_auth=False)
+    item = BandcampItem(
+        {
+            "item_id": album.item_id,
+            "band_name": spec.name,
+            "item_title": album.title,
+            "item_type": "album",
+        }
+    )
+    item.download_url = url
+    file_url = bc.get_download_file_url(item, encoding=config.media_format)
+    file_url = stat_download(bc, item, file_url)
+
+    with tempfile.TemporaryDirectory(dir=temp_dir) as td:
+        tmp_file = Path(td) / "download.bin"
+        with open(tmp_file, "wb") as fh:
+            content_filename = download_file(file_url, fh)
+        size_mb = tmp_file.stat().st_size / (1024 * 1024)
+        log.info(f"Downloaded {content_filename!r} ({size_mb:.1f} MB) for repair")
+        if not is_zip_file(tmp_file):
+            raise AcquireError(f"Repair download for {album.title!r} is not a zip")
+        expected = max(
+            0,
+            album.num_tracks
+            - len(
+                [p for p in Path(local_path).iterdir() if p.suffix.lower() == ".flac"]
+            ),
+        )
+        # Allow a small margin for artwork and similar non-track files.
+        added = extract_missing(tmp_file, local_path, max_additions=expected + 5)
+
+    id_file = Path(local_path) / ITEM_INDEX_FILENAME
+    if not id_file.is_file():
+        id_file.write_text(f"{album.item_id}\n")
+    return added
+
+
+def acquire_album(album, spec, config, gmail_reader=None, temp_dir=None):
+    """Request, retrieve and download one free album. Returns the local path."""
+    url = request_download(
+        spec.subdomain_url, album, config.email, config.country, config.postcode
+    )
+    if url is None:
+        if gmail_reader is None:
+            raise AcquireError(
+                f"{album.title!r} requires an emailed download link but Gmail is not "
+                f"configured. Run with --gmail-auth first."
+            )
+        url = gmail_reader.wait_for_link(album.item_id)
+    return resolve_and_download(
+        url,
+        album,
+        spec.name,
+        config.media_dir,
+        media_format=config.media_format,
+        temp_dir=temp_dir,
+    )

--- a/bandcampsync/freedownload.py
+++ b/bandcampsync/freedownload.py
@@ -28,7 +28,7 @@ from curl_cffi import requests
 from .bandcamp import Bandcamp, BandcampError, BandcampItem
 from .download import download_file, is_zip_file, move_file, unzip_file
 from .logger import get_logger
-from .media import clean_path_component, parse_zip_filename
+from .media import clean_label_dir_name, clean_path_component, parse_zip_filename
 
 log = get_logger("freedownload")
 
@@ -176,7 +176,10 @@ def _target_path(media_dir, label_name, album, content_filename):
         return clean_path_component(raw).strip(" -") or str(album.item_id)
 
     media_dir = Path(media_dir)
-    label_dir = media_dir / clean_path_component(label_name)
+    # Label grouping dir uses the narrower cleaner, matched by LabelIndex. The album
+    # directory below still uses clean_path_component, which LocalMedia._normalize_for_match
+    # compares leniently.
+    label_dir = media_dir / clean_label_dir_name(label_name)
     if getattr(album, "item_type", "a") in ("t", "track"):
         return label_dir / clean(f"{album.artist} - {album.title}")
     if content_filename:

--- a/bandcampsync/freedownload.py
+++ b/bandcampsync/freedownload.py
@@ -28,7 +28,7 @@ from curl_cffi import requests
 from .bandcamp import Bandcamp, BandcampError, BandcampItem
 from .download import download_file, is_zip_file, move_file, unzip_file
 from .logger import get_logger
-from .media import parse_zip_filename
+from .media import clean_path_component, parse_zip_filename
 
 log = get_logger("freedownload")
 
@@ -170,19 +170,23 @@ def _target_path(media_dir, label_name, album, content_filename):
     grouping directory. A standalone track arrives as a bare audio file rather than an
     archive, so its directory is built from the metadata instead.
     """
+    def clean(raw):
+        # Clean first, then strip: the cleaning can expose leading/trailing separators
+        # that were previously hidden behind an illegal character.
+        return clean_path_component(raw).strip(" -") or str(album.item_id)
+
     media_dir = Path(media_dir)
+    label_dir = media_dir / clean_path_component(label_name)
     if getattr(album, "item_type", "a") in ("t", "track"):
-        name = f"{album.artist} - {album.title}".strip(" -") or str(album.item_id)
-        return media_dir / label_name / name
+        return label_dir / clean(f"{album.artist} - {album.title}")
     if content_filename:
         zip_artist, zip_album = parse_zip_filename(content_filename)
         if zip_artist and zip_album:
             stem = content_filename
             if stem.lower().endswith(".zip"):
                 stem = stem[:-4]
-            return media_dir / label_name / stem
-    fallback = f"{album.artist} - {album.title}".strip(" -")
-    return media_dir / label_name / fallback
+            return label_dir / clean(stem)
+    return label_dir / clean(f"{album.artist} - {album.title}")
 
 
 def stat_download(bc, item, file_url, attempts=3, timeout=300, wait=20):

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -904,7 +904,7 @@ def do_free_sync(
     pending_only=False,
 ):
     """Scan, then download everything wanted. Returns a list of (album, path or error)."""
-    from .freedownload import AcquireError, acquire_album
+    from .freedownload import acquire_album
 
     if not config.media_dir:
         raise ValueError("No media_dir configured under defaults in the config file")

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -39,6 +39,8 @@ log = get_logger("freesync")
 ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
 # Non-free albums are re-checked after this many days in case a price has changed.
 RECHECK_DAYS = 90
+# Give up on an album after this many consecutive failed download attempts.
+MAX_DOWNLOAD_ATTEMPTS = 3
 
 STATUS_DOWNLOADED = "downloaded"
 STATUS_WANTED = "wanted"
@@ -75,6 +77,11 @@ class FreeState:
         # release with no digital files, for instance. Without this they stay pending and
         # are retried on every run forever.
         self.skipped = {}
+        # Consecutive download failures per item. Some albums are priced at zero but
+        # bandcamp still refuses the download - a limited free-download allocation that
+        # has been used up looks exactly like this. Those cannot be told apart from a
+        # transient fault on a single attempt, so count attempts and give up eventually.
+        self.failures = {}
         self.load()
 
     def load(self):
@@ -93,6 +100,7 @@ class FreeState:
         self.items = self._int_keyed(data.get("items"), "items")
         self.pending = self._int_keyed(data.get("pending"), "pending")
         self.skipped = self._int_keyed(data.get("skipped"), "skipped")
+        self.failures = self._int_keyed(data.get("failures"), "failures")
         log.info(
             f"Loaded state: {len(self.labels)} labels, {len(self.items)} cached albums, "
             f"{len(self.pending)} pending, {len(self.skipped)} skipped from {self.path}"
@@ -123,6 +131,7 @@ class FreeState:
                     "items": {str(k): v for k, v in self.items.items()},
                     "pending": {str(k): v for k, v in self.pending.items()},
                     "skipped": {str(k): v for k, v in self.skipped.items()},
+                    "failures": {str(k): v for k, v in self.failures.items()},
                 },
                 f,
                 indent=1,
@@ -974,21 +983,29 @@ def do_free_sync(
                 or "No download available" in message
             )
             log.error(f'Failed to download "{album.title}": {e}')
-            if permanent:
-                # Retrying this every run would never succeed: the release has no
-                # digital files in the requested format (physical-only items, for one).
+            attempts = state.failures.get(album.item_id, 0) + 1
+            state.failures[album.item_id] = attempts
+            if not permanent and attempts >= MAX_DOWNLOAD_ATTEMPTS:
                 log.warning(
-                    f'Marking "{album.title}" as permanently skipped; it offers no '
-                    f"{config.media_format} download"
+                    f'"{album.title}" has failed {attempts} times; giving up on it. '
+                    f"Clear it from state.failures to retry."
                 )
-                state.skipped[album.item_id] = f"no {config.media_format} download"
+                permanent = True
+                message = f"{message} (after {attempts} attempts)"
+            if permanent:
+                log.warning(f'Marking "{album.title}" as permanently skipped')
+                state.skipped[album.item_id] = message[:200]
                 state.pending.pop(album.item_id, None)
-                state.save()
+                state.failures.pop(album.item_id, None)
+            # Save either way: the attempt count has to survive the run, or a repeatedly
+            # failing album is retried forever because every run starts it back at one.
+            state.save()
             done.append((album, None, message))
             continue
         size = sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
         downloaded_bytes += size
         state.pending.pop(album.item_id, None)
+        state.failures.pop(album.item_id, None)
         state.save()
         done.append((album, path, None))
         log.info(f'Downloaded "{album.title}" -> {path} ({size / 1024**3:.2f} GB)')

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -962,7 +962,12 @@ def do_free_sync(
             path = acquire_album(
                 album, specs[label_name], config, get_gmail_reader, temp_dir
             )
-        except (AcquireError, ValueError) as e:
+        except Exception as e:
+            # Deliberately broad. A transient network fault - curl_cffi raises its own
+            # RequestException, which is not a ValueError - would otherwise abort a
+            # multi-hour batch partway through. One album failing must never cost the
+            # rest of the run; anything not classified as permanent stays pending and is
+            # retried on the next run.
             message = str(e)
             permanent = (
                 "does not contain requested encoding" in message

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -172,6 +172,7 @@ class FreeState:
             "is_free": is_free,
             "require_email": album.require_email,
             "num_tracks": album.num_tracks,
+            "item_type": album.item_type,
             "checked_ts": int(time.time()),
         }
 
@@ -799,7 +800,8 @@ def pending_albums(config, state, api=None):
             band_id = spec.band_id or state.label(spec.name).get("band_id")
             log.info(f"Cache predates URL storage, fetching details for {item_id}")
             album = album_from_details(
-                api.tralbum_details(band_id, item_id, "a"), label_name=label_name
+                api.tralbum_details(band_id, item_id, (cached.get("item_type") or "a")),
+                label_name=label_name,
             )
             if album.item_id is None or not album.title:
                 # Delisted or otherwise gone. Record it so the queue drains instead of
@@ -823,6 +825,7 @@ def pending_albums(config, state, api=None):
                 require_email=bool(cached.get("require_email")),
                 free_download=False,
                 num_tracks=int(cached.get("num_tracks") or 0),
+                item_type=cached.get("item_type") or "a",
                 label_name=label_name,
             )
         out.append((label_name, album))

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -32,7 +32,7 @@ from .labels import (
     list_discography,
 )
 from .logger import get_logger
-from .media import LocalMedia
+from .media import LocalMedia, clean_label_dir_name
 
 log = get_logger("freesync")
 
@@ -186,7 +186,10 @@ class LabelIndex:
     """
 
     def __init__(self, media_dir, label_name):
-        self.dir = Path(media_dir) / label_name
+        # Must use the same derivation as freedownload._target_path, or this index looks
+        # in a directory the downloader never writes to and every album reports as
+        # missing. See clean_label_dir_name for the failure this prevents.
+        self.dir = Path(media_dir) / clean_label_dir_name(label_name)
         self.by_id = {}
         # Titles are NOT unique: The Audio Atelier has four distinct releases all called
         # "Best of 2025 (Free Download)". Keyed by a plain dict, later directories would

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -793,10 +793,14 @@ def pending_albums(config, state, api=None):
                 api.tralbum_details(band_id, item_id, "a"), label_name=label_name
             )
             if album.item_id is None or not album.title:
+                # Delisted or otherwise gone. Record it so the queue drains instead of
+                # carrying an item that can never be fetched.
                 log.warning(
-                    f"Skipping pending item {item_id}: bandcamp returned no usable "
-                    f"details for it"
+                    f"Pending item {item_id} returns no usable details; recording it "
+                    f"as unavailable"
                 )
+                state.skipped[item_id] = "no details from bandcamp"
+                state.pending.pop(item_id, None)
                 continue
             state.cache(album, album.is_free)
         else:
@@ -931,12 +935,19 @@ def do_free_sync(
             )
         wanted = wanted[:limit]
 
-    # Only build a Gmail reader if something actually needs one.
-    gmail_reader = None
-    if any(getattr(album, "require_email", False) for _label, album in wanted):
-        from .gmail import GmailReader, load_credentials
+    # Built on first use rather than up front. The cached require_email flag is not a
+    # reliable predictor - bandcamp emails the link for albums cached as not requiring
+    # it - and deciding up front meant those downloads failed outright even though
+    # credentials were available.
+    _gmail = {}
 
-        gmail_reader = GmailReader(load_credentials(client_secret, token_path))
+    def get_gmail_reader():
+        if "reader" not in _gmail:
+            from .gmail import GmailReader, load_credentials
+
+            log.info("Album needs an emailed link, authorising Gmail")
+            _gmail["reader"] = GmailReader(load_credentials(client_secret, token_path))
+        return _gmail["reader"]
 
     done, downloaded_bytes = [], 0
     budget = int(max_gb * 1024**3) if max_gb else None
@@ -949,7 +960,7 @@ def do_free_sync(
             break
         try:
             path = acquire_album(
-                album, specs[label_name], config, gmail_reader, temp_dir
+                album, specs[label_name], config, get_gmail_reader, temp_dir
             )
         except (AcquireError, ValueError) as e:
             message = str(e)

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -71,6 +71,10 @@ class FreeState:
         # spotted during the first full scan) would fall behind the cutoff on the next
         # run and never be seen again.
         self.pending = {}
+        # Items that can never be downloaded in the configured format - a physical-only
+        # release with no digital files, for instance. Without this they stay pending and
+        # are retried on every run forever.
+        self.skipped = {}
         self.load()
 
     def load(self):
@@ -88,9 +92,10 @@ class FreeState:
         # file unreadable, which would silently reset every label to a first full scan.
         self.items = self._int_keyed(data.get("items"), "items")
         self.pending = self._int_keyed(data.get("pending"), "pending")
+        self.skipped = self._int_keyed(data.get("skipped"), "skipped")
         log.info(
             f"Loaded state: {len(self.labels)} labels, {len(self.items)} cached albums, "
-            f"{len(self.pending)} pending from {self.path}"
+            f"{len(self.pending)} pending, {len(self.skipped)} skipped from {self.path}"
         )
 
     @staticmethod
@@ -117,6 +122,7 @@ class FreeState:
                     "labels": self.labels,
                     "items": {str(k): v for k, v in self.items.items()},
                     "pending": {str(k): v for k, v in self.pending.items()},
+                    "skipped": {str(k): v for k, v in self.skipped.items()},
                 },
                 f,
                 indent=1,
@@ -476,6 +482,12 @@ def scan_label(api, spec, state, media_dir, full_scan=False):
             state.pending.pop(album.item_id, None)
             results.append((album, STATUS_NOT_FREE, f"{album.price} {album.currency}"))
             continue
+        if album.item_id in state.skipped:
+            state.pending.pop(album.item_id, None)
+            results.append(
+                (album, STATUS_ERROR, f"skipped: {state.skipped[album.item_id]}")
+            )
+            continue
         local, ambiguous = index.find(album)
         if local:
             state.pending.pop(album.item_id, None)
@@ -762,6 +774,8 @@ def pending_albums(config, state, api=None):
     specs = {spec.name: spec for spec in config.labels}
     out = []
     for item_id, label_name in sorted(state.pending.items()):
+        if item_id in state.skipped:
+            continue
         spec = specs.get(label_name)
         if not spec:
             log.warning(
@@ -938,8 +952,23 @@ def do_free_sync(
                 album, specs[label_name], config, gmail_reader, temp_dir
             )
         except (AcquireError, ValueError) as e:
+            message = str(e)
+            permanent = (
+                "does not contain requested encoding" in message
+                or "No download available" in message
+            )
             log.error(f'Failed to download "{album.title}": {e}')
-            done.append((album, None, str(e)))
+            if permanent:
+                # Retrying this every run would never succeed: the release has no
+                # digital files in the requested format (physical-only items, for one).
+                log.warning(
+                    f'Marking "{album.title}" as permanently skipped; it offers no '
+                    f"{config.media_format} download"
+                )
+                state.skipped[album.item_id] = f"no {config.media_format} download"
+                state.pending.pop(album.item_id, None)
+                state.save()
+            done.append((album, None, message))
             continue
         size = sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
         downloaded_bytes += size

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -1003,9 +1003,12 @@ def do_free_sync(
             # rest of the run; anything not classified as permanent stays pending and is
             # retried on the next run.
             message = str(e)
-            permanent = (
-                "does not contain requested encoding" in message
-                or "No download available" in message
+            # A release that offers other formats but not the requested one will never
+            # gain it (a cassette has no FLAC), so that is permanent. A release that
+            # offers no downloads at all is "currently unavailable" and a label can
+            # re-enable it, so treat that as retryable via the failure counter instead.
+            permanent = ("does not contain requested encoding" in message) or (
+                "No download available" in message
             )
             log.error(f'Failed to download "{album.title}": {e}')
             attempts = state.failures.get(album.item_id, 0) + 1

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -773,6 +773,29 @@ def backfill_ids(config, state, only_labels=None, apply=False, output=None):
     return totals
 
 
+def _fetch_details_any_type(api, band_id, item_id, hint, label_name):
+    """Fetch tralbum_details, trying both item types before giving up.
+
+    An id resolves under exactly one type - a standalone track only answers as "t", an
+    album only as "a" - and querying the wrong one returns an empty payload that looks
+    like a delisted item. So try the hinted type first, then the other, and only treat it
+    as gone when neither yields details.
+    """
+    order = ["t", "a"] if hint in ("t", "track") else ["a", "t"]
+    for item_type in order:
+        try:
+            album = album_from_details(
+                api.tralbum_details(band_id, item_id, item_type),
+                label_name=label_name,
+            )
+        except LabelError as e:
+            log.warning(f"Details fetch for {item_id} as {item_type!r} failed: {e}")
+            continue
+        if album.item_id is not None and album.title:
+            return album
+    return None
+
+
 def pending_albums(config, state, api=None):
     """Rebuild FreeAlbum objects for everything queued, without re-scanning.
 
@@ -799,11 +822,10 @@ def pending_albums(config, state, api=None):
                 api = BandcampAPI(delay=config.request_delay)
             band_id = spec.band_id or state.label(spec.name).get("band_id")
             log.info(f"Cache predates URL storage, fetching details for {item_id}")
-            album = album_from_details(
-                api.tralbum_details(band_id, item_id, (cached.get("item_type") or "a")),
-                label_name=label_name,
+            album = _fetch_details_any_type(
+                api, band_id, item_id, cached.get("item_type"), label_name
             )
-            if album.item_id is None or not album.title:
+            if album is None or album.item_id is None or not album.title:
                 # Delisted or otherwise gone. Record it so the queue drains instead of
                 # carrying an item that can never be fetched.
                 log.warning(

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -1,0 +1,857 @@
+"""
+Scanning and reporting for free / pay-what-you-want label downloads.
+
+Scan strategy, per label:
+
+  * The first time a label is scanned there is no date cutoff, so the whole back catalogue
+    is examined. This catches free albums missed during manual downloading.
+  * Afterwards the cutoff is the newest release date already examined, recorded in state.
+    An explicit "since" in the config overrides it, --full-scan bypasses it, and the
+    newest local file time is used only as a fallback for a label adopted with existing
+    files but no recorded scan.
+  * Albums found wanted but not yet downloaded are kept pending and reconsidered on every
+    run regardless of the cutoff, so nothing is lost to a --limit run or a failure.
+
+Album classifications are cached by item_id so a label's back catalogue is only fetched
+once. Prices can change, so entries that were not free are re-checked periodically.
+"""
+
+import json
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .labelconfig import MAX_PRICE, matches, prefilter
+from .labels import (
+    BandcampAPI,
+    FreeAlbum,
+    LabelError,
+    RateLimited,
+    album_from_details,
+    list_discography,
+)
+from .logger import get_logger
+from .media import LocalMedia
+
+log = get_logger("freesync")
+
+ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
+# Non-free albums are re-checked after this many days in case a price has changed.
+RECHECK_DAYS = 90
+
+STATUS_DOWNLOADED = "downloaded"
+STATUS_WANTED = "wanted"
+STATUS_NOT_FREE = "not-free"
+STATUS_FILTERED = "filtered"
+STATUS_ERROR = "error"
+# Title matches more than one local directory, so neither downloading nor skipping is
+# safe. Resolved by writing bandcamp_item_id.txt files.
+STATUS_AMBIGUOUS = "ambiguous"
+ALL_STATUSES = (
+    STATUS_WANTED,
+    STATUS_DOWNLOADED,
+    STATUS_AMBIGUOUS,
+    STATUS_NOT_FREE,
+    STATUS_FILTERED,
+    STATUS_ERROR,
+)
+
+
+class FreeState:
+    """Persistent scan state and album classification cache."""
+
+    def __init__(self, state_path):
+        self.path = Path(state_path)
+        self.labels = {}
+        self.items = {}
+        # Albums classified as wanted but not yet downloaded. These are always
+        # reconsidered regardless of the date cutoff, otherwise an album that was found
+        # but not fetched (a --limit run, a failed download, or simply an older release
+        # spotted during the first full scan) would fall behind the cutoff on the next
+        # run and never be seen again.
+        self.pending = {}
+        self.load()
+
+    def load(self):
+        if not self.path.is_file():
+            log.info(f"No existing state file, starting fresh: {self.path}")
+            return
+        try:
+            with open(self.path, "rt", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception as e:
+            log.warning(f"Could not read state file {self.path}: {e}, starting fresh")
+            return
+        self.labels = data.get("labels") or {}
+        # Keys are coerced defensively: a malformed entry must not make the whole state
+        # file unreadable, which would silently reset every label to a first full scan.
+        self.items = self._int_keyed(data.get("items"), "items")
+        self.pending = self._int_keyed(data.get("pending"), "pending")
+        log.info(
+            f"Loaded state: {len(self.labels)} labels, {len(self.items)} cached albums, "
+            f"{len(self.pending)} pending from {self.path}"
+        )
+
+    @staticmethod
+    def _int_keyed(mapping, what):
+        out = {}
+        dropped = 0
+        for key, value in (mapping or {}).items():
+            try:
+                out[int(key)] = value
+            except (TypeError, ValueError):
+                dropped += 1
+        if dropped:
+            log.warning(f"Dropped {dropped} malformed {what} key(s) from the state file")
+        return out
+
+    def save(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        with open(tmp, "wt", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "labels": self.labels,
+                    "items": {str(k): v for k, v in self.items.items()},
+                    "pending": {str(k): v for k, v in self.pending.items()},
+                },
+                f,
+                indent=1,
+                sort_keys=True,
+            )
+        tmp.replace(self.path)
+        log.info(f"Wrote state to {self.path}")
+
+    def label(self, name):
+        return self.labels.setdefault(name, {})
+
+    def has_scanned(self, name):
+        return bool(self.labels.get(name, {}).get("first_scan_done"))
+
+    def cached(self, item_id):
+        """Return a cached classification, or None if absent or due for re-check."""
+        entry = self.items.get(item_id)
+        if not entry:
+            return None
+        if entry.get("is_free"):
+            return entry
+        checked = entry.get("checked_ts", 0)
+        if time.time() - checked > RECHECK_DAYS * 86400:
+            return None
+        return entry
+
+    def cache(self, album, is_free):
+        if album.item_id is None:
+            # A details response without an id is unusable: it cannot be correlated to a
+            # download, and storing it under a None key corrupts the state file.
+            log.warning(f"Refusing to cache an album with no item id: {album.title!r}")
+            return
+        self.items[album.item_id] = {
+            "title": album.title,
+            "artist": album.artist,
+            "url": album.url,
+            "price": album.price,
+            "is_free": is_free,
+            "require_email": album.require_email,
+            "num_tracks": album.num_tracks,
+            "checked_ts": int(time.time()),
+        }
+
+
+class LabelIndex:
+    """Index of what is already downloaded for one label.
+
+    Scoped to the label's own directory rather than the whole media tree: it is much
+    faster, and it avoids matching an album against a same-titled release by a different
+    artist elsewhere in the collection.
+    """
+
+    def __init__(self, media_dir, label_name):
+        self.dir = Path(media_dir) / label_name
+        self.by_id = {}
+        # Titles are NOT unique: The Audio Atelier has four distinct releases all called
+        # "Best of 2025 (Free Download)". Keyed by a plain dict, later directories would
+        # overwrite earlier ones and every one of those releases would match whichever
+        # survived - reporting albums as downloaded that are not on disk at all.
+        self.by_title = {}
+        self._index()
+
+    @property
+    def ids(self):
+        return set(self.by_id)
+
+    def _index(self):
+        if not self.dir.is_dir():
+            log.info(f"No local directory yet for label: {self.dir}")
+            return
+        for child in sorted(p for p in self.dir.iterdir() if p.is_dir()):
+            id_file = child / ITEM_INDEX_FILENAME
+            if id_file.is_file():
+                try:
+                    self.by_id[int(id_file.read_text().strip())] = child.name
+                except (ValueError, OSError) as e:
+                    log.warning(f"Could not read {id_file}: {e}")
+            title = child.name.split(" - ", 1)[1] if " - " in child.name else child.name
+            self.by_title.setdefault(LocalMedia._normalize_for_match(title), []).append(
+                child.name
+            )
+        ambiguous = sum(1 for v in self.by_title.values() if len(v) > 1)
+        log.info(
+            f"Indexed {self.dir}: {len(self.by_id)} with ids, "
+            f"{sum(len(v) for v in self.by_title.values())} directories"
+            + (f", {ambiguous} title collision(s)" if ambiguous else "")
+        )
+
+    def find(self, album):
+        """Locate an album locally.
+
+        Returns (directory_name, ambiguous). An id match is authoritative. A title match
+        is only trusted when exactly one directory carries that title; otherwise the
+        result is ambiguous and the caller must not assume either way, because guessing
+        wrong either re-downloads something already held or silently skips something
+        missing. Writing bandcamp_item_id.txt files resolves it permanently.
+        """
+        if album.item_id in self.by_id:
+            return self.by_id[album.item_id], False
+        candidates = self.by_title.get(LocalMedia._normalize_for_match(album.title), [])
+        # Directories already claimed by a different item id are not candidates.
+        claimed = {name for iid, name in self.by_id.items() if iid != album.item_id}
+        unclaimed = [c for c in candidates if c not in claimed]
+        if len(unclaimed) == 1:
+            return unclaimed[0], False
+        if len(unclaimed) > 1:
+            return None, True
+        return None, False
+
+    def newest_mtime(self):
+        """Modification time of the newest file in the label directory, or None.
+
+        Used as the default scan cutoff: it approximates when this label was last
+        downloaded, so releases older than it are already accounted for.
+        """
+        if not self.dir.is_dir():
+            return None
+        newest = 0.0
+        for path in self.dir.rglob("*"):
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                continue
+            newest = max(newest, mtime)
+        if not newest:
+            return None
+        return datetime.fromtimestamp(newest, tz=timezone.utc)
+
+
+# Words a label may bolt onto a title without it being a different release. Catalogue
+# numbers ("RDC 26") are matched separately by CATALOGUE_REGEX.
+NOISE_TOKENS = {
+    "free",
+    "download",
+    "downloads",
+    "name",
+    "your",
+    "price",
+    "nyp",
+    "bonus",
+    "digital",
+    "edition",
+    "remaster",
+    "remastered",
+}
+# Whole phrases that survive normalisation as a single run of letters, because
+# _normalize_for_match drops punctuation without inserting a space: "name-your-price"
+# becomes "nameyourprice".
+NOISE_PHRASES = {
+    "free",
+    "freedownload",
+    "nameyourprice",
+    "nyp",
+    "bonus",
+    "digital",
+    "remaster",
+    "remastered",
+}
+CATALOGUE_REGEX = re.compile(r"^([a-z]{2,6})\s*\d{1,4}$")
+# Words that make a trailing number a volume marker rather than a catalogue number.
+VOLUME_WORDS = {"vol", "volume", "pt", "part", "no", "chapter", "book", "series"}
+# A trailing roman numeral or bare number usually marks a genuinely different volume
+# (Trip to Poland vs Trip to Poland II), so those must never be called duplicates.
+SEQUEL_REGEX = re.compile(r"^(i{1,3}|iv|v|vi{1,3}|ix|x{1,3}|\d{1,3})$")
+
+
+def _looks_like_same_release(shorter, longer):
+    """True when `longer` is `shorter` plus only decorative extra words.
+
+    Deliberately conservative: a trailing volume marker means a genuinely different
+    release, and treating those as duplicates would merge distinct albums and lose
+    music. "Trip to Poland" and "Trip to Poland II" must never match.
+    """
+    if not shorter or not longer.startswith(shorter):
+        return False
+    remainder = longer[len(shorter) :].strip()
+    if not remainder:
+        return False
+
+    # Catalogue numbers first: the digits in "rdc 26" would otherwise look like a sequel
+    # number. Guard against "vol 2" and friends, which really are different releases.
+    catalogue = CATALOGUE_REGEX.match(remainder)
+    if catalogue and catalogue.group(1) not in VOLUME_WORDS:
+        return True
+
+    tokens = [t for t in remainder.split() if t]
+    if not tokens:
+        return False
+    if any(SEQUEL_REGEX.match(t) for t in tokens):
+        return False
+    if remainder.replace(" ", "") in NOISE_PHRASES:
+        return True
+    return all(t in NOISE_TOKENS for t in tokens)
+
+
+def find_duplicate_dirs(media_dir, label_name):
+    """Return [(kept, candidate)] directory-name pairs that look like the same release.
+
+    Labels rename releases after the fact - adding a catalogue number, dropping a
+    "(free!)" suffix - which defeats exact title matching and leaves two copies on disk.
+    This only reports; deciding which to remove is a judgement call.
+    """
+    label_dir = Path(media_dir) / label_name
+    if not label_dir.is_dir():
+        return []
+    titles = {}
+    for child in sorted(p for p in label_dir.iterdir() if p.is_dir()):
+        title = child.name.split(" - ", 1)[1] if " - " in child.name else child.name
+        titles[child.name] = LocalMedia._normalize_for_match(title)
+
+    pairs = []
+    names = list(titles)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            na, nb = titles[a], titles[b]
+            if na == nb:
+                pairs.append((a, b))
+            elif _looks_like_same_release(na, nb):
+                pairs.append((a, b))
+            elif _looks_like_same_release(nb, na):
+                pairs.append((b, a))
+    return pairs
+
+
+def report_duplicates(config, only_labels=None, output=None):
+    """Print likely duplicate directories for every configured label. Local only."""
+    total = 0
+    for spec in config.labels:
+        if only_labels and spec.name not in only_labels:
+            continue
+        pairs = find_duplicate_dirs(config.media_dir, spec.name)
+        if not pairs:
+            continue
+        _safe_print("", output)
+        _safe_print(f"=== {spec.name} ===", output)
+        for a, b in pairs:
+            total += 1
+            _safe_print("  possible duplicate:", output)
+            _safe_print(f"    {a}", output)
+            _safe_print(f"    {b}", output)
+    _safe_print("", output)
+    _safe_print(f"{total} possible duplicate pair(s) found", output)
+    return total
+
+
+def resolve_cutoff(spec, state, index, full_scan):
+    """Decide the release-date cutoff for a label scan. Returns (cutoff, why).
+
+    The cutoff is the newest *release date already examined*, recorded in state - not the
+    newest local file time. Those differ, and using file time is actively wrong: it
+    updates whenever anything is downloaded, so fetching a new release would push the
+    cutoff past older releases that had not been fetched yet, hiding them permanently.
+    File time is only a fallback for a label adopted with existing local files but no
+    recorded scan.
+    """
+    if full_scan:
+        return None, "full scan requested"
+    if not state.has_scanned(spec.name):
+        return None, "first scan of this label, examining the full back catalogue"
+    if spec.since:
+        return spec.since, f"configured since: {spec.since:%Y-%m-%d}"
+    seen = state.label(spec.name).get("newest_release_seen")
+    if seen:
+        cutoff = datetime.fromtimestamp(seen, tz=timezone.utc)
+        return cutoff, f"newest release already examined: {cutoff:%Y-%m-%d}"
+    mtime = index.newest_mtime()
+    if mtime:
+        return mtime, f"newest local file: {mtime:%Y-%m-%d}"
+    return None, "no local files to date from, examining everything"
+
+
+def scan_label(api, spec, state, media_dir, full_scan=False):
+    """Scan one label.
+
+    Returns (results, index, meta) where results is a list of
+    (album_or_stub, status, detail) tuples and meta describes what the scan considered.
+    """
+    log.info(f'Scanning label "{spec.name}" ({spec.url})')
+    index = LabelIndex(media_dir, spec.name)
+
+    band_id = spec.band_id or state.label(spec.name).get("band_id")
+    if not band_id:
+        band_id = api.resolve_band_id(spec.url)
+        log.info(f'Resolved band_id for "{spec.name}": {band_id}')
+    state.label(spec.name)["band_id"] = band_id
+
+    cutoff, why = resolve_cutoff(spec, state, index, full_scan)
+    log.info(f'Cutoff for "{spec.name}": {why}')
+
+    discography = list_discography(api, band_id)
+    log.info(f'"{spec.name}" discography: {len(discography)} items')
+
+    considered = []
+    skipped_cutoff = skipped_prefilter = 0
+    for entry in discography:
+        if entry.item_id is None:
+            continue
+        # Pending albums are always reconsidered, however old, until downloaded.
+        is_pending = entry.item_id in state.pending
+        if (
+            cutoff
+            and entry.release_date
+            and entry.release_date < cutoff
+            and not is_pending
+        ):
+            skipped_cutoff += 1
+            continue
+        # Reject on the cheap metadata before spending a per-album request.
+        keep, _reason = prefilter(entry, spec.match)
+        if not keep:
+            skipped_prefilter += 1
+            continue
+        considered.append(entry)
+    log.info(
+        f'"{spec.name}": {len(considered)} of {len(discography)} items to fetch '
+        f"({skipped_cutoff} before cutoff, {skipped_prefilter} rejected by prefilter)"
+    )
+
+    results = []
+    errors = 0
+    for entry in considered:
+        item_id, item_type, title = entry.item_id, entry.item_type, entry.title
+        cached = state.cached(item_id)
+        if cached is not None and not cached.get("is_free"):
+            # Same reasoning as the freshly-classified not-free branch below: a pending
+            # entry must not survive a not-free verdict, or it bypasses the cutoff and
+            # is reconsidered forever.
+            state.pending.pop(item_id, None)
+            results.append(
+                (_Stub(item_id, title, cached), STATUS_NOT_FREE, "cached: not free")
+            )
+            continue
+        try:
+            details = api.tralbum_details(band_id, item_id, item_type)
+            album = album_from_details(details, label_name=spec.name)
+        except RateLimited:
+            # Abort rather than marking every remaining album as failed. State is not
+            # marked scanned, so the next run resumes the full sweep.
+            log.error(
+                f'Rate limited while scanning "{spec.name}" after '
+                f"{len(results)}/{len(considered)} albums. Increase request_delay "
+                f"and re-run; already-classified albums are cached."
+            )
+            raise
+        except LabelError as e:
+            log.warning(f"Failed to fetch details for {item_id} ({title}): {e}")
+            results.append((_Stub(item_id, title, {}), STATUS_ERROR, str(e)))
+            errors += 1
+            continue
+
+        state.cache(album, album.is_free)
+
+        if not album.is_free or album.price > MAX_PRICE:
+            # Clear any pending entry: an album can stop being free (labels re-price
+            # them) or turn out never to have been downloadable. Leaving it pending
+            # would make it bypass the cutoff and be retried on every future run.
+            state.pending.pop(album.item_id, None)
+            results.append((album, STATUS_NOT_FREE, f"{album.price} {album.currency}"))
+            continue
+        local, ambiguous = index.find(album)
+        if local:
+            state.pending.pop(album.item_id, None)
+            results.append((album, STATUS_DOWNLOADED, local))
+            continue
+        if ambiguous:
+            state.pending.pop(album.item_id, None)
+            results.append(
+                (
+                    album,
+                    STATUS_AMBIGUOUS,
+                    "title matches several local directories; write "
+                    "bandcamp_item_id.txt files to disambiguate",
+                )
+            )
+            continue
+        wanted, reason = matches(album, spec.match)
+        if wanted:
+            state.pending[album.item_id] = spec.name
+        else:
+            state.pending.pop(album.item_id, None)
+        results.append((album, STATUS_WANTED if wanted else STATUS_FILTERED, reason))
+
+    state.label(spec.name)["last_scan_ts"] = int(time.time())
+    # Only record the label as fully scanned when nothing failed. Otherwise the next run
+    # would apply a cutoff and silently skip whatever was missed.
+    if errors:
+        log.warning(
+            f'"{spec.name}" had {errors} failed lookups; not marking as fully scanned '
+            f"so the next run re-examines the full catalogue"
+        )
+    else:
+        state.label(spec.name)["first_scan_done"] = True
+        # Record how far we got, so the next run only examines newer releases. Only on a
+        # clean scan: recording it after failures would skip whatever was missed.
+        newest = max(
+            (e.release_date for e in discography if e.release_date), default=None
+        )
+        if newest:
+            state.label(spec.name)["newest_release_seen"] = int(newest.timestamp())
+    meta = {
+        "cutoff_reason": why,
+        "total": len(discography),
+        "fetched": len(considered),
+        "skipped_cutoff": skipped_cutoff,
+        "skipped_prefilter": skipped_prefilter,
+    }
+    return results, index, meta
+
+
+class _Stub:
+    """Minimal stand-in for a FreeAlbum when only cached or partial data is available."""
+
+    def __init__(self, item_id, title, cached):
+        self.item_id = item_id
+        self.title = title
+        self.artist = cached.get("artist", "")
+        self.price = cached.get("price", 0.0)
+        self.num_tracks = cached.get("num_tracks", 0)
+        self.require_email = cached.get("require_email", False)
+        self.currency = ""
+        self.url = ""
+        self.release_date = None
+
+
+def _safe_print(text, output=None):
+    """Print guarding against Windows console encoding errors on unicode metadata."""
+    stream = output
+    try:
+        if stream:
+            stream.write(text + "\n")
+        else:
+            print(text)
+    except UnicodeEncodeError:
+        cleaned = text.encode("ascii", errors="replace").decode("ascii")
+        if stream:
+            stream.write(cleaned + "\n")
+        else:
+            print(cleaned)
+
+
+def print_report(all_results, output=None, meta=None):
+    """Print a per-label summary and the list of wanted albums."""
+    meta = meta or {}
+    totals = dict.fromkeys(ALL_STATUSES, 0)
+    for label_name, results in all_results.items():
+        counts = dict.fromkeys(ALL_STATUSES, 0)
+        for _album, status, _detail in results:
+            counts[status] = counts.get(status, 0) + 1
+            totals[status] = totals.get(status, 0) + 1
+        _safe_print("", output)
+        _safe_print(f"=== {label_name} ===", output)
+        info = meta.get(label_name)
+        if info:
+            # Without this an incremental run prints all zeros, which reads as a failure
+            # rather than "nothing new since last time".
+            _safe_print(f"  cutoff: {info['cutoff_reason']}", output)
+            _safe_print(
+                f"  {info['total']} releases, {info['fetched']} examined "
+                f"({info['skipped_cutoff']} older than cutoff, "
+                f"{info['skipped_prefilter']} filtered on artist/title)",
+                output,
+            )
+        summary = "  " + "  ".join(f"{k}={v}" for k, v in counts.items() if v)
+        _safe_print(summary if summary.strip() else "  nothing new", output)
+        for album, status, detail in results:
+            if status == STATUS_AMBIGUOUS:
+                _safe_print(f"  AMBIGUOUS {album.artist} - {album.title}", output)
+                _safe_print(f"          {album.url}", output)
+                _safe_print(f"          {detail}", output)
+                continue
+            if status != STATUS_WANTED:
+                continue
+            email = " [needs email]" if getattr(album, "require_email", False) else ""
+            date = ""
+            if getattr(album, "release_date", None):
+                date = f" {album.release_date:%Y-%m-%d}"
+            _safe_print(
+                f"  WANTED{date} {album.artist} - {album.title} "
+                f"({album.num_tracks} tracks){email}",
+                output,
+            )
+            _safe_print(f"          {album.url}", output)
+            _safe_print(f"          matched: {detail}", output)
+
+    _safe_print("", output)
+    _safe_print("=== totals ===", output)
+    for status in ALL_STATUSES:
+        _safe_print(f"  {status:<12} {totals.get(status, 0)}", output)
+    return totals
+
+
+def scan_all(config, state, full_scan=False, only_labels=None):
+    """Scan every enabled label. Returns ({label_name: results}, {label_name: meta})."""
+    api = BandcampAPI(delay=config.request_delay)
+    all_results = {}
+    all_meta = {}
+    for spec in config.enabled_labels:
+        if only_labels and spec.name not in only_labels:
+            continue
+        try:
+            results, _index, meta = scan_label(
+                api, spec, state, config.media_dir, full_scan
+            )
+            all_meta[spec.name] = meta
+        except RateLimited as e:
+            # Persist whatever was classified before giving up, so a re-run resumes
+            # cheaply rather than re-fetching everything.
+            all_results[spec.name] = [(_Stub(0, "", {}), STATUS_ERROR, str(e))]
+            state.save()
+            log.error("Aborting scan: rate limited by bandcamp.com")
+            break
+        except LabelError as e:
+            log.error(f'Failed to scan label "{spec.name}": {e}')
+            all_results[spec.name] = [(_Stub(0, "", {}), STATUS_ERROR, str(e))]
+            state.save()
+            continue
+        except Exception as e:
+            # One label's unexpected failure must not discard every other label's work.
+            log.exception(f'Unexpected error scanning label "{spec.name}": {e}')
+            all_results[spec.name] = [(_Stub(0, "", {}), STATUS_ERROR, repr(e))]
+            state.save()
+            continue
+        all_results[spec.name] = results
+        # Save after every label, not just at the end: a full sweep is many minutes of
+        # requests and a crash partway through should not throw away the whole run.
+        state.save()
+    state.save()
+    return all_results, all_meta
+
+
+def generate_free_report(config, state_path, full_scan=False, only_labels=None):
+    """Scan all enabled labels and print a report. Makes no changes to the media tree."""
+    if not config.media_dir:
+        raise ValueError("No media_dir configured under defaults in the config file")
+    state = FreeState(state_path)
+    all_results, all_meta = scan_all(config, state, full_scan, only_labels)
+    print_report(all_results, meta=all_meta)
+    return all_results
+
+
+def pending_albums(config, state, api=None):
+    """Rebuild FreeAlbum objects for everything queued, without re-scanning.
+
+    A bounded run (--limit / --max-gb) leaves work queued, and re-scanning every label
+    just to download it again costs hundreds of API calls for no new information. The
+    pending items were already classified and matched, so the cached metadata is enough.
+    Anything cached before the cache stored URLs is re-fetched individually.
+    """
+    specs = {spec.name: spec for spec in config.labels}
+    out = []
+    for item_id, label_name in sorted(state.pending.items()):
+        spec = specs.get(label_name)
+        if not spec:
+            log.warning(f"Pending item {item_id} belongs to unconfigured label {label_name!r}")
+            continue
+        cached = state.items.get(item_id) or {}
+        url = cached.get("url")
+        if not url:
+            if api is None:
+                api = BandcampAPI(delay=config.request_delay)
+            band_id = spec.band_id or state.label(spec.name).get("band_id")
+            log.info(f"Cache predates URL storage, fetching details for {item_id}")
+            album = album_from_details(
+                api.tralbum_details(band_id, item_id, "a"), label_name=label_name
+            )
+            if album.item_id is None or not album.title:
+                log.warning(
+                    f"Skipping pending item {item_id}: bandcamp returned no usable "
+                    f"details for it"
+                )
+                continue
+            state.cache(album, album.is_free)
+        else:
+            album = FreeAlbum(
+                item_id=item_id,
+                title=cached.get("title") or "",
+                artist=cached.get("artist") or "",
+                url=url,
+                price=cached.get("price") or 0.0,
+                is_set_price=False,
+                require_email=bool(cached.get("require_email")),
+                free_download=False,
+                num_tracks=int(cached.get("num_tracks") or 0),
+                label_name=label_name,
+            )
+        out.append((label_name, album))
+    return out
+
+
+def do_repair(config, state_path, item_id, client_secret=None, token_path=None):
+    """Re-fetch one album and add only the files missing from its local directory.
+
+    For albums a label extended after the original download. Bandcamp does not serve
+    individual tracks of a compilation, so the whole archive has to come down even for a
+    single missing file, but nothing already present is rewritten.
+    """
+    from .freedownload import repair_album
+
+    state = FreeState(state_path)
+    if not state.items.get(item_id):
+        raise ValueError(
+            f"Item {item_id} is not in the scan state; run --report first so it is known"
+        )
+
+    specs = {spec.name: spec for spec in config.labels}
+    api = BandcampAPI(delay=config.request_delay)
+    label_name = state.pending.get(item_id)
+    if not label_name:
+        # Not pending (it counts as downloaded), so find which label lists it.
+        for spec in config.labels:
+            band_id = spec.band_id or state.label(spec.name).get("band_id")
+            if not band_id:
+                continue
+            if any(e.item_id == item_id for e in list_discography(api, band_id)):
+                label_name = spec.name
+                break
+    if not label_name or label_name not in specs:
+        raise ValueError(f"Could not find a configured label owning item {item_id}")
+
+    spec = specs[label_name]
+    band_id = spec.band_id or state.label(spec.name).get("band_id")
+    album = album_from_details(
+        api.tralbum_details(band_id, item_id, "a"), label_name=label_name
+    )
+
+    index = LabelIndex(config.media_dir, label_name)
+    local_name, ambiguous = index.find(album)
+    if ambiguous:
+        raise ValueError(
+            f"{album.title!r} matches several directories under {label_name}; "
+            f"write bandcamp_item_id.txt files to disambiguate before repairing"
+        )
+    if not local_name:
+        raise ValueError(
+            f"No local directory found for {album.title!r} under {label_name}; "
+            f"use a normal download run rather than --repair"
+        )
+    local_path = Path(config.media_dir) / label_name / local_name
+    existing = len([p for p in local_path.iterdir() if p.is_file()])
+    log.info(
+        f"Repairing {album.title!r} at {local_path} "
+        f"({existing} local files, {album.num_tracks} remote tracks)"
+    )
+
+    gmail_reader = None
+    if album.require_email:
+        from .gmail import GmailReader, load_credentials
+
+        gmail_reader = GmailReader(load_credentials(client_secret, token_path))
+
+    added = repair_album(album, spec, config, local_path, gmail_reader)
+    if added:
+        log.info(f"Added {len(added)} file(s):")
+        for name in added:
+            log.info(f"  {name}")
+    else:
+        log.info("Nothing was missing; no files added")
+    return added
+
+
+def do_free_sync(
+    config,
+    state_path,
+    full_scan=False,
+    only_labels=None,
+    limit=None,
+    max_gb=None,
+    temp_dir=None,
+    client_secret=None,
+    token_path=None,
+    pending_only=False,
+):
+    """Scan, then download everything wanted. Returns a list of (album, path or error)."""
+    from .freedownload import AcquireError, acquire_album
+
+    if not config.media_dir:
+        raise ValueError("No media_dir configured under defaults in the config file")
+    state = FreeState(state_path)
+    specs = {spec.name: spec for spec in config.labels}
+    if pending_only:
+        log.info("Downloading the queued backlog without re-scanning")
+        wanted = pending_albums(config, state)
+        if only_labels:
+            wanted = [(lab, a) for lab, a in wanted if lab in only_labels]
+    else:
+        all_results, all_meta = scan_all(config, state, full_scan, only_labels)
+        print_report(all_results, meta=all_meta)
+        wanted = [
+            (label_name, album)
+            for label_name, results in all_results.items()
+            for album, status, _detail in results
+            if status == STATUS_WANTED
+        ]
+    if not wanted:
+        log.info("Nothing to download")
+        return []
+    if limit:
+        if len(wanted) > limit:
+            log.warning(
+                f"{len(wanted)} albums wanted, limiting this run to {limit}; "
+                f"re-run to fetch the rest"
+            )
+        wanted = wanted[:limit]
+
+    # Only build a Gmail reader if something actually needs one.
+    gmail_reader = None
+    if any(getattr(album, "require_email", False) for _label, album in wanted):
+        from .gmail import GmailReader, load_credentials
+
+        gmail_reader = GmailReader(load_credentials(client_secret, token_path))
+
+    done, downloaded_bytes = [], 0
+    budget = int(max_gb * 1024**3) if max_gb else None
+    for label_name, album in wanted:
+        if budget and downloaded_bytes >= budget:
+            log.warning(
+                f"Reached the {max_gb} GB budget for this run, stopping. "
+                f"Re-run to continue."
+            )
+            break
+        try:
+            path = acquire_album(
+                album, specs[label_name], config, gmail_reader, temp_dir
+            )
+        except (AcquireError, ValueError) as e:
+            log.error(f'Failed to download "{album.title}": {e}')
+            done.append((album, None, str(e)))
+            continue
+        size = sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+        downloaded_bytes += size
+        state.pending.pop(album.item_id, None)
+        state.save()
+        done.append((album, path, None))
+        log.info(f'Downloaded "{album.title}" -> {path} ({size / 1024**3:.2f} GB)')
+
+    ok = sum(1 for _a, p, _e in done if p)
+    log.info(
+        f"Downloaded {ok}/{len(done)} albums, {downloaded_bytes / 1024**3:.2f} GB total"
+    )
+    return done

--- a/bandcampsync/freesync.py
+++ b/bandcampsync/freesync.py
@@ -103,7 +103,9 @@ class FreeState:
             except (TypeError, ValueError):
                 dropped += 1
         if dropped:
-            log.warning(f"Dropped {dropped} malformed {what} key(s) from the state file")
+            log.warning(
+                f"Dropped {dropped} malformed {what} key(s) from the state file"
+            )
         return out
 
     def save(self):
@@ -655,6 +657,100 @@ def generate_free_report(config, state_path, full_scan=False, only_labels=None):
     return all_results
 
 
+def backfill_ids(config, state, only_labels=None, apply=False, output=None):
+    """Write bandcamp_item_id.txt into local directories that lack one.
+
+    Dedup falls back to matching normalised titles when no id file exists, and that is
+    fragile in practice: labels rename releases, add catalogue numbers, drop "(free!)"
+    suffixes, and reuse titles across different releases. Stamping the item id makes
+    matching exact and permanent.
+
+    Cheap: one band_details request per label, no per-album lookups. Only writes where
+    the mapping is unambiguous in both directions - exactly one local directory and
+    exactly one remote release share the title.
+    """
+    api = BandcampAPI(delay=config.request_delay)
+    totals = {"written": 0, "have": 0, "ambiguous": 0, "unmatched": 0}
+
+    for spec in config.labels:
+        if only_labels and spec.name not in only_labels:
+            continue
+        index = LabelIndex(config.media_dir, spec.name)
+        if not index.dir.is_dir():
+            continue
+        band_id = spec.band_id or state.label(spec.name).get("band_id")
+        if not band_id:
+            try:
+                band_id = api.resolve_band_id(spec.url)
+            except LabelError as e:
+                _safe_print(f"  {spec.name}: cannot resolve band id: {e}", output)
+                continue
+
+        try:
+            disco = list_discography(api, band_id)
+        except LabelError as e:
+            _safe_print(f"  {spec.name}: discography failed: {e}", output)
+            continue
+
+        remote = {}
+        for entry in disco:
+            remote.setdefault(LocalMedia._normalize_for_match(entry.title), []).append(
+                entry
+            )
+
+        rows = []
+        for key, dirs in sorted(index.by_title.items()):
+            for dirname in dirs:
+                path = index.dir / dirname
+                if (path / ITEM_INDEX_FILENAME).is_file():
+                    totals["have"] += 1
+                    continue
+                candidates = remote.get(key, [])
+                if len(candidates) == 1 and len(dirs) == 1:
+                    rows.append((dirname, candidates[0].item_id, candidates[0].title))
+                elif len(candidates) > 1 or len(dirs) > 1:
+                    totals["ambiguous"] += 1
+                    rows.append(
+                        (
+                            dirname,
+                            None,
+                            f"ambiguous: {len(candidates)} remote / {len(dirs)} local",
+                        )
+                    )
+                else:
+                    totals["unmatched"] += 1
+
+        writable = [r for r in rows if r[1] is not None]
+        if not rows:
+            continue
+        _safe_print("", output)
+        _safe_print(f"=== {spec.name} ===", output)
+        for dirname, item_id, note in rows:
+            if item_id is None:
+                _safe_print(f"  SKIP  {dirname}  ({note})", output)
+            else:
+                _safe_print(
+                    f"  {'WRITE' if apply else 'would'} {item_id:<12} {dirname}", output
+                )
+        if apply:
+            for dirname, item_id, _note in writable:
+                (index.dir / dirname / ITEM_INDEX_FILENAME).write_text(f"{item_id}\n")
+                totals["written"] += 1
+        else:
+            totals["written"] += len(writable)
+
+    _safe_print("", output)
+    verb = "wrote" if apply else "would write"
+    _safe_print(
+        f"{verb} {totals['written']} id file(s); {totals['have']} already had one, "
+        f"{totals['ambiguous']} ambiguous, {totals['unmatched']} not found remotely",
+        output,
+    )
+    if not apply:
+        _safe_print("(dry run - pass --apply to write)", output)
+    return totals
+
+
 def pending_albums(config, state, api=None):
     """Rebuild FreeAlbum objects for everything queued, without re-scanning.
 
@@ -668,7 +764,9 @@ def pending_albums(config, state, api=None):
     for item_id, label_name in sorted(state.pending.items()):
         spec = specs.get(label_name)
         if not spec:
-            log.warning(f"Pending item {item_id} belongs to unconfigured label {label_name!r}")
+            log.warning(
+                f"Pending item {item_id} belongs to unconfigured label {label_name!r}"
+            )
             continue
         cached = state.items.get(item_id) or {}
         url = cached.get("url")

--- a/bandcampsync/gmail.py
+++ b/bandcampsync/gmail.py
@@ -137,13 +137,23 @@ class GmailReader:
             )
         return response.json()
 
-    def find_download_links(self, newer_than="1d", max_messages=50):
-        """Return {item_id: download_url} from recent bandcamp download mails."""
+    def find_download_links(self, newer_than="1d", max_messages=100, want_item_id=None):
+        """Return {item_id: download_url} from recent bandcamp download mails.
+
+        Each message body has to be fetched individually, so pass want_item_id when
+        looking for one album: Gmail lists newest first and the link we just triggered is
+        normally the newest message, so this stops after a single fetch instead of
+        reading every recent download mail. Without it, a batch run costs roughly
+        max_messages API calls per album and can miss a link that has fallen outside the
+        newest max_messages.
+        """
         query = f"{SEARCH_QUERY} newer_than:{newer_than}"
         listing = self._get(f"{API_BASE}/messages", q=query, maxResults=max_messages)
         links = {}
+        scanned = 0
         for stub in listing.get("messages") or []:
             message = self._get(f"{API_BASE}/messages/{stub['id']}", format="full")
+            scanned += 1
             text = _collect_text(message.get("payload") or {})
             for url in DOWNLOAD_URL_REGEX.findall(text):
                 url = url.replace("&amp;", "&")
@@ -153,7 +163,15 @@ class GmailReader:
                 item_id = int(match.group(1))
                 # Keep the first seen; Gmail returns newest first.
                 links.setdefault(item_id, url)
-        log.info(f"Found {len(links)} bandcamp download link(s) in Gmail")
+            if want_item_id is not None and want_item_id in links:
+                log.info(
+                    f"Found the download link for {want_item_id} after {scanned} message(s)"
+                )
+                return links
+        log.info(
+            f"Found {len(links)} bandcamp download link(s) in Gmail "
+            f"({scanned} message(s) read)"
+        )
         return links
 
     def wait_for_link(self, item_id, timeout=300, poll_interval=15, newer_than="1d"):
@@ -165,7 +183,9 @@ class GmailReader:
         attempt = 0
         while True:
             attempt += 1
-            links = self.find_download_links(newer_than=newer_than)
+            links = self.find_download_links(
+                newer_than=newer_than, want_item_id=item_id
+            )
             if item_id in links:
                 log.info(
                     f"Got download link for item {item_id} after {attempt} check(s)"

--- a/bandcampsync/gmail.py
+++ b/bandcampsync/gmail.py
@@ -1,0 +1,180 @@
+"""
+Retrieval of bandcamp free-download links from Gmail.
+
+Albums with require_email set do not return a download URL directly; bandcamp emails the
+link instead. This module authorises against the Gmail API once, then reads those mails
+unattended on subsequent runs.
+
+The Google libraries are an optional dependency, installed with:
+
+    uv sync --extra gmail          (or: pip install "bandcampsync[gmail]")
+
+Only the readonly scope is requested. Nothing is ever sent, modified or deleted.
+"""
+
+import base64
+import re
+import time
+from pathlib import Path
+
+from .logger import get_logger
+
+log = get_logger("gmail")
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+
+# bandcamp sends one mail per requested album, all with the same subject, so the link must
+# be correlated on the id parameter rather than assuming the newest mail is the right one.
+SEARCH_QUERY = 'from:noreply@bandcamp.com subject:"Your download from"'
+DOWNLOAD_URL_REGEX = re.compile(r"https://bandcamp\.com/download\?[^\s\"'<>]+")
+ITEM_ID_REGEX = re.compile(r"[?&]id=(\d+)")
+
+
+class GmailError(ValueError):
+    pass
+
+
+def _require_google_libs():
+    try:
+        from google.auth.transport.requests import AuthorizedSession, Request
+        from google.oauth2.credentials import Credentials
+        from google_auth_oauthlib.flow import InstalledAppFlow
+    except ImportError as e:
+        raise GmailError(
+            "The Gmail integration requires extra dependencies. Install them with: "
+            'uv sync --extra gmail  (or: pip install "bandcampsync[gmail]")'
+        ) from e
+    return AuthorizedSession, Request, Credentials, InstalledAppFlow
+
+
+def load_credentials(client_secret_path, token_path):
+    """Return authorised credentials, running the browser consent flow if needed.
+
+    The consent flow only runs when there is no stored token and none can be refreshed,
+    so scheduled runs never block on user interaction.
+    """
+    AuthorizedSession, Request, Credentials, InstalledAppFlow = _require_google_libs()
+    client_secret_path = Path(client_secret_path)
+    token_path = Path(token_path)
+
+    creds = None
+    if token_path.is_file():
+        try:
+            creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
+        except Exception as e:
+            log.warning(f"Could not load stored token {token_path}: {e}")
+
+    if creds and creds.valid:
+        return creds
+
+    if creds and creds.expired and creds.refresh_token:
+        log.info("Refreshing expired Gmail token")
+        try:
+            creds.refresh(Request())
+        except Exception as e:
+            log.warning(f"Token refresh failed, re-authorising: {e}")
+            creds = None
+        else:
+            _save_token(token_path, creds)
+            return creds
+
+    if not client_secret_path.is_file():
+        raise GmailError(
+            f"Gmail client secret not found: {client_secret_path}. Download the OAuth "
+            f"desktop client JSON from the Google Cloud console."
+        )
+    log.info("No usable Gmail token, starting the browser authorisation flow")
+    flow = InstalledAppFlow.from_client_secrets_file(str(client_secret_path), SCOPES)
+    creds = flow.run_local_server(port=0)
+    _save_token(token_path, creds)
+    return creds
+
+
+def _save_token(token_path, creds):
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text(creds.to_json(), encoding="utf-8")
+    try:  # best effort on Windows, which ignores POSIX modes
+        token_path.chmod(0o600)
+    except OSError:
+        pass
+    log.info(f"Stored Gmail token at {token_path}")
+
+
+def _decode_part(data):
+    if not data:
+        return ""
+    padded = data + "=" * (-len(data) % 4)
+    try:
+        return base64.urlsafe_b64decode(padded).decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
+def _collect_text(payload):
+    """Recursively gather text from a Gmail message payload."""
+    out = []
+    body = payload.get("body") or {}
+    if body.get("data"):
+        out.append(_decode_part(body["data"]))
+    for part in payload.get("parts") or []:
+        out.append(_collect_text(part))
+    return "\n".join(p for p in out if p)
+
+
+class GmailReader:
+    """Reads bandcamp download links out of a Gmail mailbox."""
+
+    def __init__(self, credentials):
+        AuthorizedSession, _Request, _Credentials, _Flow = _require_google_libs()
+        self.session = AuthorizedSession(credentials)
+
+    def _get(self, url, **params):
+        response = self.session.get(url, params=params, timeout=60)
+        if response.status_code != 200:
+            raise GmailError(
+                f"Gmail API request failed ({response.status_code}): {response.text[:300]}"
+            )
+        return response.json()
+
+    def find_download_links(self, newer_than="1d", max_messages=50):
+        """Return {item_id: download_url} from recent bandcamp download mails."""
+        query = f"{SEARCH_QUERY} newer_than:{newer_than}"
+        listing = self._get(f"{API_BASE}/messages", q=query, maxResults=max_messages)
+        links = {}
+        for stub in listing.get("messages") or []:
+            message = self._get(f"{API_BASE}/messages/{stub['id']}", format="full")
+            text = _collect_text(message.get("payload") or {})
+            for url in DOWNLOAD_URL_REGEX.findall(text):
+                url = url.replace("&amp;", "&")
+                match = ITEM_ID_REGEX.search(url)
+                if not match:
+                    continue
+                item_id = int(match.group(1))
+                # Keep the first seen; Gmail returns newest first.
+                links.setdefault(item_id, url)
+        log.info(f"Found {len(links)} bandcamp download link(s) in Gmail")
+        return links
+
+    def wait_for_link(self, item_id, timeout=300, poll_interval=15, newer_than="1d"):
+        """Poll until the download link for one album arrives, or time out.
+
+        Mails normally arrive within seconds, but polling makes a batch run robust.
+        """
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            links = self.find_download_links(newer_than=newer_than)
+            if item_id in links:
+                log.info(
+                    f"Got download link for item {item_id} after {attempt} check(s)"
+                )
+                return links[item_id]
+            if time.monotonic() >= deadline:
+                raise GmailError(
+                    f"No download email arrived for item {item_id} within {timeout}s. "
+                    f"Check the address configured under defaults.email matches the "
+                    f"authorised mailbox."
+                )
+            time.sleep(poll_interval)

--- a/bandcampsync/ignores.py
+++ b/bandcampsync/ignores.py
@@ -45,7 +45,7 @@ class Ignores:
             with open(self.ign_file_path, "wt") as f:
                 shutil.copyfile(TEMPLATE_IGNORES_FILE, self.ign_file_path)
 
-        with open(self.ign_file_path, "rt") as f:
+        with open(self.ign_file_path, "rt", encoding="utf-8") as f:
             try:
                 self.ign_lines = f.readlines()
             except Exception as e:

--- a/bandcampsync/labelconfig.py
+++ b/bandcampsync/labelconfig.py
@@ -25,8 +25,12 @@ log = get_logger("labelconfig")
 MAX_PRICE = 0.0
 
 # Labels are inconsistent about this field. The Audio Atelier alone uses "Various Artists",
-# "Various Artist" and "Various artist" across its catalogue, so match loosely.
-VARIOUS_ARTISTS_REGEX = re.compile(r"^\s*various\s+artists?\s*$", re.IGNORECASE)
+# "Various Artist" and "Various artist" across its catalogue; UNKNOWN PLEASURES writes it in
+# caps; B O G U S COLLECTIVE abbreviates it to "V/A". Match all of those.
+# Deliberately does NOT match a bare "VA", which is plausible as a real artist name.
+VARIOUS_ARTISTS_REGEX = re.compile(
+    r"^\s*(?:various\s+artists?|v\s*[./]\s*a\.?)\s*$", re.IGNORECASE
+)
 
 VALID_RULES = {
     "various_artists",

--- a/bandcampsync/labelconfig.py
+++ b/bandcampsync/labelconfig.py
@@ -1,0 +1,256 @@
+"""
+YAML configuration for the free/pay-what-you-want label downloader.
+
+Each label needs its own rules for deciding which albums are wanted. There is no signal
+that generalises across labels: Future Avenue tags compilations with an album artist of
+"Various Artists" and populates a distinct artist per track, while Tadpole Records uses the
+label name as the album artist, leaves every track artist null, and encodes the artist in
+the track title as "Artist : Title". Hence a small set of composable predicates rather than
+one clever heuristic.
+"""
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from .logger import get_logger
+
+log = get_logger("labelconfig")
+
+# Hard ceiling enforced in code regardless of configuration. No rule may ever cause a
+# download that costs money.
+MAX_PRICE = 0.0
+
+# Labels are inconsistent about this field. The Audio Atelier alone uses "Various Artists",
+# "Various Artist" and "Various artist" across its catalogue, so match loosely.
+VARIOUS_ARTISTS_REGEX = re.compile(r"^\s*various\s+artists?\s*$", re.IGNORECASE)
+
+VALID_RULES = {
+    "various_artists",
+    "track_artists_vary",
+    "min_track_artists",
+    "title_separator",
+    "title_regex",
+    "min_tracks",
+    "max_tracks",
+}
+
+
+class ConfigError(ValueError):
+    pass
+
+
+@dataclass
+class LabelSpec:
+    name: str
+    url: str
+    band_id: int | None = None
+    enabled: bool = True
+    since: datetime | None = None
+    match: dict = field(default_factory=dict)
+
+    @property
+    def subdomain_url(self):
+        """Base URL of the label, used as the POST target for email_download."""
+        return self.url.rstrip("/")
+
+
+@dataclass
+class FreeConfig:
+    labels: list = field(default_factory=list)
+    media_dir: Path | None = None
+    email: str = ""
+    country: str = ""
+    postcode: str = ""
+    media_format: str = "flac"
+    request_delay: float = 1.0
+
+    @property
+    def enabled_labels(self):
+        return [label for label in self.labels if label.enabled]
+
+
+def _parse_since(value, label_name):
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=value.tzinfo or timezone.utc)
+    if hasattr(value, "year"):  # a datetime.date from the YAML parser
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    try:
+        return datetime.strptime(str(value), "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError as e:
+        raise ConfigError(
+            f'Label "{label_name}" has an invalid "since" value {value!r}, '
+            f"expected YYYY-MM-DD"
+        ) from e
+
+
+def _validate_match(rules, label_name):
+    if not rules:
+        return {}
+    if not isinstance(rules, dict):
+        raise ConfigError(f'Label "{label_name}" has a "match" that is not a mapping')
+    unknown = set(rules) - VALID_RULES
+    if unknown:
+        raise ConfigError(
+            f'Label "{label_name}" has unknown match rules: {sorted(unknown)}. '
+            f"Valid rules are: {sorted(VALID_RULES)}"
+        )
+    if "title_regex" in rules:
+        try:
+            re.compile(rules["title_regex"])
+        except re.error as e:
+            raise ConfigError(
+                f'Label "{label_name}" has an invalid title_regex: {e}'
+            ) from e
+    return dict(rules)
+
+
+def load_config(config_path):
+    """Load and validate the YAML label configuration."""
+    config_path = Path(config_path)
+    if not config_path.is_file():
+        raise ConfigError(f"Configuration file does not exist: {config_path}")
+    with open(config_path, "rt", encoding="utf-8") as f:
+        try:
+            data = yaml.safe_load(f) or {}
+        except yaml.YAMLError as e:
+            raise ConfigError(f"Failed to parse {config_path} as YAML: {e}") from e
+    if not isinstance(data, dict):
+        raise ConfigError(f"{config_path} must contain a YAML mapping at the top level")
+
+    defaults = data.get("defaults") or {}
+    raw_labels = data.get("labels")
+    if not raw_labels:
+        raise ConfigError(f'{config_path} does not define any "labels"')
+
+    labels = []
+    seen = set()
+    for entry in raw_labels:
+        if not isinstance(entry, dict):
+            raise ConfigError(f"Each label must be a mapping, got: {entry!r}")
+        name = entry.get("name")
+        url = entry.get("url")
+        if not name:
+            raise ConfigError(f'A label entry is missing "name": {entry!r}')
+        if not url:
+            raise ConfigError(f'Label "{name}" is missing "url"')
+        if name in seen:
+            raise ConfigError(f'Duplicate label name: "{name}"')
+        seen.add(name)
+        labels.append(
+            LabelSpec(
+                name=name,
+                url=url,
+                band_id=entry.get("band_id"),
+                enabled=entry.get("enabled", True),
+                since=_parse_since(entry.get("since"), name),
+                match=_validate_match(entry.get("match"), name),
+            )
+        )
+
+    media_dir = defaults.get("media_dir")
+    config = FreeConfig(
+        labels=labels,
+        media_dir=Path(media_dir) if media_dir else None,
+        email=defaults.get("email", ""),
+        country=defaults.get("country", ""),
+        postcode=str(defaults.get("postcode", "")),
+        media_format=defaults.get("format", "flac"),
+        request_delay=float(defaults.get("request_delay", 1.0)),
+    )
+    log.info(
+        f"Loaded {len(config.labels)} labels from {config_path} "
+        f"({len(config.enabled_labels)} enabled)"
+    )
+    return config
+
+
+def prefilter(entry, rules):
+    """Cheap rule check against a discography entry, before fetching album details.
+
+    band_details returns the album artist and title for the whole catalogue in one
+    request, so rules that depend only on those can reject an album without spending a
+    per-album request. This is what makes scanning a label with a deep back catalogue
+    (Future Avenue has 674 releases) affordable, and it matters much more once dozens of
+    labels are configured.
+
+    Only ever returns False when a rule can be evaluated conclusively from the cheap data.
+    Rules needing track data (track_artists_vary, title_separator) always pass here and
+    are evaluated later by matches().
+    """
+    if not rules:
+        return True, "no rules"
+    if rules.get("various_artists"):
+        if entry.artist and not VARIOUS_ARTISTS_REGEX.match(entry.artist):
+            return False, f"artist is {entry.artist!r}, not Various Artists"
+    pattern = rules.get("title_regex")
+    if pattern and not re.search(pattern, entry.title):
+        return False, f"title does not match {pattern!r}"
+    return True, "passed prefilter"
+
+
+def matches(album, rules):
+    """Return (bool, reason) for whether an album satisfies a label's match rules.
+
+    All rules are ANDed. An empty rule set matches everything, which is intended: some
+    labels post only a handful of releases and every free one is wanted.
+    """
+    if not rules:
+        return True, "no match rules (all free albums wanted)"
+
+    reasons = []
+    if rules.get("various_artists"):
+        if not VARIOUS_ARTISTS_REGEX.match(album.artist or ""):
+            return False, f"artist is {album.artist!r}, not Various Artists"
+        reasons.append("artist is Various Artists")
+
+    if rules.get("track_artists_vary"):
+        distinct = album.distinct_track_artists
+        if len(distinct) < 2:
+            return False, f"only {len(distinct)} distinct track artist(s)"
+        reasons.append(f"{len(distinct)} distinct track artists")
+
+    min_artists = rules.get("min_track_artists")
+    if min_artists is not None:
+        # track_artists_vary only means ">= 2", which matches two-person collaborations
+        # and splits as readily as real compilations. Use this to demand a real spread.
+        distinct = album.distinct_track_artists
+        if len(distinct) < int(min_artists):
+            return False, (
+                f"{len(distinct)} distinct track artists < "
+                f"min_track_artists {min_artists}"
+            )
+        reasons.append(f"{len(distinct)} >= {min_artists} track artists")
+
+    separator = rules.get("title_separator")
+    if separator:
+        hits = sum(1 for t in album.track_titles if separator in t)
+        if not album.track_titles or hits < max(2, len(album.track_titles) // 2):
+            return False, (
+                f"only {hits}/{len(album.track_titles)} track titles "
+                f"contain {separator!r}"
+            )
+        reasons.append(f"{hits}/{len(album.track_titles)} titles contain {separator!r}")
+
+    pattern = rules.get("title_regex")
+    if pattern:
+        if not re.search(pattern, album.title):
+            return False, f"title does not match {pattern!r}"
+        reasons.append(f"title matches {pattern!r}")
+
+    min_tracks = rules.get("min_tracks")
+    if min_tracks is not None and album.num_tracks < int(min_tracks):
+        return False, f"{album.num_tracks} tracks < min_tracks {min_tracks}"
+    if min_tracks is not None:
+        reasons.append(f"{album.num_tracks} >= {min_tracks} tracks")
+
+    max_tracks = rules.get("max_tracks")
+    if max_tracks is not None and album.num_tracks > int(max_tracks):
+        return False, f"{album.num_tracks} tracks > max_tracks {max_tracks}"
+
+    return True, "; ".join(reasons) or "matched"

--- a/bandcampsync/labels.py
+++ b/bandcampsync/labels.py
@@ -57,6 +57,10 @@ class FreeAlbum:
     require_email: bool
     free_download: bool
     num_tracks: int
+    # bandcamp's own code: "a" for an album, "t" for a standalone track. Single tracks
+    # are released free on their own often enough to matter, and every request that
+    # touches an item has to name its type correctly.
+    item_type: str = "a"
     # Default True: absent means the API did not say, and the common case is downloadable.
     has_digital_download: bool = True
     currency: str = ""
@@ -236,6 +240,7 @@ def album_from_details(details, label_name=""):
         is_set_price=bool(details.get("is_set_price")),
         require_email=bool(details.get("require_email")),
         free_download=bool(details.get("free_download")),
+        item_type=(details.get("type") or "a"),
         has_digital_download=bool(details.get("has_digital_download", True)),
         num_tracks=int(details.get("num_downloadable_tracks") or len(tracks)),
         currency=details.get("currency") or "",

--- a/bandcampsync/labels.py
+++ b/bandcampsync/labels.py
@@ -1,0 +1,279 @@
+"""
+Discovery and classification of free / pay-what-you-want albums on record label
+bandcamp.com pages.
+
+This is the counterpart to sync.py: rather than syncing items already purchased into an
+account collection, it watches label pages for newly posted free albums. Claiming an album
+at a price of 0 does not add it to the account collection (bandcamp requires a non-zero
+minimum for that), so free albums must be discovered, requested and downloaded separately.
+
+Everything needed is available from bandcamp's undocumented mobile API, which returns clean
+JSON and lists a label's entire discography in a single request. No HTML scraping is needed.
+"""
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlsplit
+
+from curl_cffi import requests
+
+from .logger import get_logger
+
+log = get_logger("labels")
+
+
+API_BASE = "https://bandcamp.com/api/mobile/24"
+# Matches the data-band attribute on any page of a label, used to resolve a band_id from
+# a label URL the first time it is seen.
+BAND_ID_REGEX = re.compile(r'data-band="[^"]*?&quot;id&quot;:\s*(\d+)')
+BAND_ID_REGEX_PLAIN = re.compile(r'data-band=\'[^\']*?"id":\s*(\d+)')
+
+
+class LabelError(ValueError):
+    pass
+
+
+class RateLimited(LabelError):
+    """Raised when bandcamp.com rate limits us past the retry budget.
+
+    Distinct from LabelError so a scan can abort cleanly rather than marking hundreds of
+    albums as individually failed.
+    """
+
+
+@dataclass
+class FreeAlbum:
+    """A single album on a label page, with everything needed to classify it."""
+
+    item_id: int
+    title: str
+    artist: str
+    url: str
+    price: float
+    is_set_price: bool
+    require_email: bool
+    free_download: bool
+    num_tracks: int
+    # Default True: absent means the API did not say, and the common case is downloadable.
+    has_digital_download: bool = True
+    currency: str = ""
+    release_date: datetime | None = None
+    track_artists: list = field(default_factory=list)
+    track_titles: list = field(default_factory=list)
+    label_name: str = ""
+
+    @property
+    def is_free(self):
+        """True when the album can actually be obtained for 0.
+
+        Gate on price and is_set_price. Note that `free_download` maps to bandcamp's
+        download_pref == 1 ("truly free, instant download") and is False for the far more
+        common name-your-price-with-no-minimum case, so it must NOT be used to decide
+        whether 0 is allowed.
+
+        has_digital_download matters because bandcamp reports price=None for items that
+        are not separately purchasable at all - individual tracks of a compilation, for
+        instance. Those would otherwise look free (None becomes 0.0) and every download
+        attempt would fail.
+        """
+        return self.price == 0.0 and not self.is_set_price and self.has_digital_download
+
+    @property
+    def distinct_track_artists(self):
+        return {a for a in self.track_artists if a}
+
+    def __repr__(self):
+        return (
+            f"<FreeAlbum {self.item_id} {self.artist!r} - {self.title!r} "
+            f"price={self.price} free={self.is_free} tracks={self.num_tracks}>"
+        )
+
+
+class BandcampAPI:
+    """Thin client for bandcamp's mobile API.
+
+    A delay is applied between requests; this is an undocumented API and a run across many
+    labels can otherwise issue a large number of calls in a short window.
+    """
+
+    def __init__(self, delay=1.0, timeout=60, max_retries=5, backoff=4.0):
+        self.session = requests.Session(impersonate="chrome")
+        self.delay = delay
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.backoff = backoff
+        self._last_request = 0.0
+        # Consecutive rate-limited responses, used to give up rather than hammer the API.
+        self.consecutive_429 = 0
+
+    def _throttle(self):
+        if self.delay <= 0:
+            return
+        elapsed = time.monotonic() - self._last_request
+        if elapsed < self.delay:
+            time.sleep(self.delay - elapsed)
+        self._last_request = time.monotonic()
+
+    def _get(self, url, is_json=True):
+        """GET with backoff on HTTP 429.
+
+        A full first scan of a large label issues hundreds of requests and bandcamp will
+        rate limit; 429 must be waited out rather than treated as a per-album failure,
+        otherwise a scan silently reports free albums as errors.
+        """
+        response = None
+        for attempt in range(self.max_retries + 1):
+            self._throttle()
+            try:
+                response = self.session.get(url, timeout=self.timeout)
+            except Exception as e:
+                raise LabelError(f"Failed to make HTTP request to {url}: {e}") from e
+            if response.status_code != 429:
+                self.consecutive_429 = 0
+                break
+            self.consecutive_429 += 1
+            if attempt >= self.max_retries:
+                raise RateLimited(
+                    f"Rate limited by bandcamp.com after {attempt + 1} attempts: {url}"
+                )
+            wait = self._retry_after(response) or self.backoff * (2**attempt)
+            log.warning(
+                f"Rate limited (429), waiting {wait:.0f}s "
+                f"(attempt {attempt + 1}/{self.max_retries})"
+            )
+            time.sleep(wait)
+
+        if response.status_code != 200:
+            raise LabelError(
+                f"Failed to make HTTP request to {url}: "
+                f"unexpected status code: {response.status_code}"
+            )
+        if not is_json:
+            return response.text
+
+        try:
+            return json.loads(response.text)
+        except Exception as e:
+            raise LabelError(f"Failed to parse response from {url} as JSON: {e}") from e
+
+    @staticmethod
+    def _retry_after(response):
+        """Seconds to wait per a Retry-After header, if the server sent a usable one."""
+        value = response.headers.get("Retry-After") if response.headers else None
+        if not value:
+            return None
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            return None
+
+    def resolve_band_id(self, label_url):
+        """Resolve a label's numeric band_id from its bandcamp URL."""
+        parts = urlsplit(label_url)
+        url = f"{parts.scheme or 'https'}://{parts.netloc}/music"
+        body = self._get(url, is_json=False)
+        for regex in (BAND_ID_REGEX, BAND_ID_REGEX_PLAIN):
+            match = regex.search(body)
+            if match:
+                return int(match.group(1))
+        raise LabelError(
+            f"Failed to locate a band id in {url}, the page may not be a label page or "
+            f"bandcamp.com may have changed their markup"
+        )
+
+    def band_details(self, band_id):
+        """Return a label's full discography. Unpaginated, one request, no prices."""
+        return self._get(f"{API_BASE}/band_details?band_id={band_id}")
+
+    def tralbum_details(self, band_id, item_id, item_type="a"):
+        """Return full metadata for one album or track, including price and tracks."""
+        return self._get(
+            f"{API_BASE}/tralbum_details?band_id={band_id}"
+            f"&tralbum_type={item_type}&tralbum_id={item_id}"
+        )
+
+
+EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _parse_release_date(value):
+    """band_details gives an RFC-1123 string, tralbum_details a unix timestamp."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        # Not datetime.fromtimestamp(): it raises OSError on Windows for negative
+        # timestamps, and labels with pre-1970 back catalogue really do have them
+        # (Projekt Records crashed a full scan this way). Arithmetic on the epoch works
+        # for negatives on every platform.
+        try:
+            return EPOCH + timedelta(seconds=float(value))
+        except (OverflowError, ValueError, OSError):
+            log.warning(f"Out-of-range release timestamp: {value!r}")
+            return None
+    for fmt in ("%d %b %Y %H:%M:%S %Z", "%d %b %Y %H:%M:%S"):
+        try:
+            return datetime.strptime(str(value).strip(), fmt).replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            continue
+    log.warning(f"Could not parse release date: {value!r}")
+    return None
+
+
+def album_from_details(details, label_name=""):
+    """Build a FreeAlbum from a tralbum_details API response."""
+    tracks = details.get("tracks") or []
+    return FreeAlbum(
+        item_id=details.get("id"),
+        title=details.get("title") or "",
+        artist=details.get("tralbum_artist") or "",
+        url=details.get("bandcamp_url") or "",
+        price=float(details.get("price") or 0.0),
+        is_set_price=bool(details.get("is_set_price")),
+        require_email=bool(details.get("require_email")),
+        free_download=bool(details.get("free_download")),
+        has_digital_download=bool(details.get("has_digital_download", True)),
+        num_tracks=int(details.get("num_downloadable_tracks") or len(tracks)),
+        currency=details.get("currency") or "",
+        release_date=_parse_release_date(details.get("release_date")),
+        track_artists=[t.get("band_name") for t in tracks],
+        track_titles=[t.get("title") or "" for t in tracks],
+        label_name=label_name or (details.get("label") or ""),
+    )
+
+
+@dataclass
+class DiscoEntry:
+    """One entry from a label's discography listing.
+
+    Cheap: comes from the single band_details request. Carries no price, but does carry
+    the album artist and title, which is enough to skip many albums without spending a
+    per-album request.
+    """
+
+    item_id: int
+    item_type: str
+    title: str
+    artist: str = ""
+    release_date: datetime | None = None
+
+
+def list_discography(api, band_id):
+    """Return a label's discography as DiscoEntry objects, newest first. One request."""
+    data = api.band_details(band_id)
+    out = []
+    for entry in data.get("discography") or []:
+        out.append(
+            DiscoEntry(
+                item_id=entry.get("item_id"),
+                item_type="a" if entry.get("item_type") == "album" else "t",
+                title=entry.get("title") or "",
+                artist=entry.get("artist_name") or entry.get("band_name") or "",
+                release_date=_parse_release_date(entry.get("release_date")),
+            )
+        )
+    return out

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -1,9 +1,27 @@
+from pathlib import PurePosixPath
 from unicodedata import normalize
 from bandcampsync.bandcamp import BandcampItem
 from .logger import get_logger
 
 
 log = get_logger("media")
+
+
+def parse_zip_filename(filename):
+    """Split 'Artist - Album.zip' into (artist, album).
+
+    Returns (None, None) on failure.
+    """
+    if not filename:
+        return (None, None)
+    # Strip .zip extension
+    stem = filename
+    if stem.lower().endswith(".zip"):
+        stem = stem[:-4]
+    parts = stem.split(" - ", 1)
+    if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+        return (None, None)
+    return (parts[0].strip(), parts[1].strip())
 
 
 class LocalMedia:
@@ -20,12 +38,13 @@ class LocalMedia:
 
     ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
 
-    def __init__(self, media_dir, ignores, skip_item_index, sync_ignore_file):
+    def __init__(self, media_dir, ignores, skip_item_index, sync_ignore_file, dir_format="artist-album"):
         self.media_dir = media_dir
         self.ignores = ignores
         self.media = {}
         self.item_names = set()
         self.sync_ignore_file = sync_ignore_file
+        self.dir_format = dir_format
         log.info(f"Local media directory: {self.media_dir}")
 
         # If the ignores file is empty, we need to traverse the filesystem anyway
@@ -50,6 +69,11 @@ class LocalMedia:
         return format_prefix if format_prefix else format_str
 
     def index(self):
+        if self.dir_format == "zip":
+            return self._index_zip_format()
+        return self._index_artist_album_format()
+
+    def _index_artist_album_format(self):
         for child1 in self.media_dir.iterdir():
             if child1.is_dir():
                 for child2 in child1.iterdir():
@@ -72,6 +96,30 @@ class LocalMedia:
                                 log.info(
                                     f"Detected locally downloaded media: {item_id} = {child2}"
                                 )
+        return True
+
+    def _index_zip_format(self):
+        """Index directories in zip format: Artist - Album at depth 1, or Label/Artist - Album at depth 2."""
+        for child1 in self.media_dir.iterdir():
+            if not child1.is_dir():
+                continue
+            # Check if child1 itself is an album dir (depth 1: media_dir/Artist - Album/)
+            id_file = child1 / self.ITEM_INDEX_FILENAME
+            if id_file.is_file():
+                item_id = self.read_item_id(id_file)
+                self.media[item_id] = child1
+                log.info(f"Detected locally downloaded media: {item_id} = {child1}")
+            # Always add to item_names for name-based matching
+            self.item_names.add(child1.name)
+            # Check depth 2: media_dir/Label/Artist - Album/
+            for child2 in child1.iterdir():
+                if child2.is_dir():
+                    self.item_names.add(child2.name)
+                    id_file2 = child2 / self.ITEM_INDEX_FILENAME
+                    if id_file2.is_file():
+                        item_id = self.read_item_id(id_file2)
+                        self.media[item_id] = child2
+                        log.info(f"Detected locally downloaded media: {item_id} = {child2}")
         return True
 
     def read_item_id(self, filepath):
@@ -97,12 +145,107 @@ class LocalMedia:
             return True
         return False
 
+    def is_locally_downloaded_by_id(self, item):
+        """Check only by item_id (used in zip format before download)."""
+        return item.item_id in self.media
+
     def get_path_for_purchase(self, item):
         return (
             self.media_dir
             / self._clean_path(item.band_name)
             / self._clean_path(f"{item.item_title}{item.folder_suffix}")
         )
+
+    def get_path_for_zip_purchase(self, item, content_filename):
+        """Compute local path for a zip-format purchase.
+
+        Uses the ZIP filename from Content-Disposition to determine the directory name.
+        Compares the ZIP artist with band_name to detect label releases.
+        """
+        zip_artist, zip_album = parse_zip_filename(content_filename)
+        if zip_artist and zip_album:
+            zip_dirname = PurePosixPath(content_filename).stem
+            # Compare artist to band_name to detect label grouping
+            if zip_artist.lower() != item.band_name.lower():
+                # Label release: Label/Artist - Album
+                return self.media_dir / self._clean_path(item.band_name) / zip_dirname
+            else:
+                # Direct artist release: Artist - Album
+                return self.media_dir / zip_dirname
+        # Fallback: construct from metadata
+        dirname = self._clean_path(f"{item.band_name} - {item.item_title}{item.folder_suffix}")
+        return self.media_dir / dirname
+
+    def get_path_for_track_purchase(self, item):
+        """Compute local path for a single track in zip format."""
+        dirname = self._clean_path(f"{item.band_name} - {item.item_title}{item.folder_suffix}")
+        return self.media_dir / dirname
+
+    def get_expected_name_for_zip(self, item):
+        """Return the expected directory name for a zip-format purchase.
+
+        Used for name-based fallback matching when no bandcamp_item_id.txt exists.
+        """
+        return self._clean_path(
+            f"{item.band_name} - {item.item_title}{item.folder_suffix}"
+        )
+
+    @staticmethod
+    def _normalize_for_match(s):
+        """Reduce a string to lowercase alphanumeric + spaces for fuzzy comparison.
+
+        Handles differences like colon→hyphen vs colon→removed that arise
+        because Bandcamp ZIP filenames and _clean_path use different sanitization.
+        """
+        return "".join(c.lower() for c in s if c.isalnum() or c == " ").strip()
+
+    def find_zip_item_by_title(self, item):
+        """Try to find a locally downloaded item by matching the title portion.
+
+        For label releases, the on-disk name is 'ActualArtist - Title' which
+        won't match 'LabelName - Title'. This checks if any indexed directory
+        has a title portion (after ' - ') that matches the item's title when
+        both are normalized.
+
+        Returns the matching directory name, or None.
+        """
+        norm_title = self._normalize_for_match(
+            f"{item.item_title}{item.folder_suffix}"
+        )
+        for name in self.item_names:
+            parts = name.split(" - ", 1)
+            if len(parts) == 2:
+                on_disk_title = self._normalize_for_match(parts[1])
+                if on_disk_title == norm_title:
+                    return name
+        return None
+
+    def find_zip_item_by_artist(self, item):
+        """Try to find a locally downloaded item by matching the artist prefix.
+
+        Handles cases where metadata drifted (e.g. label dropped from Bandcamp,
+        title gained/lost a suffix like 'EP'). Checks if any indexed directory
+        starts with 'band_name - ' and the on-disk title is a substring of the
+        Bandcamp title or vice versa (using normalized comparison).
+
+        Returns the matching directory name, or None.
+        """
+        norm_band = self._normalize_for_match(item.band_name)
+        norm_title = self._normalize_for_match(
+            f"{item.item_title}{item.folder_suffix}"
+        )
+        for name in self.item_names:
+            parts = name.split(" - ", 1)
+            if len(parts) != 2:
+                continue
+            on_disk_band = self._normalize_for_match(parts[0])
+            if on_disk_band != norm_band:
+                continue
+            on_disk_title = self._normalize_for_match(parts[1])
+            # Check if one title is a substring of the other
+            if on_disk_title in norm_title or norm_title in on_disk_title:
+                return name
+        return None
 
     def get_path_for_file(self, local_path, file_name):
         return local_path / self._clean_path(file_name)

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -229,6 +229,8 @@ class LocalMedia:
         norm_title = self._normalize_for_match(
             f"{item.item_title}{item.folder_suffix}"
         )
+        if not norm_title:
+            return None
         for name in self.item_names:
             parts = name.split(" - ", 1)
             if len(parts) == 2:
@@ -248,9 +250,13 @@ class LocalMedia:
         Returns the matching directory name, or None.
         """
         norm_band = self._normalize_for_match(item.band_name)
+        if not norm_band:
+            return None
         norm_title = self._normalize_for_match(
             f"{item.item_title}{item.folder_suffix}"
         )
+        if not norm_title:
+            return None
         for name in self.item_names:
             parts = name.split(" - ", 1)
             if len(parts) != 2:

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -177,18 +177,16 @@ class LocalMedia:
         """Compute local path for a zip-format purchase.
 
         Uses the ZIP filename from Content-Disposition to determine the directory name.
-        Compares the ZIP artist with band_name to detect label releases.
+        Places into a label subdirectory when the ZIP artist differs from band_name,
+        or when a directory matching band_name already exists (user-organized label).
         """
         zip_artist, zip_album = parse_zip_filename(content_filename)
         if zip_artist and zip_album:
             zip_dirname = PurePosixPath(content_filename).stem
-            # Compare artist to band_name to detect label grouping
-            if zip_artist.lower() != item.band_name.lower():
-                # Label release: Label/Artist - Album
-                return self.media_dir / self._clean_path(item.band_name) / zip_dirname
-            else:
-                # Direct artist release: Artist - Album
-                return self.media_dir / zip_dirname
+            band_dir = self.media_dir / self._clean_path(item.band_name)
+            if zip_artist.lower() != item.band_name.lower() or band_dir.is_dir():
+                return band_dir / zip_dirname
+            return self.media_dir / zip_dirname
         # Fallback: construct from metadata
         dirname = self._clean_path(f"{item.band_name} - {item.item_title}{item.folder_suffix}")
         return self.media_dir / dirname
@@ -237,37 +235,6 @@ class LocalMedia:
                 on_disk_title = self._normalize_for_match(parts[1])
                 if on_disk_title == norm_title:
                     return name
-        return None
-
-    def find_zip_item_by_artist(self, item):
-        """Try to find a locally downloaded item by matching the artist prefix.
-
-        Handles cases where metadata drifted (e.g. label dropped from Bandcamp,
-        title gained/lost a suffix like 'EP'). Checks if any indexed directory
-        starts with 'band_name - ' and the on-disk title is a substring of the
-        Bandcamp title or vice versa (using normalized comparison).
-
-        Returns the matching directory name, or None.
-        """
-        norm_band = self._normalize_for_match(item.band_name)
-        if not norm_band:
-            return None
-        norm_title = self._normalize_for_match(
-            f"{item.item_title}{item.folder_suffix}"
-        )
-        if not norm_title:
-            return None
-        for name in self.item_names:
-            parts = name.split(" - ", 1)
-            if len(parts) != 2:
-                continue
-            on_disk_band = self._normalize_for_match(parts[0])
-            if on_disk_band != norm_band:
-                continue
-            on_disk_title = self._normalize_for_match(parts[1])
-            # Check if one title is a substring of the other
-            if on_disk_title in norm_title or norm_title in on_disk_title:
-                return name
         return None
 
     def get_path_for_file(self, local_path, file_name):

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -59,7 +59,8 @@ class LocalMedia:
         for c in normalized_path:
             if c not in disallowed_punctuation:
                 outstr += c
-        return outstr
+        # Windows silently strips trailing dots and spaces from directory names
+        return outstr.rstrip(". ")
 
     def clean_format(self, format_str):
         if "-" not in format_str:
@@ -81,6 +82,8 @@ class LocalMedia:
                         for child3 in child2.iterdir():
                             if child3.name == self.ITEM_INDEX_FILENAME:
                                 item_id = self.read_item_id(child3)
+                                if item_id is None:
+                                    continue
                                 if self.sync_ignore_file:
                                     item = BandcampItem(
                                         {
@@ -107,8 +110,9 @@ class LocalMedia:
             id_file = child1 / self.ITEM_INDEX_FILENAME
             if id_file.is_file():
                 item_id = self.read_item_id(id_file)
-                self.media[item_id] = child1
-                log.info(f"Detected locally downloaded media: {item_id} = {child1}")
+                if item_id is not None:
+                    self.media[item_id] = child1
+                    log.info(f"Detected locally downloaded media: {item_id} = {child1}")
             # Always add to item_names for name-based matching
             self.item_names.add(child1.name)
             # Check depth 2: media_dir/Label/Artist - Album/
@@ -118,8 +122,9 @@ class LocalMedia:
                     id_file2 = child2 / self.ITEM_INDEX_FILENAME
                     if id_file2.is_file():
                         item_id = self.read_item_id(id_file2)
-                        self.media[item_id] = child2
-                        log.info(f"Detected locally downloaded media: {item_id} = {child2}")
+                        if item_id is not None:
+                            self.media[item_id] = child2
+                            log.info(f"Detected locally downloaded media: {item_id} = {child2}")
         return True
 
     def read_item_id(self, filepath):
@@ -127,10 +132,11 @@ class LocalMedia:
             item_id = f.read().strip()
         try:
             return int(item_id)
-        except Exception as e:
-            raise ValueError(
-                f'Failed to cast item ID from {filepath} "{item_id}" as an int: {e}'
-            ) from e
+        except (ValueError, TypeError):
+            log.warning(
+                f'Invalid item ID in {filepath}: "{item_id}", skipping'
+            )
+            return None
 
     def is_locally_downloaded(self, item, local_path):
         if item.item_id in self.media:
@@ -146,8 +152,19 @@ class LocalMedia:
         return False
 
     def is_locally_downloaded_by_id(self, item):
-        """Check only by item_id (used in zip format before download)."""
-        return item.item_id in self.media
+        """Check by item_id, with name-based fallback (used in zip format before download)."""
+        if item.item_id in self.media:
+            return True
+        # Fallback: check if a directory with the expected name already exists
+        # (handles label-disassociated albums that lack tracking files)
+        expected_name = self.get_expected_name_for_zip(item)
+        if expected_name in self.item_names:
+            log.info(
+                f'Detected album by name "{expected_name}" but without matching item ID '
+                f"(id:{item.item_id}), skipping download"
+            )
+            return True
+        return False
 
     def get_path_for_purchase(self, item):
         return (

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -25,6 +25,40 @@ def clean_path_component(path_str):
     return outstr.rstrip(". ")
 
 
+# Characters Windows forbids in a path component, plus the separators. Deliberately a
+# much smaller set than clean_path_component's: apostrophes and accented letters are
+# legal everywhere we target and are kept so the directory reads naturally.
+_WINDOWS_ILLEGAL_PATH_CHARS = '<>:"/\\|?*'
+
+
+def clean_label_dir_name(label_name):
+    """Derive a label's grouping directory name from its configured name.
+
+    Narrower than clean_path_component on purpose, and NOT interchangeable with it.
+    This name is derived independently in two places - LabelIndex when it looks for
+    already-downloaded albums, and _target_path when it writes new ones - so the two must
+    agree exactly or dedup silently fails and the label's entire catalogue downloads
+    again. That is precisely what happened to "What Do You Know About Ska Punk?": the
+    downloader stripped the "?" but the indexer did not, so it searched a path that cannot
+    exist on Windows, indexed nothing, and queued all 10 comps (~30 GB) as missing.
+
+    Only characters Windows actually forbids are removed, because the existing on-disk
+    label directories keep their apostrophes ("Don't Panic Records & Distro"). Accents are
+    normalised to NFC rather than decomposed, since those directories are NFC and NTFS
+    compares filenames without normalising - a decomposed name creates a second, separate
+    directory next to the composed one.
+    """
+    name = normalize("NFC", str(label_name))
+    cleaned = "".join(
+        c for c in name if c not in _WINDOWS_ILLEGAL_PATH_CHARS and ord(c) >= 32
+    )
+    # Windows silently strips trailing dots and spaces from directory names
+    cleaned = cleaned.rstrip(". ")
+    # Never fall back to an empty component - that would place albums directly in the
+    # media root instead of under the label.
+    return cleaned or "unknown-label"
+
+
 def parse_zip_filename(filename):
     """Split 'Artist - Album.zip' into (artist, album).
 

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -218,12 +218,18 @@ class LocalMedia:
 
     @staticmethod
     def _normalize_for_match(s):
-        """Reduce a string to lowercase alphanumeric + spaces for fuzzy comparison.
+        """Reduce a string to lowercase alphanumeric + single spaces for comparison.
 
         Handles differences like colon→hyphen vs colon→removed that arise
         because Bandcamp ZIP filenames and _clean_path use different sanitization.
+
+        Runs of whitespace are collapsed. Dropping a separator leaves the spaces that
+        surrounded it behind, so "RECORDS - Vol. VII" reduced to "records  vol vii" with
+        a double space and failed to match "RECORDS Vol. VII" - a real case that caused
+        an album to be downloaded a second time.
         """
-        return "".join(c.lower() for c in s if c.isalnum() or c == " ").strip()
+        cleaned = "".join(c.lower() for c in s if c.isalnum() or c.isspace())
+        return " ".join(cleaned.split())
 
     def find_zip_item_by_title(self, item):
         """Try to find a locally downloaded item by matching the title portion.

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -7,6 +7,24 @@ from .logger import get_logger
 log = get_logger("media")
 
 
+def clean_path_component(path_str):
+    """Strip characters that are illegal or awkward in a directory name.
+
+    Shared by the local media indexer and the free-album downloader so both derive the
+    same directory name for a release - dedup matches local directories by name, so the
+    two must agree exactly.
+    """
+    path_str = str(path_str)
+    disallowed_punctuation = "\"#%'*/?\\`:"
+    normalized_path = normalize("NFKD", path_str)
+    outstr = ""
+    for c in normalized_path:
+        if c not in disallowed_punctuation:
+            outstr += c
+    # Windows silently strips trailing dots and spaces from directory names
+    return outstr.rstrip(". ")
+
+
 def parse_zip_filename(filename):
     """Split 'Artist - Album.zip' into (artist, album).
 
@@ -59,15 +77,7 @@ class LocalMedia:
             self.index()
 
     def _clean_path(self, path_str):
-        path_str = str(path_str)
-        disallowed_punctuation = "\"#%'*/?\\`:"
-        normalized_path = normalize("NFKD", path_str)
-        outstr = ""
-        for c in normalized_path:
-            if c not in disallowed_punctuation:
-                outstr += c
-        # Windows silently strips trailing dots and spaces from directory names
-        return outstr.rstrip(". ")
+        return clean_path_component(path_str)
 
     def clean_format(self, format_str):
         if "-" not in format_str:

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -38,7 +38,14 @@ class LocalMedia:
 
     ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
 
-    def __init__(self, media_dir, ignores, skip_item_index, sync_ignore_file, dir_format="artist-album"):
+    def __init__(
+        self,
+        media_dir,
+        ignores,
+        skip_item_index,
+        sync_ignore_file,
+        dir_format="artist-album",
+    ):
         self.media_dir = media_dir
         self.ignores = ignores
         self.media = {}
@@ -124,7 +131,9 @@ class LocalMedia:
                         item_id = self.read_item_id(id_file2)
                         if item_id is not None:
                             self.media[item_id] = child2
-                            log.info(f"Detected locally downloaded media: {item_id} = {child2}")
+                            log.info(
+                                f"Detected locally downloaded media: {item_id} = {child2}"
+                            )
         return True
 
     def read_item_id(self, filepath):
@@ -133,9 +142,7 @@ class LocalMedia:
         try:
             return int(item_id)
         except (ValueError, TypeError):
-            log.warning(
-                f'Invalid item ID in {filepath}: "{item_id}", skipping'
-            )
+            log.warning(f'Invalid item ID in {filepath}: "{item_id}", skipping')
             return None
 
     def is_locally_downloaded(self, item, local_path):
@@ -188,12 +195,16 @@ class LocalMedia:
                 return band_dir / zip_dirname
             return self.media_dir / zip_dirname
         # Fallback: construct from metadata
-        dirname = self._clean_path(f"{item.band_name} - {item.item_title}{item.folder_suffix}")
+        dirname = self._clean_path(
+            f"{item.band_name} - {item.item_title}{item.folder_suffix}"
+        )
         return self.media_dir / dirname
 
     def get_path_for_track_purchase(self, item):
         """Compute local path for a single track in zip format."""
-        dirname = self._clean_path(f"{item.band_name} - {item.item_title}{item.folder_suffix}")
+        dirname = self._clean_path(
+            f"{item.band_name} - {item.item_title}{item.folder_suffix}"
+        )
         return self.media_dir / dirname
 
     def get_expected_name_for_zip(self, item):
@@ -224,9 +235,7 @@ class LocalMedia:
 
         Returns the matching directory name, or None.
         """
-        norm_title = self._normalize_for_match(
-            f"{item.item_title}{item.folder_suffix}"
-        )
+        norm_title = self._normalize_for_match(f"{item.item_title}{item.folder_suffix}")
         if not norm_title:
             return None
         for name in self.item_names:

--- a/bandcampsync/media.py
+++ b/bandcampsync/media.py
@@ -13,9 +13,17 @@ def clean_path_component(path_str):
     Shared by the local media indexer and the free-album downloader so both derive the
     same directory name for a release - dedup matches local directories by name, so the
     two must agree exactly.
+
+    Widening this set is normally forbidden, because a name that stops matching orphans
+    the directory already on disk and the album downloads again. "|<>" are the exception:
+    Windows and SMB refuse to create a path component containing them, so no directory
+    that ever landed on disk can contain one and no existing name can change. They were
+    added 2026-08-06 after Flowerpot Records' "12|21" failed with WinError 123 - it was
+    the only failure in a 207-album run, and clean_label_dir_name had been stripping
+    these all along via _WINDOWS_ILLEGAL_PATH_CHARS.
     """
     path_str = str(path_str)
-    disallowed_punctuation = "\"#%'*/?\\`:"
+    disallowed_punctuation = "\"#%'*/?\\`:|<>"
     normalized_path = normalize("NFKD", path_str)
     outstr = ""
     for c in normalized_path:

--- a/bandcampsync/report.py
+++ b/bandcampsync/report.py
@@ -40,11 +40,6 @@ def classify_item(item, local_media, ignores, dir_format):
         match = local_media.find_zip_item_by_title(item)
         if match:
             return ("downloaded", None)
-        # Fallback: artist-prefix match with substring title comparison
-        # (catches metadata drift, e.g. title gained/lost "EP" suffix)
-        match = local_media.find_zip_item_by_artist(item)
-        if match:
-            return ("downloaded", None)
 
     return ("missing", None)
 

--- a/bandcampsync/report.py
+++ b/bandcampsync/report.py
@@ -1,0 +1,152 @@
+import csv
+import sys
+
+from .bandcamp import Bandcamp
+from .ignores import Ignores
+from .media import LocalMedia
+from .logger import get_logger
+
+
+log = get_logger("report")
+
+
+def classify_item(item, local_media, ignores, dir_format):
+    """Classify a Bandcamp purchase as ignored, preorder, downloaded, or missing.
+
+    Returns (status, local_path) where status is one of
+    "ignored", "preorder", "downloaded", "missing".
+    local_path is the expected local directory (may be None for ignored/preorder).
+    """
+    if ignores.is_ignored(item):
+        return ("ignored", None)
+
+    if item.is_preorder:
+        return ("preorder", None)
+
+    if dir_format == "artist-album":
+        local_path = local_media.get_path_for_purchase(item)
+        if local_media.is_locally_downloaded(item, local_path):
+            return ("downloaded", local_path)
+    else:
+        # zip format: check by ID first, then fall back to name matching
+        if local_media.is_locally_downloaded_by_id(item):
+            local_path = local_media.media.get(item.item_id)
+            return ("downloaded", local_path)
+        expected_name = local_media.get_expected_name_for_zip(item)
+        if expected_name in local_media.item_names:
+            return ("downloaded", None)
+        # Fallback: title-suffix match (catches label releases where the
+        # on-disk artist differs from band_name)
+        match = local_media.find_zip_item_by_title(item)
+        if match:
+            return ("downloaded", None)
+        # Fallback: artist-prefix match with substring title comparison
+        # (catches metadata drift, e.g. title gained/lost "EP" suffix)
+        match = local_media.find_zip_item_by_artist(item)
+        if match:
+            return ("downloaded", None)
+
+    return ("missing", None)
+
+
+def _safe_print(text):
+    """Print text, replacing unencodable characters on Windows."""
+    try:
+        print(text)
+    except UnicodeEncodeError:
+        print(text.encode(sys.stdout.encoding or "utf-8", errors="replace").decode(
+            sys.stdout.encoding or "utf-8", errors="replace"
+        ))
+
+
+def print_report(results, output=None):
+    """Print a human-readable summary to stdout (or the given file object)."""
+    total = len(results)
+    counts = {"downloaded": 0, "missing": 0, "ignored": 0, "preorder": 0}
+    missing_items = []
+    for item, status, _path in results:
+        counts[status] += 1
+        if status == "missing":
+            missing_items.append(item)
+
+    lines = [
+        "BandcampSync Collection Report",
+        "=" * 30,
+        f"Total purchases: {total}",
+        f"  Downloaded:    {counts['downloaded']}",
+        f"  Missing:       {counts['missing']}",
+        f"  Ignored:       {counts['ignored']}",
+        f"  Preorders:     {counts['preorder']}",
+    ]
+
+    if missing_items:
+        lines.append("")
+        lines.append("Missing items:")
+        for item in missing_items:
+            lines.append(f"  - {item.band_name} / {item.item_title} (id:{item.item_id})")
+
+    text = "\n".join(lines)
+    if output:
+        output.write(text + "\n")
+    else:
+        _safe_print(text)
+
+
+def write_csv(results, csv_path):
+    """Write a CSV report with one row per purchase."""
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["item_id", "band_name", "item_title", "item_type", "status", "local_path"]
+        )
+        for item, status, local_path in results:
+            item_type = item._data.get("item_type", "")
+            writer.writerow(
+                [
+                    item.item_id,
+                    item.band_name,
+                    item.item_title,
+                    item_type,
+                    status,
+                    str(local_path) if local_path else "",
+                ]
+            )
+
+
+def generate_report(
+    cookies,
+    media_dir,
+    ign_file_path=None,
+    ign_patterns="",
+    skip_item_index=False,
+    dir_format="artist-album",
+    csv_path=None,
+):
+    """Generate a collection report comparing Bandcamp purchases to local files.
+
+    This is read-only: it never modifies the ignore file or writes tracking files.
+    """
+    bandcamp = Bandcamp(cookies=cookies)
+    bandcamp.verify_authentication()
+    bandcamp.load_purchases()
+
+    ignores = Ignores(ign_file_path=ign_file_path, ign_patterns=ign_patterns)
+    local_media = LocalMedia(
+        media_dir=media_dir,
+        ignores=ignores,
+        skip_item_index=skip_item_index,
+        sync_ignore_file=False,
+        dir_format=dir_format,
+    )
+
+    results = []
+    for item in bandcamp.purchases:
+        status, local_path = classify_item(item, local_media, ignores, dir_format)
+        results.append((item, status, local_path))
+
+    print_report(results)
+    if csv_path:
+        write_csv(results, csv_path)
+        log.info(f"CSV report written to {csv_path}")
+
+    return results

--- a/bandcampsync/report.py
+++ b/bandcampsync/report.py
@@ -49,9 +49,11 @@ def _safe_print(text):
     try:
         print(text)
     except UnicodeEncodeError:
-        print(text.encode(sys.stdout.encoding or "utf-8", errors="replace").decode(
-            sys.stdout.encoding or "utf-8", errors="replace"
-        ))
+        print(
+            text.encode(sys.stdout.encoding or "utf-8", errors="replace").decode(
+                sys.stdout.encoding or "utf-8", errors="replace"
+            )
+        )
 
 
 def print_report(results, output=None):
@@ -78,7 +80,9 @@ def print_report(results, output=None):
         lines.append("")
         lines.append("Missing items:")
         for item in missing_items:
-            lines.append(f"  - {item.band_name} / {item.item_title} (id:{item.item_id})")
+            lines.append(
+                f"  - {item.band_name} / {item.item_title} (id:{item.item_id})"
+            )
 
     text = "\n".join(lines)
     if output:

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -1,12 +1,14 @@
 import asyncio
+import os
 import time
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from .logger import get_logger
-from .bandcamp import Bandcamp, BandcampError, BandcampDownloadUnavailable
+from .bandcamp import Bandcamp, BandcampError
 from .ignores import Ignores
 from .media import LocalMedia
 from .notify import NotifyURL
+from curl_cffi.requests.exceptions import RequestException
 from .download import (
     download_file,
     unzip_file,
@@ -127,16 +129,21 @@ class Syncer:
                     item, initial_download_url
                 )
 
-                with NamedTemporaryFile(
-                    mode="w+b", delete=True, dir=self.temp_dir_root
-                ) as temp_file:
+                temp_file = NamedTemporaryFile(
+                    mode="w+b", delete=False, dir=self.temp_dir_root
+                )
+                temp_file_path = Path(temp_file.name)
+                try:
                     log.info(
                         f'Downloading item "{item.band_name} / {item.item_title}" (id:{item.item_id}) '
                         f"from {mask_sig(download_file_url)} to {temp_file.name}"
                     )
                     content_filename = download_file(download_file_url, temp_file)
-                    temp_file.seek(0)
-                    temp_file_path = Path(temp_file.name)
+                    # Close the temp file before any operation that re-opens
+                    # it by path. On Windows, NamedTemporaryFile holds an
+                    # exclusive lock that prevents other code (ZipFile,
+                    # shutil.copyfile) from opening the same file.
+                    temp_file.close()
                     if is_zip_file(temp_file_path):
                         # Determine local_path for zip format after download
                         if self.dir_format == "zip":
@@ -160,9 +167,9 @@ class Syncer:
 
                         with TemporaryDirectory(dir=self.temp_dir_root) as temp_dir:
                             log.info(
-                                f'Decompressing downloaded zip "{temp_file.name}" to "{temp_dir}"'
+                                f'Decompressing downloaded zip "{temp_file_path}" to "{temp_dir}"'
                             )
-                            unzip_file(temp_file.name, temp_dir)
+                            unzip_file(str(temp_file_path), temp_dir)
                             temp_path = Path(temp_dir)
                             try:
                                 local_path.mkdir(parents=True, exist_ok=True)
@@ -189,9 +196,12 @@ class Syncer:
                         if self.dir_format == "zip":
                             local_path = self.local_media.get_path_for_track_purchase(item)
 
-                        slug = item.item_title
-                        if item.url_hints and isinstance(item.url_hints, dict):
-                            slug = item.url_hints.get("slug", item.item_title)
+                        if self.dir_format == "zip":
+                            track_name = f"{item.band_name} - {item.item_title}"
+                        else:
+                            track_name = item.item_title
+                            if item.url_hints and isinstance(item.url_hints, dict):
+                                track_name = item.url_hints.get("slug", item.item_title)
                         format_extension = self.local_media.clean_format(
                             self.media_format
                         )
@@ -203,7 +213,7 @@ class Syncer:
                             )
                             continue
                         file_dest = self.local_media.get_path_for_file(
-                            local_path, f"{slug}.{format_extension}"
+                            local_path, f"{track_name}.{format_extension}"
                         )
                         log.info(
                             f'Copying single track: "{temp_file_path}" to "{file_dest}"'
@@ -232,11 +242,18 @@ class Syncer:
 
                     self.new_items_downloaded = True
                     return True
+                finally:
+                    temp_file.close()
+                    try:
+                        os.unlink(temp_file.name)
+                    except OSError:
+                        pass
 
             except (
                 BandcampError,
                 DownloadBadStatusCode,
                 DownloadInvalidContentType,
+                RequestException,
             ) as e:
                 if attempt < self.max_retries - 1:
                     log.warning(

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -38,14 +38,17 @@ class Syncer:
         retry_wait=5,
         skip_item_index=False,
         sync_ignore_file=False,
+        dir_format="artist-album",
     ):
         self.ignores = Ignores(ign_file_path=ign_file_path, ign_patterns=ign_patterns)
         self.sync_ignore_file = sync_ignore_file
+        self.dir_format = dir_format
         self.local_media = LocalMedia(
             media_dir=dir_path,
             ignores=self.ignores,
             skip_item_index=skip_item_index,
             sync_ignore_file=sync_ignore_file,
+            dir_format=dir_format,
         )
         self.media_format = media_format
         self.temp_dir_root = temp_dir_root
@@ -75,15 +78,18 @@ class Syncer:
             bool: indicating new media was downloaded
         """
 
-        local_path = self.local_media.get_path_for_purchase(item)
-
         # Check if any ignore pattern matches the band name
-        if self.ignores.is_ignored(item):
-            if not self.show_id_file_warning and self.local_media.is_locally_downloaded(
-                item, local_path
-            ):
-                self.show_id_file_warning = True
-            return False
+        if self.dir_format == "artist-album":
+            local_path = self.local_media.get_path_for_purchase(item)
+            if self.ignores.is_ignored(item):
+                if not self.show_id_file_warning and self.local_media.is_locally_downloaded(
+                    item, local_path
+                ):
+                    self.show_id_file_warning = True
+                return False
+        else:
+            if self.ignores.is_ignored(item):
+                return False
 
         if item.is_preorder:
             log.info(
@@ -92,133 +98,164 @@ class Syncer:
             )
             return False
 
-        elif self.local_media.is_locally_downloaded(item, local_path):
-            log.info(
-                f'Already locally downloaded, skipping: "{item.band_name} / {item.item_title}" '
-                f"(id:{item.item_id})"
-            )
-            return False
-
+        if self.dir_format == "artist-album":
+            if self.local_media.is_locally_downloaded(item, local_path):
+                log.info(
+                    f'Already locally downloaded, skipping: "{item.band_name} / {item.item_title}" '
+                    f"(id:{item.item_id})"
+                )
+                return False
         else:
-            log.info(
-                f'New media item, will download: "{item.band_name} / {item.item_title}" '
-                f'(id:{item.item_id}) in "{self.media_format}"'
-            )
+            if self.local_media.is_locally_downloaded_by_id(item):
+                log.info(
+                    f'Already locally downloaded (by id), skipping: "{item.band_name} / {item.item_title}" '
+                    f"(id:{item.item_id})"
+                )
+                return False
 
-            for attempt in range(self.max_retries):
-                try:
-                    initial_download_url = self.bandcamp.get_download_file_url(
-                        item, encoding=self.media_format
-                    )
-                    download_file_url = self.bandcamp.check_download_stat(
-                        item, initial_download_url
-                    )
+        log.info(
+            f'New media item, will download: "{item.band_name} / {item.item_title}" '
+            f'(id:{item.item_id}) in "{self.media_format}"'
+        )
 
-                    with NamedTemporaryFile(
-                        mode="w+b", delete=True, dir=self.temp_dir_root
-                    ) as temp_file:
-                        log.info(
-                            f'Downloading item "{item.band_name} / {item.item_title}" (id:{item.item_id}) '
-                            f"from {mask_sig(download_file_url)} to {temp_file.name}"
-                        )
-                        download_file(download_file_url, temp_file)
-                        temp_file.seek(0)
-                        temp_file_path = Path(temp_file.name)
-                        if is_zip_file(temp_file_path):
-                            with TemporaryDirectory(dir=self.temp_dir_root) as temp_dir:
-                                log.info(
-                                    f'Decompressing downloaded zip "{temp_file.name}" to "{temp_dir}"'
-                                )
-                                unzip_file(temp_file.name, temp_dir)
-                                temp_path = Path(temp_dir)
-                                try:
-                                    local_path.mkdir(parents=True, exist_ok=True)
-                                except OSError as e:
-                                    log.error(
-                                        f"Failed to create directory: {local_path} ({e}), skipping file extraction"
-                                    )
-                                    continue
-                                for file_path in temp_path.iterdir():
-                                    file_dest = self.local_media.get_path_for_file(
-                                        local_path, file_path.name
-                                    )
-                                    log.info(
-                                        f'Moving extracted file: "{file_path}" to "{file_dest}"'
-                                    )
-                                    try:
-                                        move_file(file_path, file_dest)
-                                    except OSError as e:
-                                        log.error(
-                                            f"Failed to move {file_path} to {file_dest}: {e}"
-                                        )
-                        elif item.item_type == "track":
-                            slug = item.item_title
-                            if item.url_hints and isinstance(item.url_hints, dict):
-                                slug = item.url_hints.get("slug", item.item_title)
-                            format_extension = self.local_media.clean_format(
-                                self.media_format
+        for attempt in range(self.max_retries):
+            try:
+                initial_download_url = self.bandcamp.get_download_file_url(
+                    item, encoding=self.media_format
+                )
+                download_file_url = self.bandcamp.check_download_stat(
+                    item, initial_download_url
+                )
+
+                with NamedTemporaryFile(
+                    mode="w+b", delete=True, dir=self.temp_dir_root
+                ) as temp_file:
+                    log.info(
+                        f'Downloading item "{item.band_name} / {item.item_title}" (id:{item.item_id}) '
+                        f"from {mask_sig(download_file_url)} to {temp_file.name}"
+                    )
+                    content_filename = download_file(download_file_url, temp_file)
+                    temp_file.seek(0)
+                    temp_file_path = Path(temp_file.name)
+                    if is_zip_file(temp_file_path):
+                        # Determine local_path for zip format after download
+                        if self.dir_format == "zip":
+                            local_path = self.local_media.get_path_for_zip_purchase(
+                                item, content_filename
                             )
+                        elif self.dir_format != "artist-album":
+                            local_path = self.local_media.get_path_for_purchase(item)
+
+                        # In zip mode, check if target directory already exists
+                        if self.dir_format == "zip" and local_path.is_dir() and any(local_path.iterdir()):
+                            log.info(
+                                f'Target directory already exists with files, writing tracking and skipping extraction: '
+                                f'"{local_path}" (id:{item.item_id})'
+                            )
+                            if self.ign_file_path:
+                                self.ignores.add(item)
+                            else:
+                                self.local_media.write_bandcamp_id(item, local_path)
+                            return False
+
+                        with TemporaryDirectory(dir=self.temp_dir_root) as temp_dir:
+                            log.info(
+                                f'Decompressing downloaded zip "{temp_file.name}" to "{temp_dir}"'
+                            )
+                            unzip_file(temp_file.name, temp_dir)
+                            temp_path = Path(temp_dir)
                             try:
                                 local_path.mkdir(parents=True, exist_ok=True)
                             except OSError as e:
                                 log.error(
-                                    f"Failed to create directory: {local_path} ({e}), skipping file write"
+                                    f"Failed to create directory: {local_path} ({e}), skipping file extraction"
                                 )
                                 continue
-                            file_dest = self.local_media.get_path_for_file(
-                                local_path, f"{slug}.{format_extension}"
-                            )
-                            log.info(
-                                f'Copying single track: "{temp_file_path}" to "{file_dest}"'
-                            )
-                            try:
-                                copy_file(temp_file_path, file_dest)
-                            except OSError as e:
-                                log.error(
-                                    f"Failed to copy {temp_file_path} to {file_dest}: {e}"
+                            for file_path in temp_path.iterdir():
+                                file_dest = self.local_media.get_path_for_file(
+                                    local_path, file_path.name
                                 )
-                        else:
-                            log.error(
-                                f'Downloaded file for "{item.band_name} / {item.item_title}" (id:{item.item_id}) '
-                                f'at "{temp_file_path}" is not a zip archive or a single track, skipping'
-                            )
-                            return False
+                                log.info(
+                                    f'Moving extracted file: "{file_path}" to "{file_dest}"'
+                                )
+                                try:
+                                    move_file(file_path, file_dest)
+                                except OSError as e:
+                                    log.error(
+                                        f"Failed to move {file_path} to {file_dest}: {e}"
+                                    )
+                    elif item.item_type == "track":
+                        # Determine local_path for zip format track
+                        if self.dir_format == "zip":
+                            local_path = self.local_media.get_path_for_track_purchase(item)
 
-                        if self.ign_file_path:
-                            # We assume that if you use an ignore file once, you'll
-                            # keep using it forever (e.g. Docker).
-                            # In case you don't, you'll get warnings for missing id file
-                            # on the items downloaded in the current session.
-                            self.ignores.add(item)
-                        else:
-                            self.local_media.write_bandcamp_id(item, local_path)
-
-                        self.new_items_downloaded = True
-                        return True
-
-                except (
-                    BandcampError,
-                    DownloadBadStatusCode,
-                    DownloadInvalidContentType,
-                ) as e:
-                    if attempt < self.max_retries - 1:
-                        log.warning(
-                            f"Attempt {attempt + 1} failed for {item.band_name} / {item.item_title}: {e}. "
-                            f"Retrying in {self.retry_wait} seconds..."
+                        slug = item.item_title
+                        if item.url_hints and isinstance(item.url_hints, dict):
+                            slug = item.url_hints.get("slug", item.item_title)
+                        format_extension = self.local_media.clean_format(
+                            self.media_format
                         )
-                        time.sleep(self.retry_wait)
-                        continue
+                        try:
+                            local_path.mkdir(parents=True, exist_ok=True)
+                        except OSError as e:
+                            log.error(
+                                f"Failed to create directory: {local_path} ({e}), skipping file write"
+                            )
+                            continue
+                        file_dest = self.local_media.get_path_for_file(
+                            local_path, f"{slug}.{format_extension}"
+                        )
+                        log.info(
+                            f'Copying single track: "{temp_file_path}" to "{file_dest}"'
+                        )
+                        try:
+                            copy_file(temp_file_path, file_dest)
+                        except OSError as e:
+                            log.error(
+                                f"Failed to copy {temp_file_path} to {file_dest}: {e}"
+                            )
                     else:
                         log.error(
-                            f"All {self.max_retries} attempts failed for {item.band_name} / {item.item_title}: {e}. Skipping."
+                            f'Downloaded file for "{item.band_name} / {item.item_title}" (id:{item.item_id}) '
+                            f'at "{temp_file_path}" is not a zip archive or a single track, skipping'
                         )
                         return False
-                except DownloadExpired:
+
+                    if self.ign_file_path:
+                        # We assume that if you use an ignore file once, you'll
+                        # keep using it forever (e.g. Docker).
+                        # In case you don't, you'll get warnings for missing id file
+                        # on the items downloaded in the current session.
+                        self.ignores.add(item)
+                    else:
+                        self.local_media.write_bandcamp_id(item, local_path)
+
+                    self.new_items_downloaded = True
+                    return True
+
+            except (
+                BandcampError,
+                DownloadBadStatusCode,
+                DownloadInvalidContentType,
+            ) as e:
+                if attempt < self.max_retries - 1:
+                    log.warning(
+                        f"Attempt {attempt + 1} failed for {item.band_name} / {item.item_title}: {e}. "
+                        f"Retrying in {self.retry_wait} seconds..."
+                    )
+                    time.sleep(self.retry_wait)
+                    continue
+                else:
                     log.error(
-                        f'Download expired and requires email confirmation on Bandcamp for "{item.band_name} / {item.item_title}" '
-                        f"(id:{item.item_id}), skipping"
+                        f"All {self.max_retries} attempts failed for {item.band_name} / {item.item_title}: {e}. Skipping."
                     )
                     return False
+            except DownloadExpired:
+                log.error(
+                    f'Download expired and requires email confirmation on Bandcamp for "{item.band_name} / {item.item_title}" '
+                    f"(id:{item.item_id}), skipping"
+                )
+                return False
 
     async def sync_items(self):
         """Syncs all items with optional concurrency."""

--- a/bandcampsync/sync.py
+++ b/bandcampsync/sync.py
@@ -84,8 +84,9 @@ class Syncer:
         if self.dir_format == "artist-album":
             local_path = self.local_media.get_path_for_purchase(item)
             if self.ignores.is_ignored(item):
-                if not self.show_id_file_warning and self.local_media.is_locally_downloaded(
-                    item, local_path
+                if (
+                    not self.show_id_file_warning
+                    and self.local_media.is_locally_downloaded(item, local_path)
                 ):
                     self.show_id_file_warning = True
                 return False
@@ -154,9 +155,13 @@ class Syncer:
                             local_path = self.local_media.get_path_for_purchase(item)
 
                         # In zip mode, check if target directory already exists
-                        if self.dir_format == "zip" and local_path.is_dir() and any(local_path.iterdir()):
+                        if (
+                            self.dir_format == "zip"
+                            and local_path.is_dir()
+                            and any(local_path.iterdir())
+                        ):
                             log.info(
-                                f'Target directory already exists with files, writing tracking and skipping extraction: '
+                                f"Target directory already exists with files, writing tracking and skipping extraction: "
                                 f'"{local_path}" (id:{item.item_id})'
                             )
                             if self.ign_file_path:
@@ -194,7 +199,9 @@ class Syncer:
                     elif item.item_type == "track":
                         # Determine local_path for zip format track
                         if self.dir_format == "zip":
-                            local_path = self.local_media.get_path_for_track_purchase(item)
+                            local_path = self.local_media.get_path_for_track_purchase(
+                                item
+                            )
 
                         if self.dir_format == "zip":
                             track_name = f"{item.band_name} - {item.item_title}"

--- a/bin/bandcampfree
+++ b/bin/bandcampfree
@@ -44,6 +44,12 @@ if __name__ == '__main__':
     parser.add_argument('--pending-only', action='store_true',
         help='Download the already-queued backlog without re-scanning any label. Use for '
              'repeated bounded runs after an initial scan.')
+    parser.add_argument('--backfill-ids', action='store_true',
+        help='Write bandcamp_item_id.txt into local directories that lack one, making '
+             'dedup exact instead of relying on fragile title matching. Dry run unless '
+             '--apply is given.')
+    parser.add_argument('--apply', action='store_true',
+        help='Actually write changes for --backfill-ids (default is a dry run)')
     parser.add_argument('--check-duplicates', action='store_true',
         help='Report local directories that look like the same release under different '
              'names (labels add catalogue numbers or drop "(free!)" suffixes). Reports '
@@ -94,6 +100,12 @@ if __name__ == '__main__':
     log.info(f'Media directory: {config.media_dir}')
 
     only_labels = set(args.label) if args.label else None
+
+    if args.backfill_ids:
+        from bandcampsync.freesync import FreeState, backfill_ids
+        backfill_ids(config, FreeState(state_path), only_labels=only_labels,
+                     apply=args.apply)
+        sys.exit(0)
 
     if args.check_duplicates:
         from bandcampsync.freesync import report_duplicates

--- a/bin/bandcampfree
+++ b/bin/bandcampfree
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+
+import sys
+import argparse
+from pathlib import Path
+from bandcampsync import version, logger
+from bandcampsync.labelconfig import load_config
+from bandcampsync.freesync import generate_free_report, do_free_sync
+
+
+log = logger.get_logger('runfree')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog='bandcampfree',
+        description='Watches record label bandcamp.com pages for free and pay-what-you-want albums',
+    )
+    parser.add_argument('-v', '--version', action='store_true',
+        help='Displays the bandcampsync version and exits')
+    parser.add_argument('-C', '--config', default='',
+        help='Path to the YAML label configuration file')
+    parser.add_argument('-d', '--directory', default='',
+        help='Path to the media directory, overrides defaults.media_dir in the config')
+    parser.add_argument('-s', '--state', default='',
+        help='Path to the scan state file (default: alongside the config as bandcampfree-state.json)')
+    parser.add_argument('-l', '--label', action='append', default=[],
+        help='Only scan the named label, may be repeated')
+    parser.add_argument('--full-scan', action='store_true',
+        help='Ignore release date cutoffs and re-examine every album for each label')
+    parser.add_argument('--report', action='store_true',
+        help='Report what would be downloaded without downloading anything')
+    parser.add_argument('--limit', type=int, default=0,
+        help='Download at most this many albums this run')
+    parser.add_argument('--max-gb', type=float, default=0.0,
+        help='Stop once this many GB have been downloaded this run')
+    parser.add_argument('-t', '--temp-dir', default='',
+        help='Path to use for temporary downloads')
+    parser.add_argument('--repair', type=int, default=0, metavar='ITEM_ID',
+        help='Re-fetch one album and add only the files missing from its local directory. '
+             'For albums a label extended after the original download; bandcamp does not '
+             'allow fetching individual tracks of a compilation.')
+    parser.add_argument('--pending-only', action='store_true',
+        help='Download the already-queued backlog without re-scanning any label. Use for '
+             'repeated bounded runs after an initial scan.')
+    parser.add_argument('--check-duplicates', action='store_true',
+        help='Report local directories that look like the same release under different '
+             'names (labels add catalogue numbers or drop "(free!)" suffixes). Reports '
+             'only; removes nothing.')
+    parser.add_argument('--gmail-auth', action='store_true',
+        help='Run the one-time Gmail authorisation flow and exit')
+    parser.add_argument('--client-secret', default=str(Path.home() / '.bandcampfree' / 'client_secret.json'),
+        help='Path to the Google OAuth desktop client JSON')
+    parser.add_argument('--token', default=str(Path.home() / '.bandcampfree' / 'token.json'),
+        help='Path to store the Gmail OAuth token')
+    args = parser.parse_args()
+
+    if args.version:
+        print(f'BandcampSync version: {version}', file=sys.stdout)
+        sys.exit(0)
+
+    if args.gmail_auth:
+        from bandcampsync.gmail import load_credentials, GmailReader
+        creds = load_credentials(args.client_secret, args.token)
+        reader = GmailReader(creds)
+        links = reader.find_download_links(newer_than='7d')
+        log.info(f'Gmail authorisation complete, token stored at {args.token}')
+        if links:
+            log.info(f'Found {len(links)} recent bandcamp download link(s):')
+            for item_id, url in sorted(links.items()):
+                log.info(f'  item {item_id}: {url[:70]}...')
+        else:
+            log.info('No bandcamp download emails found in the last 7 days')
+        sys.exit(0)
+
+    if not args.config:
+        raise ValueError('A configuration file is required (--config/-C)')
+
+    config_path = Path(args.config).resolve()
+    config = load_config(config_path)
+
+    if args.directory:
+        config.media_dir = Path(args.directory).resolve()
+    if not config.media_dir:
+        raise ValueError('No media directory set, use --directory or defaults.media_dir')
+    if not config.media_dir.is_dir():
+        raise ValueError(f'Media directory does not exist: {config.media_dir}')
+
+    state_path = Path(args.state).resolve() if args.state else \
+        config_path.parent / 'bandcampfree-state.json'
+
+    log.info(f'BandcampSync (free) v{version} starting')
+    log.info(f'Media directory: {config.media_dir}')
+
+    only_labels = set(args.label) if args.label else None
+
+    if args.check_duplicates:
+        from bandcampsync.freesync import report_duplicates
+        report_duplicates(config, only_labels=only_labels)
+        sys.exit(0)
+
+    if args.repair:
+        from bandcampsync.freesync import do_repair
+        do_repair(
+            config,
+            state_path,
+            args.repair,
+            client_secret=args.client_secret,
+            token_path=args.token,
+        )
+        log.info('Repair complete')
+        sys.exit(0)
+
+    if args.report:
+        generate_free_report(
+            config,
+            state_path,
+            full_scan=args.full_scan,
+            only_labels=only_labels,
+        )
+        log.info('Report complete')
+        sys.exit(0)
+
+    temp_dir = None
+    if args.temp_dir:
+        temp_dir = Path(args.temp_dir).resolve()
+        if not temp_dir.is_dir():
+            raise ValueError(f'Temporary directory does not exist: {temp_dir}')
+
+    do_free_sync(
+        config,
+        state_path,
+        full_scan=args.full_scan,
+        only_labels=only_labels,
+        limit=args.limit,
+        max_gb=args.max_gb,
+        temp_dir=temp_dir,
+        client_secret=args.client_secret,
+        token_path=args.token,
+        pending_only=args.pending_only,
+    )
+    log.info('Done')

--- a/bin/bandcampsync
+++ b/bin/bandcampsync
@@ -4,7 +4,7 @@
 import sys
 import argparse
 from pathlib import Path
-from bandcampsync import version, logger, do_sync
+from bandcampsync import version, logger, do_sync, generate_report
 
 
 log = logger.get_logger('run')
@@ -41,6 +41,12 @@ if __name__ == '__main__':
         help='Skip indexing downloaded items in the filesystem; only use ignore file for to determining which items are downloaded already')
     parser.add_argument('--sync-ignore-file', action='store_true',
         help='Add already downloaded items found in filesystem to ignore file')
+    parser.add_argument('--dir-format', choices=['artist-album', 'zip'], default='artist-album',
+        help='Directory naming format: "artist-album" (default: Artist/Album) or "zip" (Artist - Album, with label grouping)')
+    parser.add_argument('--report', action='store_true',
+        help='Run in report mode: compare purchases to local files without downloading')
+    parser.add_argument('--report-csv', default='',
+        help='Write a CSV report to the given path (implies --report)')
     args = parser.parse_args()
     if args.version:
         print(f'BandcampSync version: {version}', file=sys.stdout)
@@ -52,6 +58,7 @@ if __name__ == '__main__':
     media_format = args.format
     skip_item_index = args.skip_item_index
     sync_ignore_file = args.sync_ignore_file
+    dir_format = args.dir_format
 
     if skip_item_index and not ign_file_path:
         raise ValueError("--skip-item-index was passed, but no ignore file path was passed. --skip-item-index requires an ignore file path (--ignore-file/-I)")
@@ -85,6 +92,19 @@ if __name__ == '__main__':
     with open(cookies_path, 'rt') as f:
         cookies = f.read().strip()
     log.info(f'Loaded cookies from "{cookies_path}"')
+    if args.report or args.report_csv:
+        csv_path = Path(args.report_csv).resolve() if args.report_csv else None
+        generate_report(
+            cookies,
+            dir_path,
+            ign_file_path=ign_file_path,
+            ign_patterns=ign_patterns,
+            skip_item_index=skip_item_index,
+            dir_format=dir_format,
+            csv_path=csv_path,
+        )
+        log.info('Report complete')
+        sys.exit(0)
     do_sync(
         cookies,
         dir_path,
@@ -97,6 +117,7 @@ if __name__ == '__main__':
         max_retries,
         retry_wait,
         skip_item_index,
-        sync_ignore_file
+        sync_ignore_file,
+        dir_format,
     )
     log.info(f'Done')

--- a/bin/bandcampsync-service
+++ b/bin/bandcampsync-service
@@ -40,6 +40,7 @@ if __name__ == '__main__':
     retry_wait_env = os.getenv('RETRY_WAIT', '5')
     concurrency_env = os.getenv('CONCURRENCY', '1')
     skip_item_index_env = os.getenv('SKIP_ITEM_INDEX', False)
+    dir_format_env = os.getenv('DIR_FORMAT', 'artist-album')
     try:
         max_retries = int(max_retries_env)
     except (ValueError, TypeError):
@@ -56,6 +57,7 @@ if __name__ == '__main__':
         skip_item_index = bool(skip_item_index_env)
     except (ValueError, TypeError):
         skip_item_index = False
+    dir_format = dir_format_env if dir_format_env in ('artist-album', 'zip') else 'artist-album'
 
 
     cookies_path = Path(cookies_path_env).resolve()
@@ -104,7 +106,7 @@ if __name__ == '__main__':
     try:
         while not catch_shutdown.shutdown:
             log.info(f'Starting synchronisation')
-            do_sync(cookies, dir_path, media_format_env, temp_dir, ign_file_path, ign_patterns, notify_url, concurrency, max_retries, retry_wait, skip_item_index)
+            do_sync(cookies, dir_path, media_format_env, temp_dir, ign_file_path, ign_patterns, notify_url, concurrency, max_retries, retry_wait, skip_item_index, dir_format=dir_format)
             random_delay = randrange(0, 3600)
             time_now = datetime.now(tz).replace(microsecond=0)
             time_tomorrow = time_now + timedelta(days=1)

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -1,0 +1,466 @@
+"""Find duplicate directories in the music library.
+
+Detects cases where the same album exists both at the top level
+(e.g., "Artist - Album") and inside a label subdirectory
+(e.g., "LabelName/Artist - Album").
+
+Compares file names and sizes to confirm duplicates.
+
+Usage:
+    python find_duplicates.py [media_dir]              # Report only
+    python find_duplicates.py [media_dir] --review     # Detailed review of non-safe items
+    python find_duplicates.py [media_dir] --resolve    # Dry-run: show what would be done
+    python find_duplicates.py [media_dir] --resolve --execute  # Actually resolve safe duplicates
+"""
+
+import io
+import os
+import shutil
+import sys
+import unicodedata
+from pathlib import Path
+from collections import defaultdict
+
+# Force UTF-8 output on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+
+ITEM_INDEX_FILENAME = "bandcamp_item_id.txt"
+
+# Characters that bandcampsync's _clean_path() strips from filenames
+SANITIZED_CHARS = set("#%'*/?\\:")
+
+IGNORABLE_FILES = {"Thumbs.db", "desktop.ini", ".DS_Store"}
+
+
+def sanitize_name(name):
+    """Normalize a filename for comparison.
+
+    Applies the same stripping as bandcampsync's _clean_path(), plus:
+    - NFC Unicode normalization
+    - Strips combining diacritical marks (handles decomposed vs precomposed)
+    - Normalizes smart quotes and accent marks to nothing (like _clean_path strips ')
+    """
+    # First NFC-normalize so we have a consistent base
+    name = unicodedata.normalize("NFC", name)
+    # Strip the characters _clean_path removes
+    name = "".join(c for c in name if c not in SANITIZED_CHARS)
+    # Decompose to NFD so we can strip combining marks
+    name = unicodedata.normalize("NFD", name)
+    # Remove combining diacritical marks (category "M")
+    name = "".join(c for c in name if unicodedata.category(c) != "Mn")
+    # Re-compose
+    name = unicodedata.normalize("NFC", name)
+    # Normalize various quote-like and accent characters to nothing
+    name = name.replace("\u00B4", "")  # acute accent ´
+    name = name.replace("\u2018", "")  # left single quote '
+    name = name.replace("\u2019", "")  # right single quote '
+    # Normalize ellipsis
+    name = name.replace("\u2026", "...")
+    # Collapse whitespace (stripping combining marks can leave extra spaces)
+    name = " ".join(name.split())
+    return name
+
+
+def names_match_after_sanitize(name_a, name_b):
+    """Check if two filenames match after applying path sanitization.
+
+    Also tries matching with spaces removed to handle cases where
+    combining accents acting as apostrophes leave orphan spaces.
+    """
+    sa, sb = sanitize_name(name_a), sanitize_name(name_b)
+    if sa == sb:
+        return True
+    # Fallback: compare without spaces (handles 'Paddy s' vs 'Paddys')
+    return sa.replace(" ", "") == sb.replace(" ", "")
+
+
+def build_sanitized_mapping(names_a, names_b):
+    """Try to pair up filenames that differ only by sanitized characters.
+
+    Returns dict mapping name_a -> name_b for matched pairs, or None if
+    not all unpaired names can be matched.
+    """
+    mapping = {}
+    unmatched_b = set(names_b)
+    for na in names_a:
+        for nb in list(unmatched_b):
+            if names_match_after_sanitize(na, nb):
+                mapping[na] = nb
+                unmatched_b.discard(nb)
+                break
+    return mapping if not unmatched_b else None
+
+
+def get_file_inventory(dirpath):
+    """Return dict of {filename: size} for all files in a directory (non-recursive)."""
+    inventory = {}
+    try:
+        for entry in os.scandir(dirpath):
+            if entry.is_file():
+                if entry.name == ITEM_INDEX_FILENAME:
+                    continue
+                try:
+                    inventory[entry.name] = entry.stat().st_size
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return inventory
+
+
+def get_item_id(dirpath):
+    """Read the bandcamp_item_id.txt from a directory, or return None."""
+    id_file = Path(dirpath) / ITEM_INDEX_FILENAME
+    if id_file.is_file():
+        try:
+            return int(id_file.read_text().strip())
+        except (ValueError, OSError):
+            pass
+    return None
+
+
+def find_label_dirs(media_dir):
+    """Find directories that contain subdirectories with Artist - Album pattern."""
+    labels = {}
+    for entry in os.scandir(media_dir):
+        if not entry.is_dir():
+            continue
+        album_subdirs = []
+        try:
+            for sub in os.scandir(entry.path):
+                if sub.is_dir() and " - " in sub.name:
+                    album_subdirs.append(sub.name)
+        except OSError:
+            continue
+        if album_subdirs:
+            labels[entry.name] = album_subdirs
+    return labels
+
+
+def classify_overlap(top_files, label_files):
+    """Classify the overlap between two file inventories."""
+    if not top_files and not label_files:
+        return "both-empty", ""
+
+    # Filter out ignorable files (Thumbs.db, etc.) for classification
+    top_clean = {k: v for k, v in top_files.items() if k not in IGNORABLE_FILES}
+    label_clean = {k: v for k, v in label_files.items() if k not in IGNORABLE_FILES}
+
+    if not top_clean and label_clean:
+        return "empty-top", f"top has no real files, label has {len(label_clean)}"
+    if top_clean and not label_clean:
+        return "empty-label", f"label has no real files, top has {len(top_clean)}"
+    if not top_clean and not label_clean:
+        return "both-empty", ""
+
+    if top_clean == label_clean:
+        return "exact", ""
+
+    top_names = set(top_clean.keys())
+    label_names = set(label_clean.keys())
+
+    if top_names == label_names:
+        diffs = []
+        for name in top_names:
+            if top_clean[name] != label_clean[name]:
+                diff = abs(top_clean[name] - label_clean[name])
+                diffs.append((name, diff))
+        max_diff = max(d[1] for d in diffs) if diffs else 0
+        return "same-files-diff-sizes", f"max diff: {max_diff:,} bytes"
+
+    common = top_names & label_names
+    only_top = top_names - label_names
+    only_label = label_names - top_names
+
+    # Before declaring partial-overlap, check if unmatched files pair up
+    # after applying the same character sanitization bandcampsync uses
+    if only_top and only_label and len(only_top) == len(only_label):
+        mapping = build_sanitized_mapping(only_top, only_label)
+        if mapping:
+            n = len(common) + len(mapping)
+            return "sanitized-match", f"all {n} files match ({len(mapping)} after sanitization)"
+
+    # Also check if only_top/only_label are just ignorable leftovers
+    # that survived the initial filter (shouldn't happen, but defensive)
+
+    if not only_top and only_label:
+        return "superset-label", f"label has {len(only_label)} extra files"
+    if only_top and not only_label:
+        return "superset-top", f"top has {len(only_top)} extra files"
+
+    if len(top_clean) == len(label_clean) and len(common) >= len(top_clean) * 0.7:
+        return "filename-drift", f"{len(common)}/{len(top_clean)} files match"
+
+    ratio = max(len(top_clean), len(label_clean)) / max(1, min(len(top_clean), len(label_clean)))
+    if ratio > 2.0:
+        return "different-content", f"top: {len(top_clean)} files, label: {len(label_clean)} files"
+
+    if common:
+        return "partial-overlap", f"{len(common)} shared, {len(only_top)} only-top, {len(only_label)} only-label"
+    return "no-file-overlap", ""
+
+
+def find_duplicates(media_dir):
+    """Find duplicate directories that exist both at top level and in label subdirs."""
+    media_path = Path(media_dir)
+
+    top_level_dirs = set()
+    for entry in os.scandir(media_dir):
+        if entry.is_dir():
+            top_level_dirs.add(entry.name)
+
+    print(f"Found {len(top_level_dirs)} top-level directories")
+
+    labels = find_label_dirs(media_dir)
+    print(f"Found {len(labels)} potential label directories")
+
+    duplicates = []
+    for label_name, album_subdirs in sorted(labels.items()):
+        for album_name in sorted(album_subdirs):
+            if album_name in top_level_dirs:
+                top_path = media_path / album_name
+                label_path = media_path / label_name / album_name
+
+                top_files = get_file_inventory(top_path)
+                label_files = get_file_inventory(label_path)
+                match, detail = classify_overlap(top_files, label_files)
+
+                top_id = get_item_id(top_path)
+                label_id = get_item_id(label_path)
+
+                duplicates.append({
+                    "album": album_name,
+                    "label": label_name,
+                    "top_path": str(top_path),
+                    "label_path": str(label_path),
+                    "match": match,
+                    "detail": detail,
+                    "top_files": top_files,
+                    "label_files": label_files,
+                    "top_file_count": len(top_files),
+                    "label_file_count": len(label_files),
+                    "top_size": sum(top_files.values()),
+                    "label_size": sum(label_files.values()),
+                    "top_id": top_id,
+                    "label_id": label_id,
+                })
+
+    return duplicates
+
+
+SAFE_TYPES = {"exact", "same-files-diff-sizes", "filename-drift", "sanitized-match", "empty-top"}
+
+
+def print_report(duplicates):
+    """Print human-readable duplicate report."""
+    if not duplicates:
+        print("\nNo duplicates found.")
+        return
+
+    by_match = defaultdict(list)
+    for d in duplicates:
+        by_match[d["match"]].append(d)
+
+    total_recoverable = sum(
+        min(d["top_size"], d["label_size"])
+        for d in duplicates if d["match"] in SAFE_TYPES
+    )
+
+    print(f"\n{'='*60}")
+    print("DUPLICATE DIRECTORY REPORT")
+    print(f"{'='*60}")
+    print(f"Total duplicates found: {len(duplicates)}")
+    print(f"Space recoverable (safe matches): {total_recoverable / (1024**3):.1f} GB")
+    print()
+    for match_type, items in sorted(by_match.items()):
+        print(f"  {match_type}: {len(items)}")
+
+    order = ["exact", "same-files-diff-sizes", "filename-drift",
+             "sanitized-match", "empty-top", "empty-label",
+             "superset-label", "superset-top", "partial-overlap",
+             "different-content", "both-empty", "no-file-overlap"]
+    for match_type in order:
+        items = by_match.get(match_type, [])
+        if not items:
+            continue
+        print(f"\n{'-'*60}")
+        print(f"Match type: {match_type} ({len(items)} items)")
+        print(f"{'-'*60}")
+        for d in items:
+            detail = f" -- {d['detail']}" if d['detail'] else ""
+            print(f"\n  Album: {d['album']}")
+            print(f"  Label: {d['label']}{detail}")
+            print(f"  Top-level:  {d['top_file_count']} files, {d['top_size']:,} bytes (id: {d['top_id']})")
+            print(f"  Label dir:  {d['label_file_count']} files, {d['label_size']:,} bytes (id: {d['label_id']})")
+
+    by_label = defaultdict(list)
+    for d in duplicates:
+        by_label[d["label"]].append(d)
+
+    print(f"\n{'='*60}")
+    print("DUPLICATES BY LABEL")
+    print(f"{'='*60}")
+    for label, items in sorted(by_label.items(), key=lambda x: -len(x[1])):
+        label_total = sum(min(d["top_size"], d["label_size"]) for d in items if d["match"] in SAFE_TYPES)
+        label_total_str = f" ({label_total / (1024**3):.1f} GB recoverable)" if label_total > 0 else ""
+        print(f"\n  {label}: {len(items)} duplicates{label_total_str}")
+        for d in items:
+            print(f"    - {d['album']} [{d['match']}]")
+
+
+def print_review(duplicates):
+    """Print detailed file-by-file comparison for non-safe items."""
+    non_safe = [d for d in duplicates if d["match"] not in SAFE_TYPES]
+    if not non_safe:
+        print("\nAll duplicates are safe matches - nothing to review.")
+        return
+
+    print(f"\n{'='*60}")
+    print(f"DETAILED REVIEW: {len(non_safe)} non-safe items")
+    print(f"{'='*60}")
+
+    for d in non_safe:
+        print(f"\n{'='*60}")
+        print(f"Album: {d['album']}")
+        print(f"Label: {d['label']}")
+        print(f"Match: {d['match']} -- {d['detail']}")
+        print(f"Top ID: {d['top_id']}  |  Label ID: {d['label_id']}")
+        print()
+
+        top_files = d["top_files"]
+        label_files = d["label_files"]
+        top_names = set(top_files.keys())
+        label_names = set(label_files.keys())
+        common = top_names & label_names
+        only_top = sorted(top_names - label_names)
+        only_label = sorted(label_names - top_names)
+
+        if common:
+            print("  SHARED FILES:")
+            for name in sorted(common):
+                ts = top_files[name]
+                ls = label_files[name]
+                marker = "" if ts == ls else f"  ** SIZE DIFF: {abs(ts - ls):,} bytes"
+                print(f"    {name} ({ts:,} / {ls:,}){marker}")
+
+        if only_top:
+            print(f"\n  ONLY IN TOP-LEVEL ({len(only_top)}):")
+            for name in only_top:
+                print(f"    {name} ({top_files[name]:,})")
+
+        if only_label:
+            print(f"\n  ONLY IN LABEL DIR ({len(only_label)}):")
+            for name in only_label:
+                print(f"    {name} ({label_files[name]:,})")
+
+
+def resolve_duplicates(duplicates, execute=False):
+    """Resolve safe duplicates by copying tracking to label dir and removing top-level.
+
+    For safe matches (exact, same-files-diff-sizes, filename-drift):
+      - Copy bandcamp_item_id.txt from top-level to label dir
+      - Delete top-level directory
+
+    For superset-label:
+      - Copy bandcamp_item_id.txt from top-level to label dir
+      - Delete top-level directory (label has more content)
+
+    For superset-top:
+      - Skip (top has more content, needs manual review)
+    """
+    SKIP_ALBUMS = {
+        "VAAV Social Club - The Contras of Falling in Love",
+        "The Frixion - To Hell and Back",
+    }
+    safe = [d for d in duplicates if d["match"] in SAFE_TYPES and d["album"] not in SKIP_ALBUMS]
+    superset_label = [d for d in duplicates if d["match"] == "superset-label" and d["album"] not in SKIP_ALBUMS]
+    resolvable = safe + superset_label
+
+    if not resolvable:
+        print("\nNo resolvable duplicates found.")
+        return
+
+    mode = "EXECUTING" if execute else "DRY RUN"
+    print(f"\n{'='*60}")
+    print(f"DUPLICATE RESOLUTION ({mode})")
+    print(f"{'='*60}")
+    print(f"Resolvable items: {len(resolvable)}")
+
+    total_freed = 0
+    resolved = 0
+    errors = 0
+
+    for d in resolvable:
+        top_path = Path(d["top_path"])
+        label_path = Path(d["label_path"])
+        item_id = d["top_id"]
+
+        label_id = d["label_id"]
+        action_needed = []
+
+        if item_id and label_id is None:
+            action_needed.append(f"Write {ITEM_INDEX_FILENAME} (id:{item_id}) to {label_path}")
+        elif item_id and label_id and label_id != item_id:
+            print(f"\n  SKIP (ID mismatch): {d['album']}")
+            print(f"    Top ID: {item_id}, Label ID: {label_id}")
+            continue
+
+        action_needed.append(f"Delete {top_path}")
+        freed = d["top_size"]
+        total_freed += freed
+
+        print(f"\n  [{d['match']}] {d['album']}")
+        print(f"    Label: {d['label']}")
+        for action in action_needed:
+            print(f"    -> {action}")
+        print(f"    Space freed: {freed / (1024**2):.0f} MB")
+
+        if execute:
+            try:
+                # Write tracking file to label dir
+                if label_id is None:
+                    id_file = label_path / ITEM_INDEX_FILENAME
+                    id_file.write_text(f"{item_id}\n")
+                    print(f"    [OK] Wrote {id_file}")
+
+                # Delete top-level directory
+                shutil.rmtree(str(top_path))
+                print(f"    [OK] Deleted {top_path}")
+                resolved += 1
+            except OSError as e:
+                print(f"    [ERROR] {e}")
+                errors += 1
+
+    print(f"\n{'-'*60}")
+    print(f"Total space to free: {total_freed / (1024**3):.1f} GB")
+    if execute:
+        print(f"Resolved: {resolved}, Errors: {errors}")
+    else:
+        print("Run with --execute to apply changes.")
+
+
+if __name__ == "__main__":
+    media_dir = r"N:\Bandcamp (FLAC)"
+    do_review = False
+    do_resolve = False
+    do_execute = False
+
+    args = sys.argv[1:]
+    # First non-flag arg is media_dir
+    positional = [a for a in args if not a.startswith("--")]
+    if positional:
+        media_dir = positional[0]
+
+    do_review = "--review" in args
+    do_resolve = "--resolve" in args
+    do_execute = "--execute" in args
+
+    duplicates = find_duplicates(media_dir)
+    print_report(duplicates)
+
+    if do_review:
+        print_review(duplicates)
+
+    if do_resolve:
+        resolve_duplicates(duplicates, execute=do_execute)

--- a/fix_track_names.py
+++ b/fix_track_names.py
@@ -1,0 +1,122 @@
+"""Rename slug-named single-track files to use 'Artist - Title.flac' naming.
+
+Finds single-track directories where the FLAC file has a URL slug name
+(from direct track downloads, not ZIP extraction) and renames it to match
+the directory name.
+
+Usage:
+    python fix_track_names.py [media_dir]              # Dry run (report only)
+    python fix_track_names.py [media_dir] --execute    # Actually rename files
+"""
+
+import io
+import os
+import sys
+from pathlib import Path
+
+if sys.stdout.encoding != "utf-8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+
+IGNORABLE = {"Thumbs.db", "desktop.ini", ".DS_Store", "bandcamp_item_id.txt"}
+
+
+def find_misnamed_tracks(media_dir):
+    """Find single-track directories where the FLAC has a slug name."""
+    base = Path(media_dir)
+    results = []
+
+    dirs_to_check = []
+    for entry in os.scandir(str(base)):
+        if not entry.is_dir():
+            continue
+        # Top-level album dir
+        if " - " in entry.name:
+            dirs_to_check.append((entry.path, None))
+        # Label subdir
+        for sub in os.scandir(entry.path):
+            if sub.is_dir() and " - " in sub.name:
+                dirs_to_check.append((sub.path, entry.name))
+
+    for dirpath, label in dirs_to_check:
+        dirname = os.path.basename(dirpath)
+
+        # Get audio files
+        audio_files = []
+        for f in os.scandir(dirpath):
+            if f.is_file() and f.name not in IGNORABLE and f.name.lower().endswith(".flac"):
+                audio_files.append(f.name)
+
+        # Only single-track directories
+        if len(audio_files) != 1:
+            continue
+
+        current = audio_files[0]
+        expected = f"{dirname}.flac"
+
+        # Skip if already correctly named
+        if current == expected:
+            continue
+
+        stem = current.rsplit(".", 1)[0]
+
+        # Skip files from ZIP extraction (start with dir name or contain ' - ')
+        if current.startswith(dirname) or " - " in stem:
+            continue
+
+        results.append({
+            "dir": dirpath,
+            "label": label,
+            "dirname": dirname,
+            "current": current,
+            "expected": expected,
+        })
+
+    return results
+
+
+def fix_tracks(results, execute=False):
+    mode = "EXECUTING" if execute else "DRY RUN"
+    print(f"\n{'=' * 60}")
+    print(f"TRACK RENAME ({mode})")
+    print(f"{'=' * 60}")
+    print(f"Tracks to rename: {len(results)}\n")
+
+    renamed = 0
+    errors = 0
+
+    for r in results:
+        label_str = f" (in {r['label']})" if r["label"] else ""
+        print(f"  {r['dirname']}{label_str}")
+        print(f"    {r['current']}")
+        print(f"    -> {r['expected']}")
+
+        if execute:
+            src = Path(r["dir"]) / r["current"]
+            dst = Path(r["dir"]) / r["expected"]
+            try:
+                src.rename(dst)
+                print(f"    [OK]")
+                renamed += 1
+            except OSError as e:
+                print(f"    [ERROR] {e}")
+                errors += 1
+        print()
+
+    print(f"{'-' * 60}")
+    if execute:
+        print(f"Renamed: {renamed}, Errors: {errors}")
+    else:
+        print("Run with --execute to apply changes.")
+
+
+if __name__ == "__main__":
+    media_dir = r"N:\Bandcamp (FLAC)"
+    args = sys.argv[1:]
+    positional = [a for a in args if not a.startswith("--")]
+    if positional:
+        media_dir = positional[0]
+
+    do_execute = "--execute" in args
+
+    results = find_misnamed_tracks(media_dir)
+    fix_tracks(results, execute=do_execute)

--- a/labels.example.yaml
+++ b/labels.example.yaml
@@ -1,0 +1,49 @@
+# Configuration for bandcampfree, the free / pay-what-you-want label watcher.
+#
+# Scanning: the first time a label is scanned there is no date cutoff, so the whole back
+# catalogue is examined to catch anything missed during manual downloading. Afterwards the
+# cutoff defaults to the newest file modification time in the label's local directory. Set
+# "since" to override that, or pass --full-scan to ignore cutoffs entirely.
+
+defaults:
+  media_dir: "N:/Bandcamp (FLAC)"
+  format: flac
+  # Used for albums that require an email address to receive the download link.
+  email: you@example.com
+  country: US
+  postcode: "12345"
+  # Seconds between API requests. Bandcamp returns HTTP 429 if pushed; a full first
+  # scan of a large label issues hundreds of requests, so keep this at 1s or higher.
+  request_delay: 1.0
+
+labels:
+  # Compilations are tagged with an album artist of "Various Artists" and each track
+  # carries its own artist, so both signals are available.
+  - name: Future Avenue
+    url: https://futureavenuelabel.bandcamp.com/
+    band_id: 2509431535
+    match:
+      various_artists: true
+      track_artists_vary: true
+    enabled: true
+
+  # A counter-example: the album artist is the label itself and every track artist is
+  # null, with the real artist encoded in the track title as "Artist : Title". The rules
+  # that work for Future Avenue would match nothing here.
+  - name: Tadpole Records
+    url: https://tadpolerecords.bandcamp.com/
+    band_id: 2942737017
+    match:
+      title_separator: " : "
+      min_tracks: 10
+    enabled: true
+
+  # A label with few releases where every free album is wanted: omit "match" entirely.
+  # - name: Example Label
+  #   url: https://examplelabel.bandcamp.com/
+  #   enabled: true
+
+  # A dormant label kept for reference but not scanned.
+  # - name: Defunct Label
+  #   url: https://defunctlabel.bandcamp.com/
+  #   enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license-files = ["LICENSE",]
 dependencies = [
     "beautifulsoup4>=4.14.3",
     "curl-cffi>=0.14.0",
+    "pyyaml>=6.0",
 ]
 keywords = [
   "bandcampsync",
@@ -25,6 +26,14 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.optional-dependencies]
+# Only needed for retrieving download links for albums that require an email address.
+# The core sync tool does not need these.
+gmail = [
+    "google-auth>=2.30.0",
+    "google-auth-oauthlib>=1.2.0",
 ]
 
 [project.urls]

--- a/resolve_reviewed_dupes.py
+++ b/resolve_reviewed_dupes.py
@@ -1,0 +1,385 @@
+"""Resolve duplicates identified in 'duplicate review.txt'."""
+
+import io
+import shutil
+import os
+import sys
+from pathlib import Path
+
+if sys.stdout.encoding != "utf-8":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+
+base = Path(r"N:\Bandcamp (FLAC)")
+IDFILE = "bandcamp_item_id.txt"
+
+
+def move_tracking(src_dir, dst_dir):
+    src_id = src_dir / IDFILE
+    dst_id = dst_dir / IDFILE
+    if src_id.exists() and not dst_id.exists():
+        content = src_id.read_text().strip()
+        dst_id.write_text(f"{content}\n")
+        print(f"    Wrote tracking ID {content} to keep dir")
+    elif src_id.exists() and dst_id.exists():
+        print(f"    Both have tracking (keep:{dst_id.read_text().strip()}, remove:{src_id.read_text().strip()})")
+
+
+JUNK_FILES = {"Thumbs.db", "desktop.ini", ".DS_Store"}
+
+
+def cleanup_parent(path):
+    parent = path.parent
+    if parent != base:
+        _remove_if_empty(parent)
+
+
+def _remove_if_empty(d):
+    """Remove directory if it only contains junk files (Thumbs.db etc.)."""
+    if not d.exists():
+        return
+    try:
+        remaining = [f for f in d.iterdir() if f.name not in JUNK_FILES]
+        if not remaining:
+            shutil.rmtree(str(d))
+            print(f"    Removed parent: {d.name}")
+    except OSError:
+        pass
+
+
+def _force_rmtree(path):
+    """Remove directory tree, fixing permissions if needed."""
+    import stat
+
+    def on_error(func, fpath, exc_info):
+        try:
+            os.chmod(fpath, stat.S_IRWXU)
+            func(fpath)
+        except OSError:
+            pass
+
+    shutil.rmtree(str(path), onerror=on_error)
+
+
+def resolve(keep_path, remove_path):
+    keep = Path(keep_path)
+    remove = Path(remove_path)
+    if not keep.exists():
+        print(f"  [SKIP] Keep dir not found: {keep}")
+        return False
+    if not remove.exists():
+        print(f"  [SKIP] Remove dir not found: {remove}")
+        return False
+    move_tracking(remove, keep)
+    _force_rmtree(remove)
+    cleanup_parent(remove)
+    print(f"  [OK] Kept: .../{keep.parent.name}/{keep.name}" if keep.parent != base else f"  [OK] Kept: {keep.name}")
+    print(f"       Removed: .../{remove.parent.name}/{remove.name}" if remove.parent != base else f"       Removed: {remove.name}")
+    return True
+
+
+def find_dir(parent, *keywords):
+    """Find a directory under parent containing all keywords."""
+    for d in parent.iterdir():
+        if d.is_dir() and all(k in d.name for k in keywords):
+            return d
+    return None
+
+
+def find_dirs(parent, *keywords):
+    """Find all directories under parent containing all keywords."""
+    return [d for d in parent.iterdir() if d.is_dir() and all(k in d.name for k in keywords)]
+
+
+def main():
+    swamp = base / "The Swamp Records"
+    alfa = base / "Alfa Matrix"
+    at = base / "AnalogueTrash"
+    upr = base / "UNKNOWN PLEASURES RECORDS"
+    dt = base / "darkTunes"
+    va = base / "VA"
+
+    print("=== The Swamp Records duplicates ===\n")
+
+    # A.J. Kaufmann pairs
+    for d in list(base.iterdir()):
+        if not d.is_dir() or d == swamp:
+            continue
+        if d.name.startswith("A.J. Kaufmann") and d.is_dir():
+            has_subdirs = any(s.is_dir() for s in d.iterdir())
+            if not has_subdirs:
+                continue
+            for sub in list(d.iterdir()):
+                if sub.is_dir():
+                    swamp_match = find_dir(swamp, *sub.name.split(" - ", 1))
+                    if swamp_match:
+                        resolve(swamp_match, sub)
+            if d.exists():
+                remaining = [f for f in d.iterdir() if f.name not in {"Thumbs.db", "desktop.ini", ".DS_Store"}]
+                if not remaining:
+                    shutil.rmtree(str(d))
+                    print(f"    Removed parent: {d.name}")
+
+    # Bog Wizard & Dust Lord
+    for d in find_dirs(base, "Bog Wizard", "Dust Lord"):
+        if d.parent == base:
+            for sub in list(d.iterdir()):
+                if sub.is_dir() and "Four Tales" in sub.name:
+                    swamp_match = find_dir(swamp, "Bog Wizard", "Four Tales")
+                    if swamp_match:
+                        resolve(swamp_match, sub)
+            _remove_if_empty(d)
+
+    # Pink Elephant Music volumes
+    for d in list(base.iterdir()):
+        if "Pink Elephant Music Vol" in d.name and d.is_dir() and d.parent == base:
+            d_digits = "".join(c for c in d.name if c.isdigit())
+            for sw in swamp.iterdir():
+                if "Pink Elephant Music Vol" in sw.name:
+                    sw_digits = "".join(c for c in sw.name if c.isdigit())
+                    if d_digits and sw_digits and d_digits == sw_digits:
+                        resolve(sw, d)
+                        break
+
+    # MurderNotSuicide
+    for d in list(base.iterdir()):
+        if "MurderNotSuicide" in d.name and d.is_dir() and d.parent == base:
+            for sub in list(d.iterdir()):
+                if sub.is_dir() and "INTO THE BLACK" in sub.name:
+                    swamp_match = find_dir(swamp, "MurderNotSuicide", "INTO THE BLACK")
+                    if swamp_match:
+                        resolve(swamp_match, sub)
+            _remove_if_empty(d)
+
+    # Green Hog Band
+    for d in list(base.iterdir()):
+        if "Green Hog Band" in d.name and "Crypt of Doom" in d.name and d.parent == base:
+            swamp_match = find_dir(swamp, "Green Hog Band", "Crypt of Doom")
+            if swamp_match:
+                resolve(swamp_match, d)
+
+    # Merlock
+    for d in list(base.iterdir()):
+        if "Merlock" in d.name and "that which speaks" in d.name and d.parent == base:
+            swamp_match = find_dir(swamp, "Merlock", "that which speaks")
+            if swamp_match:
+                resolve(swamp_match, d)
+
+    print("\n=== Alfa Matrix duplicates ===\n")
+
+    # MATRIX REB00TED volumes
+    for d in list(base.iterdir()):
+        if "MATRIX" in d.name and "REB00TED" in d.name and d.is_dir() and d.parent == base:
+            for key in ["SIMON CARTER", "PSY"]:
+                if key in d.name:
+                    for am in alfa.iterdir():
+                        if key in am.name:
+                            # More specific match for PSY'AVIAH volumes
+                            if "Trip" in d.name and "Trip" not in am.name:
+                                continue
+                            if "Electro Dance" in d.name and "Electro Dance" not in am.name:
+                                continue
+                            if "Hard Dance" in d.name and "Hard Dance" not in am.name:
+                                continue
+                            resolve(am, d)
+                            break
+                    break
+
+    # Alfa Matrix Re-covered volumes
+    for d in list(base.iterdir()):
+        if "Alfa Matrix Re-covered" in d.name and d.is_dir() and d.parent == base:
+            if "Vol.2" in d.name or "Vol. 2" in d.name:
+                am = find_dir(alfa, "Re-covered", "Vol. 2")
+                if not am:
+                    am = find_dir(alfa, "Re-covered", "Vol.2")
+                if am:
+                    resolve(am, d)
+            elif "Vol.1" in d.name or ("Bonus Tracks Version)" in d.name and "Vol" not in d.name):
+                # Vol 1 or the original (no vol number)
+                for am in alfa.iterdir():
+                    if "Re-covered" in am.name and "Vol. 2" not in am.name and "Vol.2" not in am.name:
+                        resolve(am, d)
+                        break
+
+    print("\n=== AnalogueTrash ===\n")
+    top_bliss = base / "This Bliss - Grave of Sound"
+    label_bliss = at / "This Bliss - Grave of Sound"
+    if top_bliss.exists() and label_bliss.exists():
+        resolve(label_bliss, top_bliss)
+
+    print("\n=== Brown Bear Records ===\n")
+    bbr = base / "Brown Bear Records"
+    for d in list(base.iterdir()):
+        if "Primal Beast" in d.name and d.is_dir() and d.parent == base and d != bbr:
+            for sub in list(d.iterdir()):
+                if sub.is_dir() and "Jurassic Park" in sub.name:
+                    br_match = find_dir(bbr, "Primal Beast", "Jurassic Park")
+                    if br_match:
+                        resolve(br_match, sub)
+            _remove_if_empty(d)
+
+    print("\n=== Collector's Series DIY ===\n")
+    csd = base / "Collector's Series DIY"
+    for d in list(base.iterdir()):
+        if "Varios Artistas" in d.name and d.is_dir() and d.parent == base:
+            for sub in list(d.iterdir()):
+                if sub.is_dir() and "Discography complete" in sub.name:
+                    cs_match = find_dir(csd, "Discography complete")
+                    if cs_match:
+                        resolve(cs_match, sub)
+            _remove_if_empty(d)
+
+    print("\n=== Amanda Palmer - apostrophe fix ===\n")
+    # Find the one with apostrophe and the one without
+    palmer_keep = None
+    palmer_remove = None
+    for d in base.iterdir():
+        if "Amanda Palmer" in d.name and "Rhiannon" in d.name and "Fire" in d.name:
+            if "It's" in d.name or "\u2019" in d.name:
+                palmer_keep = d
+            elif "Its" in d.name:
+                palmer_remove = d
+    if palmer_keep and palmer_remove:
+        resolve(palmer_keep, palmer_remove)
+
+    print("\n=== darkTunes ===\n")
+    for d in list(base.iterdir()):
+        if "Gothic Music Orgy" in d.name and d.is_dir() and d.parent == base:
+            dt_match = find_dir(dt, "Gothic Music Orgy")
+            if dt_match:
+                resolve(dt_match, d)
+
+    print("\n=== KICKING RECORDS vs VA ===\n")
+    kr = base / "KICKING RECORDS"
+    if va.exists() and kr.exists():
+        for vad in list(va.iterdir()):
+            if "CAFZIC" in vad.name:
+                kr_match = find_dir(kr, "CAFZIC")
+                if kr_match:
+                    resolve(kr_match, vad)
+    _remove_if_empty(va)
+
+    print("\n=== UNKNOWN PLEASURES RECORDS ===\n")
+
+    # CHRIS SHAPE + DAVE INOX
+    for d in list(base.iterdir()):
+        if "CHRIS SHAPE" in d.name and "Fake Truths" in d.name and d.parent == base:
+            u = find_dir(upr, "CHRIS SHAPE", "Fake Truths")
+            if u:
+                resolve(u, d)
+
+    # NOIR DESIR TRIBUTE
+    for d in list(base.iterdir()):
+        if d.name.startswith("NOIR DESIR") and d.is_dir() and d.parent == base:
+            if " - " not in d.name:
+                # It's the parent dir
+                for sub in list(d.iterdir()):
+                    if sub.is_dir() and "Filles" in sub.name:
+                        u = find_dir(upr, "NOIR DESIR", "Filles")
+                        if u:
+                            resolve(u, sub)
+                _remove_if_empty(d)
+
+    # EUROPEAN GHOST
+    for d in list(base.iterdir()):
+        if "EUROPEAN GHOST" in d.name and "Collection Of Shadows" in d.name and d.parent == base:
+            u = find_dir(upr, "EUROPEAN GHOST")
+            if u:
+                resolve(u, d)
+
+    # FOLLOW ME NOT
+    for d in list(base.iterdir()):
+        if "FOLLOW ME NOT" in d.name and "If The Sky Remains" in d.name and d.parent == base:
+            u = find_dir(upr, "FOLLOW ME NOT")
+            if u:
+                resolve(u, d)
+
+    # HIV+ albums
+    hiv_keys = [
+        "Empire of Chaos",
+        "Abstract & Harsh",
+        "Anthology Of Noise",
+        "Censored Frequencies",
+        "Hypnoise Movement",
+        "Interferencias",
+        "Overdose Kill Me",
+        "Rotten Beat",
+    ]
+    for d in list(base.iterdir()):
+        if d.name.startswith("HIV+") and d.is_dir() and d.parent == base:
+            for key in hiv_keys:
+                if key in d.name:
+                    u = find_dir(upr, "HIV+", key)
+                    if u:
+                        resolve(u, d)
+                    break
+
+    print("\n=== Depressive Illusions Records vs VA ===\n")
+    di = base / "Depressive Illusions Records"
+    if va.exists() and di.exists():
+        for vad in list(va.iterdir()):
+            if "KISS" in vad.name and "Black Diamond" in vad.name:
+                di_match = find_dir(di, "Black Diamond", "KISS")
+                if di_match:
+                    resolve(di_match, vad)
+    _remove_if_empty(va)
+
+    print("\n=== Cosa Magnetica ===\n")
+    cm = base / "Cosa Magnetica"
+    for d in list(base.iterdir()):
+        if "Olivier" in d.name and "Julie Rass" in d.name and d.is_dir() and d != cm:
+            for sub in list(d.iterdir()):
+                if sub.is_dir() and "Honey" in sub.name:
+                    cm_match = find_dir(cm, "Honey")
+                    if cm_match:
+                        resolve(cm_match, sub)
+            _remove_if_empty(d)
+
+    print("\n=== Lycia - Bleak Vane ===\n")
+    lycia_keep = None
+    lycia_remove = None
+    for d in base.iterdir():
+        if "Lycia" in d.name and "Bleak" in d.name and "Vane" in d.name:
+            if "~" in d.name:
+                lycia_keep = d
+            else:
+                lycia_remove = d
+    if lycia_keep and lycia_remove:
+        resolve(lycia_keep, lycia_remove)
+
+    print("\n=== Mellow Beast - pre-order ===\n")
+    mellow_keep = None
+    mellow_remove = None
+    for d in base.iterdir():
+        if "Mellow Beast" in d.name and "Grimble" in d.name:
+            if "pre-order" in d.name:
+                mellow_remove = d
+            else:
+                mellow_keep = d
+    if mellow_keep and mellow_remove:
+        resolve(mellow_keep, mellow_remove)
+
+    print("\n=== Scortor - typo fix ===\n")
+    scortor_keep = None
+    scortor_remove = None
+    for d in base.iterdir():
+        if "Scortor" in d.name and "Moist Tales" in d.name:
+            if d.name.endswith("Kingdom"):
+                scortor_keep = d
+            elif d.name.endswith("Kingdo"):
+                scortor_remove = d
+    if scortor_keep and scortor_remove:
+        resolve(scortor_keep, scortor_remove)
+
+    print("\n=== The Content Label ===\n")
+    tcl = base / "The Content Label"
+    for d in list(base.iterdir()):
+        if "Content L" in d.name and "Sampler 5" in d.name and d.is_dir() and d.parent == base:
+            tc_match = find_dir(tcl, "Sampler 5")
+            if tc_match:
+                resolve(tc_match, d)
+
+    print("\n=== Done ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/tralbum-details-free-compilation.json
+++ b/tests/data/tralbum-details-free-compilation.json
@@ -1,0 +1,37 @@
+{
+ "id": 760931394,
+ "title": "Atmospheric Progressive #021 (Free Download)",
+ "tralbum_artist": "Various Artists",
+ "price": 0.0,
+ "is_set_price": false,
+ "require_email": true,
+ "free_download": false,
+ "currency": "EUR",
+ "num_downloadable_tracks": 30,
+ "bandcamp_url": "https://futureavenuelabel.bandcamp.com/album/atmospheric-progressive-021-free-download",
+ "release_date": 1783036800,
+ "type": "a",
+ "label": null,
+ "tracks": [
+  {
+   "band_name": "Secretly Famous",
+   "title": "Galerus (Juan Ram Remix)",
+   "track_num": 1
+  },
+  {
+   "band_name": "Christopher Hermann",
+   "title": "The End of Our Story (Part 2) (Shayan Pasha Remix)",
+   "track_num": 2
+  },
+  {
+   "band_name": "Kris Dur",
+   "title": "Calupoh",
+   "track_num": 3
+  },
+  {
+   "band_name": "Vitaly Shturm",
+   "title": "Paranoid Girl (Instrumental Mix)",
+   "track_num": 4
+  }
+ ]
+}

--- a/tests/test_bandcamp.py
+++ b/tests/test_bandcamp.py
@@ -50,9 +50,11 @@ def physical_item(physical_payload):
 def test_is_physical_purchase_true(physical_item):
     assert BandcampItem(physical_item).is_physical_purchase() is True
 
+
 # Tests if an item is _not_ a physical purchase (though doesn't necessarily include a digital component).
 def test_is_physical_purchase_false(digital_item):
     assert BandcampItem(digital_item).is_physical_purchase() is False
+
 
 # Tests if a download URL can be retrieved for a digital purchase.
 def test_resolve_download_url_digital(bandcamp, digital_payload, digital_item):
@@ -63,6 +65,7 @@ def test_resolve_download_url_digital(bandcamp, digital_payload, digital_item):
     )
     expected_key = _download_key(digital_item)
     assert download_url == digital_payload["redownload_urls"][expected_key]
+
 
 # Tests that no download URL can be retrieved for a physical-only purchase.
 def test_resolve_download_url_physical(bandcamp, physical_payload, physical_item):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from bandcampsync.download import _is_expired_download_page
+from bandcampsync.download import _is_expired_download_page, _parse_content_disposition_filename
 
 
 def _load_fixture(name):
@@ -16,3 +16,34 @@ def test_expired_download_page():
 def test_non_expired_download_page():
     html = _load_fixture("download-choose-format.html")
     assert _is_expired_download_page(html) is False
+
+
+def test_parse_content_disposition_quoted():
+    header = 'attachment; filename="Artist - Album.zip"'
+    assert _parse_content_disposition_filename(header) == "Artist - Album.zip"
+
+
+def test_parse_content_disposition_unquoted():
+    header = "attachment; filename=Artist - Album.zip"
+    assert _parse_content_disposition_filename(header) == "Artist - Album.zip"
+
+
+def test_parse_content_disposition_utf8():
+    header = "attachment; filename*=UTF-8''Artist%20-%20Album.zip"
+    assert _parse_content_disposition_filename(header) == "Artist - Album.zip"
+
+
+def test_parse_content_disposition_utf8_special_chars():
+    header = "attachment; filename*=UTF-8''%C3%89milie%20-%20L%27album.zip"
+    assert _parse_content_disposition_filename(header) == "\u00c9milie - L'album.zip"
+
+
+def test_parse_content_disposition_missing():
+    assert _parse_content_disposition_filename(None) is None
+    assert _parse_content_disposition_filename("") is None
+    assert _parse_content_disposition_filename("attachment") is None
+
+
+def test_parse_content_disposition_utf8_preferred_over_plain():
+    header = "attachment; filename=\"fallback.zip\"; filename*=UTF-8''Preferred%20-%20Name.zip"
+    assert _parse_content_disposition_filename(header) == "Preferred - Name.zip"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
-from bandcampsync.download import _is_expired_download_page, _parse_content_disposition_filename
+from bandcampsync.download import (
+    _is_expired_download_page,
+    _parse_content_disposition_filename,
+)
 
 
 def _load_fixture(name):

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -780,3 +780,78 @@ def test_download_loop_survives_a_transient_network_error(tmp_path, monkeypatch)
     assert sum(1 for _a, path, _e in done if path) == 1
     # A transient failure stays queued for the next run rather than being written off.
     assert 1 in freesync.FreeState(state_path).pending
+
+
+def _sync_env(tmp_path, item_ids):
+    from bandcampsync import freesync
+
+    from bandcampsync.labelconfig import FreeConfig, LabelSpec
+
+    state_path = tmp_path / "s.json"
+    state = freesync.FreeState(state_path)
+    for i in item_ids:
+        state.pending[i] = "L"
+        state.items[i] = {
+            "title": f"Album {i}",
+            "url": f"https://x.bandcamp.com/album/{i}",
+            "num_tracks": 3,
+            "is_free": True,
+        }
+    state.save()
+    media = tmp_path / "media"
+    (media / "L").mkdir(parents=True)
+    config = FreeConfig(
+        labels=[LabelSpec(name="L", url="https://l.bandcamp.com/")],
+        media_dir=media,
+        email="e@x.com",
+        country="US",
+        postcode="12345",
+    )
+    return config, state_path
+
+
+def test_repeated_failures_eventually_give_up(tmp_path, monkeypatch):
+    """An album priced at zero that bandcamp still refuses (an exhausted free-download
+    allocation looks like this) would otherwise be retried on every run forever."""
+    from bandcampsync import freesync
+
+    config, state_path = _sync_env(tmp_path, [1])
+
+    def always_fails(album, spec, cfg, gmail, temp_dir):
+        raise ValueError("Sorry, this item is no longer available for free.")
+
+    monkeypatch.setattr("bandcampsync.freedownload.acquire_album", always_fails)
+
+    for attempt in range(1, freesync.MAX_DOWNLOAD_ATTEMPTS + 1):
+        freesync.do_free_sync(config, state_path, pending_only=True)
+        state = freesync.FreeState(state_path)
+        if attempt < freesync.MAX_DOWNLOAD_ATTEMPTS:
+            assert 1 in state.pending, f"should still be queued after {attempt}"
+            assert 1 not in state.skipped
+    assert 1 not in state.pending
+    assert 1 in state.skipped
+
+
+def test_a_success_clears_the_failure_count(tmp_path, monkeypatch):
+    from bandcampsync import freesync
+
+    config, state_path = _sync_env(tmp_path, [2])
+    calls = {"n": 0}
+
+    def fails_once(album, spec, cfg, gmail, temp_dir):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("transient")
+        target = config.media_dir / "L" / "Album 2"
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "t.flac").write_text("x")
+        return target
+
+    monkeypatch.setattr("bandcampsync.freedownload.acquire_album", fails_once)
+
+    freesync.do_free_sync(config, state_path, pending_only=True)
+    assert freesync.FreeState(state_path).failures.get(2) == 1
+    freesync.do_free_sync(config, state_path, pending_only=True)
+    state = freesync.FreeState(state_path)
+    assert 2 not in state.failures
+    assert 2 not in state.pending

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -650,3 +650,79 @@ def test_pending_albums_ignores_skipped(tmp_path):
     config = FreeConfig(labels=[LabelSpec(name="L", url="https://l.bandcamp.com/")])
     out = freesync.pending_albums(config, state)
     assert [a.item_id for _lab, a in out] == [1]
+
+
+def test_acquire_album_accepts_a_lazy_gmail_reader(monkeypatch):
+    """The cached require_email flag is unreliable, so the reader is built on demand.
+    acquire_album must therefore accept a callable, not just an instance."""
+    from bandcampsync import freedownload
+    from bandcampsync.labelconfig import FreeConfig, LabelSpec
+
+    built = []
+
+    class _Reader:
+        def wait_for_link(self, item_id):
+            return f"https://bandcamp.com/download?id={item_id}"
+
+    def factory():
+        built.append(1)
+        return _Reader()
+
+    # bandcamp emailed the link (returns None), so the reader must be constructed
+    monkeypatch.setattr(freedownload, "request_download", lambda *a, **k: None)
+    captured = {}
+    monkeypatch.setattr(
+        freedownload,
+        "resolve_and_download",
+        lambda url, album, label, media_dir, media_format="flac", temp_dir=None: (
+            captured.setdefault("url", url)
+        ),
+    )
+
+    album = FreeAlbum(
+        item_id=42,
+        title="x",
+        artist="a",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=1,
+    )
+    config = FreeConfig(email="e@x.com", country="US", postcode="12345")
+    spec = LabelSpec(name="L", url="https://l.bandcamp.com/")
+
+    freedownload.acquire_album(album, spec, config, factory)
+    assert built == [1], "reader should be built exactly once, on demand"
+    assert "id=42" in captured["url"]
+
+
+def test_acquire_album_still_accepts_a_plain_reader(monkeypatch):
+    from bandcampsync import freedownload
+    from bandcampsync.labelconfig import FreeConfig, LabelSpec
+
+    class _Reader:
+        def wait_for_link(self, item_id):
+            return "https://bandcamp.com/download?id=7"
+
+    monkeypatch.setattr(freedownload, "request_download", lambda *a, **k: None)
+    monkeypatch.setattr(
+        freedownload,
+        "resolve_and_download",
+        lambda *a, **k: "ok",
+    )
+    album = FreeAlbum(
+        item_id=7,
+        title="x",
+        artist="a",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=True,
+        free_download=False,
+        num_tracks=1,
+    )
+    config = FreeConfig(email="e@x.com", country="US", postcode="12345")
+    spec = LabelSpec(name="L", url="https://l.bandcamp.com/")
+    assert freedownload.acquire_album(album, spec, config, _Reader()) == "ok"

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -960,3 +960,46 @@ def test_fetch_details_returns_none_when_truly_gone(monkeypatch):
             return {"id": None, "title": ""}
 
     assert freesync._fetch_details_any_type(_API(), 1, 999, None, "L") is None
+
+
+def test_unavailable_release_is_retryable_not_permanent(tmp_path, monkeypatch):
+    """A release with an empty downloads dict is "currently unavailable" (Valentine
+    Records pulled several while their listings stayed live). A label can re-enable it,
+    so it must retry via the counter rather than being written off on the first failure
+    like a genuinely FLAC-less cassette."""
+    from bandcampsync import freesync
+
+    config, state_path = _sync_env(tmp_path, [1])
+
+    def unavailable(album, spec, cfg, gmail, temp_dir):
+        raise ValueError(
+            "Release offers no downloads (id 1); it may be temporarily unavailable"
+        )
+
+    monkeypatch.setattr("bandcampsync.freedownload.acquire_album", unavailable)
+
+    freesync.do_free_sync(config, state_path, pending_only=True)
+    state = freesync.FreeState(state_path)
+    assert 1 in state.pending, "an unavailable release must stay queued, not be skipped"
+    assert 1 not in state.skipped
+    assert state.failures.get(1) == 1
+
+
+def test_missing_format_is_permanent(tmp_path, monkeypatch):
+    """A release offering other formats but not FLAC (a cassette) will never gain it."""
+    from bandcampsync import freesync
+
+    config, state_path = _sync_env(tmp_path, [2])
+
+    def no_flac(album, spec, cfg, gmail, temp_dir):
+        raise ValueError(
+            "Download formats does not contain requested encoding: flac "
+            "(available encodings: ['mp3-320', 'aac-hi'])"
+        )
+
+    monkeypatch.setattr("bandcampsync.freedownload.acquire_album", no_flac)
+
+    freesync.do_free_sync(config, state_path, pending_only=True)
+    state = freesync.FreeState(state_path)
+    assert 2 not in state.pending
+    assert 2 in state.skipped

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -569,8 +569,84 @@ def test_cache_refuses_album_without_item_id(tmp_path):
     """Storing under a None key is what corrupted the state file in the first place."""
     state = FreeState(tmp_path / "s.json")
     album = FreeAlbum(
-        item_id=None, title="", artist="", url="", price=0.0, is_set_price=False,
-        require_email=False, free_download=False, num_tracks=0,
+        item_id=None,
+        title="",
+        artist="",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=0,
     )
     state.cache(album, True)
     assert state.items == {}
+
+
+def test_skipped_items_survive_state_roundtrip(tmp_path):
+    """A release with no digital download can never succeed; recording it stops the
+    tool retrying it on every run forever."""
+    path = tmp_path / "s.json"
+    state = FreeState(path)
+    state.skipped[555] = "no flac download"
+    state.pending[555] = "L"
+    state.save()
+
+    reloaded = FreeState(path)
+    assert reloaded.skipped == {555: "no flac download"}
+
+
+def test_scan_does_not_requeue_skipped_items(tmp_path, monkeypatch):
+    from bandcampsync import freesync
+    from bandcampsync.labelconfig import LabelSpec
+    from bandcampsync.labels import DiscoEntry
+
+    state = freesync.FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    state.skipped[7] = "no flac download"
+    state.pending[7] = "L"
+
+    entry = DiscoEntry(item_id=7, item_type="a", title="Tape Only", artist="X")
+    monkeypatch.setattr(freesync, "list_discography", lambda api, band_id: [entry])
+    monkeypatch.setattr(
+        freesync,
+        "album_from_details",
+        lambda details, label_name="": FreeAlbum(
+            item_id=7,
+            title="Tape Only",
+            artist="X",
+            url="",
+            price=0.0,
+            is_set_price=False,
+            require_email=False,
+            free_download=False,
+            num_tracks=5,
+        ),
+    )
+
+    class _API:
+        def tralbum_details(self, *a, **k):
+            return {}
+
+    spec = LabelSpec(name="L", url="https://l.bandcamp.com/", band_id=1)
+    results, _index, _meta = freesync.scan_label(_API(), spec, state, tmp_path)
+
+    assert results[0][1] == freesync.STATUS_ERROR
+    assert "skipped" in results[0][2]
+    assert 7 not in state.pending
+
+
+def test_pending_albums_ignores_skipped(tmp_path):
+    from bandcampsync import freesync
+    from bandcampsync.labelconfig import FreeConfig, LabelSpec
+
+    state = freesync.FreeState(tmp_path / "s.json")
+    state.pending[1] = "L"
+    state.pending[2] = "L"
+    state.skipped[2] = "no flac download"
+    state.items[1] = {"title": "ok", "url": "https://x.bandcamp.com/album/a"}
+    state.items[2] = {"title": "tape", "url": "https://x.bandcamp.com/album/b"}
+
+    config = FreeConfig(labels=[LabelSpec(name="L", url="https://l.bandcamp.com/")])
+    out = freesync.pending_albums(config, state)
+    assert [a.item_id for _lab, a in out] == [1]

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -932,6 +932,70 @@ def test_track_target_path_is_built_from_metadata(tmp_path):
     assert path == tmp_path / "L" / "SECRET AGENT - Rat Salad"
 
 
+def test_target_path_strips_path_separators_from_metadata(tmp_path):
+    """The real VATERLAND case: a track whose artist contains "/" must not turn that into
+    a directory separator. Windows rejects the resulting path outright, and on any OS it
+    would silently nest the release one level too deep."""
+    from bandcampsync.freedownload import _target_path
+
+    track = FreeAlbum(
+        item_id=2890937455,
+        title="FTR-WEB 052: x-24-cx [Joy Division cover]",
+        artist="Союз Дахау / Dachau Union",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=1,
+        item_type="t",
+    )
+    path = _target_path(tmp_path, "VATERLAND", track, None)
+    assert path.parent == tmp_path / "VATERLAND"
+    assert "/" not in path.name and "\\" not in path.name and ":" not in path.name
+
+
+def test_target_path_cleans_zip_stem_and_label(tmp_path):
+    """Album downloads take the zip-filename branch, which must be cleaned too - dedup
+    matches local directories by name, so it has to agree with LocalMedia._clean_path."""
+    from bandcampsync.freedownload import _target_path
+
+    album = FreeAlbum(
+        item_id=5,
+        title="T",
+        artist="A",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=3,
+        item_type="a",
+    )
+    path = _target_path(tmp_path, "L", album, "AC/DC - Vol: One.zip")
+    assert path == tmp_path / "L" / "ACDC - Vol One"
+
+
+def test_target_path_falls_back_to_item_id_when_name_cleans_to_empty(tmp_path):
+    """A name made entirely of stripped characters must not yield the label directory."""
+    from bandcampsync.freedownload import _target_path
+
+    track = FreeAlbum(
+        item_id=77,
+        title="???",
+        artist="///",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=1,
+        item_type="t",
+    )
+    path = _target_path(tmp_path, "L", track, None)
+    assert path == tmp_path / "L" / "77"
+
+
 def test_fetch_details_falls_back_to_track_type(monkeypatch):
     """The real SECRET AGENT Rat Salad case: the id only answers as a track. Querying it
     as an album returns an empty payload that mimics a delisted item."""

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -726,3 +726,57 @@ def test_acquire_album_still_accepts_a_plain_reader(monkeypatch):
     config = FreeConfig(email="e@x.com", country="US", postcode="12345")
     spec = LabelSpec(name="L", url="https://l.bandcamp.com/")
     assert freedownload.acquire_album(album, spec, config, _Reader()) == "ok"
+
+
+def test_download_loop_survives_a_transient_network_error(tmp_path, monkeypatch):
+    """curl_cffi raises its own RequestException, which is not a ValueError. Letting it
+    escape aborted a multi-hour batch after 50 successful downloads."""
+    from bandcampsync import freesync
+    from bandcampsync.labelconfig import FreeConfig, LabelSpec
+
+    state_path = tmp_path / "s.json"
+    state = freesync.FreeState(state_path)
+    state.pending[1] = "L"
+    state.pending[2] = "L"
+    for i in (1, 2):
+        state.items[i] = {
+            "title": f"Album {i}",
+            "url": f"https://x.bandcamp.com/album/{i}",
+            "num_tracks": 3,
+            "is_free": True,
+        }
+    state.save()
+
+    media = tmp_path / "media"
+    (media / "L").mkdir(parents=True)
+    config = FreeConfig(
+        labels=[LabelSpec(name="L", url="https://l.bandcamp.com/")],
+        media_dir=media,
+        email="e@x.com",
+        country="US",
+        postcode="12345",
+    )
+
+    class _Boom(Exception):
+        """Stands in for curl_cffi.requests.exceptions.RequestException."""
+
+    calls = []
+
+    def fake_acquire(album, spec, cfg, gmail, temp_dir):
+        calls.append(album.item_id)
+        if album.item_id == 1:
+            raise _Boom("Resolving timed out after 30008 milliseconds")
+        target = media / "L" / f"Album {album.item_id}"
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "t.flac").write_text("x")
+        return target
+
+    monkeypatch.setattr("bandcampsync.freedownload.acquire_album", fake_acquire)
+
+    done = freesync.do_free_sync(config, state_path, pending_only=True)
+
+    # The failure must not stop the second album from being attempted.
+    assert calls == [1, 2]
+    assert sum(1 for _a, path, _e in done if path) == 1
+    # A transient failure stays queued for the next run rather than being written off.
+    assert 1 in freesync.FreeState(state_path).pending

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -855,3 +855,78 @@ def test_a_success_clears_the_failure_count(tmp_path, monkeypatch):
     state = freesync.FreeState(state_path)
     assert 2 not in state.failures
     assert 2 not in state.pending
+
+
+# --- standalone tracks, not just albums ---
+
+
+def test_request_download_names_the_item_type_correctly():
+    """A free release can be a single track. Telling bandcamp "album" for a track makes
+    it refuse with the same misleading "no longer available for free" message."""
+    from bandcampsync.freedownload import _item_type_name
+
+    def album(t):
+        return FreeAlbum(
+            item_id=1,
+            title="x",
+            artist="a",
+            url="",
+            price=0.0,
+            is_set_price=False,
+            require_email=False,
+            free_download=False,
+            num_tracks=1,
+            item_type=t,
+        )
+
+    assert _item_type_name(album("a")) == "album"
+    assert _item_type_name(album("t")) == "track"
+    assert _item_type_name(album("track")) == "track"
+
+
+def test_album_from_details_reads_the_item_type():
+    from bandcampsync.labels import album_from_details
+
+    assert album_from_details({"id": 1, "title": "x", "type": "t"}).item_type == "t"
+    assert album_from_details({"id": 1, "title": "x", "type": "a"}).item_type == "a"
+    # Absent means album, which is overwhelmingly the common case.
+    assert album_from_details({"id": 1, "title": "x"}).item_type == "a"
+
+
+def test_item_type_survives_the_state_cache(tmp_path):
+    state = FreeState(tmp_path / "s.json")
+    track = FreeAlbum(
+        item_id=9,
+        title="Rat Salad",
+        artist="SECRET AGENT",
+        url="u",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=1,
+        item_type="t",
+    )
+    state.cache(track, True)
+    state.save()
+    assert FreeState(tmp_path / "s.json").items[9]["item_type"] == "t"
+
+
+def test_track_target_path_is_built_from_metadata(tmp_path):
+    """A track has no "Artist - Album.zip" filename to derive a directory from."""
+    from bandcampsync.freedownload import _target_path
+
+    track = FreeAlbum(
+        item_id=9,
+        title="Rat Salad",
+        artist="SECRET AGENT",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=1,
+        item_type="t",
+    )
+    path = _target_path(tmp_path, "L", track, "Rat Salad.flac")
+    assert path == tmp_path / "L" / "SECRET AGENT - Rat Salad"

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -930,3 +930,33 @@ def test_track_target_path_is_built_from_metadata(tmp_path):
     )
     path = _target_path(tmp_path, "L", track, "Rat Salad.flac")
     assert path == tmp_path / "L" / "SECRET AGENT - Rat Salad"
+
+
+def test_fetch_details_falls_back_to_track_type(monkeypatch):
+    """The real SECRET AGENT Rat Salad case: the id only answers as a track. Querying it
+    as an album returns an empty payload that mimics a delisted item."""
+    from bandcampsync import freesync
+
+    def fake_details(band_id, item_id, item_type):
+        if item_type == "t":
+            return {"id": item_id, "title": "Rat Salad", "type": "t", "price": 0.0}
+        return {"id": None, "title": ""}  # empty as an album
+
+    class _API:
+        tralbum_details = staticmethod(fake_details)
+
+    album = freesync._fetch_details_any_type(_API(), 1, 999, None, "L")
+    assert album is not None
+    assert album.item_id == 999
+    assert album.item_type == "t"
+
+
+def test_fetch_details_returns_none_when_truly_gone(monkeypatch):
+    from bandcampsync import freesync
+
+    class _API:
+        @staticmethod
+        def tralbum_details(band_id, item_id, item_type):
+            return {"id": None, "title": ""}
+
+    assert freesync._fetch_details_any_type(_API(), 1, 999, None, "L") is None

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -1,0 +1,576 @@
+import time
+from datetime import datetime, timezone
+
+from bandcampsync.labels import DiscoEntry, FreeAlbum
+from bandcampsync.labelconfig import LabelSpec, prefilter
+from bandcampsync.freesync import FreeState, LabelIndex, RECHECK_DAYS, resolve_cutoff
+
+
+def _album(**kwargs):
+    defaults = dict(
+        item_id=42,
+        title="Atmospheric Progressive #021 (Free Download)",
+        artist="Various Artists",
+        url="https://example.bandcamp.com/album/test",
+        price=0.0,
+        is_set_price=False,
+        require_email=True,
+        free_download=False,
+        num_tracks=30,
+    )
+    defaults.update(kwargs)
+    return FreeAlbum(**defaults)
+
+
+# --- prefilter: reject on cheap metadata before spending a request ---
+
+
+def test_prefilter_rejects_wrong_artist():
+    entry = DiscoEntry(item_id=1, item_type="a", title="Daydreams", artist="Magros")
+    keep, reason = prefilter(entry, {"various_artists": True})
+    assert keep is False
+    assert "Magros" in reason
+
+
+def test_prefilter_keeps_various_artists():
+    entry = DiscoEntry(item_id=1, item_type="a", title="Comp", artist="Various Artists")
+    keep, _ = prefilter(entry, {"various_artists": True})
+    assert keep is True
+
+
+def test_prefilter_passes_rules_it_cannot_evaluate():
+    """track_artists_vary needs track data, so it must not reject at prefilter time."""
+    entry = DiscoEntry(item_id=1, item_type="a", title="Comp", artist="Tadpole Records")
+    keep, _ = prefilter(entry, {"track_artists_vary": True, "title_separator": " : "})
+    assert keep is True
+
+
+def test_prefilter_keeps_when_artist_unknown():
+    """An empty artist must not be rejected; fall through to the full check."""
+    entry = DiscoEntry(item_id=1, item_type="a", title="Comp", artist="")
+    keep, _ = prefilter(entry, {"various_artists": True})
+    assert keep is True
+
+
+def test_prefilter_title_regex():
+    entry = DiscoEntry(item_id=1, item_type="a", title="Winter Sampler 2021")
+    assert prefilter(entry, {"title_regex": "Sampler"})[0] is True
+    assert prefilter(entry, {"title_regex": "Compilation"})[0] is False
+
+
+# --- scan cutoff ---
+
+
+class _Index:
+    def __init__(self, mtime=None):
+        self._mtime = mtime
+
+    def newest_mtime(self):
+        return self._mtime
+
+
+def _spec(**kwargs):
+    defaults = dict(name="L", url="https://l.bandcamp.com/")
+    defaults.update(kwargs)
+    return LabelSpec(**defaults)
+
+
+def test_first_scan_has_no_cutoff(tmp_path):
+    """The first scan of a label must examine everything, to catch up on manual gaps."""
+    state = FreeState(tmp_path / "s.json")
+    cutoff, why = resolve_cutoff(
+        _spec(), state, _Index(datetime.now(timezone.utc)), False
+    )
+    assert cutoff is None
+    assert "first scan" in why
+
+
+def test_full_scan_overrides_cutoff(tmp_path):
+    state = FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    cutoff, why = resolve_cutoff(
+        _spec(), state, _Index(datetime.now(timezone.utc)), True
+    )
+    assert cutoff is None
+    assert "full scan" in why
+
+
+def test_subsequent_scan_uses_recorded_release_date(tmp_path):
+    state = FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    seen = datetime(2026, 7, 3, tzinfo=timezone.utc)
+    state.label("L")["newest_release_seen"] = int(seen.timestamp())
+    cutoff, why = resolve_cutoff(_spec(), state, _Index(None), False)
+    assert cutoff == seen
+    assert "already examined" in why
+
+
+def test_recorded_release_date_beats_disk_mtime(tmp_path):
+    """File mtime must not win: downloading anything updates it, which would push the
+    cutoff past older releases that were never fetched."""
+    state = FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    seen = datetime(2025, 4, 21, tzinfo=timezone.utc)
+    state.label("L")["newest_release_seen"] = int(seen.timestamp())
+    fresh_mtime = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    cutoff, _ = resolve_cutoff(_spec(), state, _Index(fresh_mtime), False)
+    assert cutoff == seen
+
+
+def test_disk_mtime_used_only_as_fallback(tmp_path):
+    state = FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    mtime = datetime(2026, 5, 24, tzinfo=timezone.utc)
+    cutoff, why = resolve_cutoff(_spec(), state, _Index(mtime), False)
+    assert cutoff == mtime
+    assert "newest local file" in why
+
+
+def test_pending_survives_state_roundtrip(tmp_path):
+    """A wanted-but-not-downloaded album must not be forgotten between runs."""
+    path = tmp_path / "s.json"
+    state = FreeState(path)
+    state.pending[760931394] = "Future Avenue"
+    state.save()
+    assert FreeState(path).pending == {760931394: "Future Avenue"}
+
+
+def test_configured_since_beats_disk_mtime(tmp_path):
+    state = FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    cutoff, why = resolve_cutoff(
+        _spec(since=since),
+        state,
+        _Index(datetime(2026, 5, 24, tzinfo=timezone.utc)),
+        False,
+    )
+    assert cutoff == since
+    assert "configured since" in why
+
+
+def test_no_local_files_means_no_cutoff(tmp_path):
+    state = FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    cutoff, _ = resolve_cutoff(_spec(), state, _Index(None), False)
+    assert cutoff is None
+
+
+# --- classification cache ---
+
+
+def test_free_classification_cached_indefinitely(tmp_path):
+    state = FreeState(tmp_path / "s.json")
+    state.cache(_album(), is_free=True)
+    state.items[42]["checked_ts"] = 0  # ancient
+    assert state.cached(42) is not None
+
+
+def test_paid_classification_expires_for_recheck(tmp_path):
+    """Prices can change, so a not-free verdict must not be cached forever."""
+    state = FreeState(tmp_path / "s.json")
+    state.cache(_album(price=5.0), is_free=False)
+    assert state.cached(42) is not None
+    state.items[42]["checked_ts"] = time.time() - (RECHECK_DAYS + 1) * 86400
+    assert state.cached(42) is None
+
+
+def test_state_roundtrip(tmp_path):
+    path = tmp_path / "s.json"
+    state = FreeState(path)
+    state.label("L")["band_id"] = 123
+    state.cache(_album(), is_free=True)
+    state.save()
+
+    reloaded = FreeState(path)
+    assert reloaded.labels["L"]["band_id"] == 123
+    assert reloaded.cached(42)["title"].startswith("Atmospheric")
+
+
+def test_state_survives_corrupt_file(tmp_path):
+    path = tmp_path / "s.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    state = FreeState(path)
+    assert state.labels == {}
+    assert state.items == {}
+
+
+# --- local index ---
+
+
+def test_index_matches_by_id_and_by_name(tmp_path):
+    label_dir = tmp_path / "Future Avenue"
+    with_id = (
+        label_dir / "Various Artists - Atmospheric Progressive #020 (Free Download)"
+    )
+    with_id.mkdir(parents=True)
+    (with_id / "bandcamp_item_id.txt").write_text("305708411\n")
+    name_only = (
+        label_dir / "Various Artists - Atmospheric Progressive #019 (Free Download)"
+    )
+    name_only.mkdir(parents=True)
+
+    index = LabelIndex(tmp_path, "Future Avenue")
+    assert 305708411 in index.ids
+
+    by_id = _album(
+        item_id=305708411, title="Atmospheric Progressive #020 (Free Download)"
+    )
+    assert index.find(by_id)[0] is not None
+
+    by_name = _album(item_id=999, title="Atmospheric Progressive #019 (Free Download)")
+    assert index.find(by_name)[0] == name_only.name
+
+    missing = _album(item_id=1, title="Atmospheric Progressive #021 (Free Download)")
+    assert index.find(missing)[0] is None
+
+
+def test_index_normalisation_tolerates_punctuation_drift(tmp_path):
+    """On-disk names come from zip filenames and drift from the remote title."""
+    label_dir = tmp_path / "Future Avenue"
+    (
+        label_dir / "Various Artists - Best Of 2023 - The Originals (Free Download)"
+    ).mkdir(parents=True)
+    index = LabelIndex(tmp_path, "Future Avenue")
+    remote = _album(item_id=7, title="Best Of 2023 | The Originals (Free Download)")
+    assert index.find(remote)[0] is not None
+
+
+def test_index_handles_missing_label_dir(tmp_path):
+    index = LabelIndex(tmp_path, "Nonexistent Label")
+    assert index.ids == set()
+    assert index.newest_mtime() is None
+    assert index.find(_album())[0] is None
+
+
+# --- repair: extract only what is missing ---
+
+
+def test_extract_missing_adds_only_absent_files(tmp_path):
+    import zipfile
+    from bandcampsync.freedownload import extract_missing
+
+    local = tmp_path / "album"
+    local.mkdir()
+    (local / "01 One.flac").write_text("original one")
+    (local / "02 Two.flac").write_text("original two")
+
+    archive = tmp_path / "album.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("01 One.flac", "REPLACED")
+        zf.writestr("02 Two.flac", "REPLACED")
+        zf.writestr("03 Three.flac", "the missing track")
+        zf.writestr("cover.jpg", "art")
+
+    added = extract_missing(archive, local)
+
+    assert sorted(added) == ["03 Three.flac", "cover.jpg"]
+    # Existing files must not be rewritten.
+    assert (local / "01 One.flac").read_text() == "original one"
+    assert (local / "02 Two.flac").read_text() == "original two"
+    assert (local / "03 Three.flac").read_text() == "the missing track"
+
+
+def test_extract_missing_flattens_nested_entries(tmp_path):
+    import zipfile
+    from bandcampsync.freedownload import extract_missing
+
+    local = tmp_path / "album"
+    local.mkdir()
+    archive = tmp_path / "album.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("nested/dir/04 Four.flac", "data")
+
+    added = extract_missing(archive, local)
+    assert added == ["04 Four.flac"]
+    assert (local / "04 Four.flac").is_file()
+
+
+def test_extract_missing_noop_when_complete(tmp_path):
+    import zipfile
+    from bandcampsync.freedownload import extract_missing
+
+    local = tmp_path / "album"
+    local.mkdir()
+    (local / "01 One.flac").write_text("x")
+    archive = tmp_path / "album.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("01 One.flac", "y")
+
+    assert extract_missing(archive, local) == []
+
+
+def test_extract_missing_matches_across_album_rename(tmp_path):
+    """The real Weedian failure: the label renamed 'Trip to Poland' to
+    'Trip to Poland II', and the album title is embedded in every filename. Comparing
+    full filenames matched nothing and duplicated the entire 119-track directory."""
+    import zipfile
+    from bandcampsync.freedownload import extract_missing
+
+    local = tmp_path / "album"
+    local.mkdir()
+    for n, t in [
+        ("01", "Tortuga - Esoteric Order"),
+        ("02", "Weedpecker - Reality Fades"),
+    ]:
+        (local / f"WEEDIAN - Trip to Poland (+100 Bands) - {n} {t}.flac").write_text(
+            "old"
+        )
+
+    archive = tmp_path / "album.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        for n, t in [
+            ("01", "Tortuga - Esoteric Order"),
+            ("02", "Weedpecker - Reality Fades"),
+            ("03", "Pemod - Meduza"),
+        ]:
+            zf.writestr(
+                f"WEEDIAN - Trip to Poland II (+100 Bands) - {n} {t}.flac", "new"
+            )
+
+    added = extract_missing(archive, local)
+
+    assert len(added) == 1
+    assert "Pemod - Meduza" in added[0]
+    assert len(list(local.glob("*.flac"))) == 3
+
+
+def test_extract_missing_refuses_runaway_duplication(tmp_path):
+    """Guard: if names have drifted beyond reconciliation, stop rather than double the
+    directory."""
+    import zipfile
+    import pytest
+    from bandcampsync.freedownload import AcquireError, extract_missing
+
+    local = tmp_path / "album"
+    local.mkdir()
+    for i in range(10):
+        (local / f"Completely Different Name {i:02d}.flac").write_text("x")
+
+    archive = tmp_path / "album.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        for i in range(10):
+            zf.writestr(f"Unrelated Naming Scheme {i:02d}.flac", "y")
+
+    with pytest.raises(AcquireError, match="Refusing to duplicate"):
+        extract_missing(archive, local, max_additions=2)
+
+
+def test_pending_cleared_when_album_stops_being_free(tmp_path, monkeypatch):
+    """A pending album that turns out not to be free must be dropped from pending,
+    otherwise it bypasses the date cutoff and is reconsidered on every future run."""
+    from bandcampsync import freesync
+    from bandcampsync.labelconfig import LabelSpec
+    from bandcampsync.labels import DiscoEntry
+
+    state = freesync.FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    state.pending[7] = "L"
+
+    entry = DiscoEntry(item_id=7, item_type="a", title="Streaming Only", artist="X")
+    monkeypatch.setattr(freesync, "list_discography", lambda api, band_id: [entry])
+    # price 0 but not downloadable -> not free
+    monkeypatch.setattr(
+        freesync,
+        "album_from_details",
+        lambda details, label_name="": FreeAlbum(
+            item_id=7,
+            title="Streaming Only",
+            artist="X",
+            url="",
+            price=0.0,
+            is_set_price=False,
+            require_email=False,
+            free_download=False,
+            num_tracks=1,
+            has_digital_download=False,
+        ),
+    )
+
+    class _API:
+        def tralbum_details(self, *a, **k):
+            return {}
+
+    spec = LabelSpec(name="L", url="https://l.bandcamp.com/", band_id=1)
+    results, _index, _meta = freesync.scan_label(_API(), spec, state, tmp_path)
+
+    assert results[0][1] == freesync.STATUS_NOT_FREE
+    assert 7 not in state.pending
+
+
+def test_pending_cleared_when_cached_not_free(tmp_path, monkeypatch):
+    """Same, via the cached-classification shortcut rather than a fresh fetch."""
+    from bandcampsync import freesync
+    from bandcampsync.labelconfig import LabelSpec
+    from bandcampsync.labels import DiscoEntry
+
+    state = freesync.FreeState(tmp_path / "s.json")
+    state.label("L")["first_scan_done"] = True
+    state.pending[9] = "L"
+    state.items[9] = {"title": "Paid", "is_free": False, "checked_ts": 2**31}
+
+    entry = DiscoEntry(item_id=9, item_type="a", title="Paid", artist="X")
+    monkeypatch.setattr(freesync, "list_discography", lambda api, band_id: [entry])
+
+    spec = LabelSpec(name="L", url="https://l.bandcamp.com/", band_id=1)
+    results, _index, _meta = freesync.scan_label(object(), spec, state, tmp_path)
+
+    assert results[0][1] == freesync.STATUS_NOT_FREE
+    assert 9 not in state.pending
+
+
+# --- duplicate detection: report, never auto-merge ---
+
+
+def _mkdirs(root, label, names):
+    for n in names:
+        (root / label / n).mkdir(parents=True)
+    return root
+
+
+def test_finds_catalogue_number_duplicates(tmp_path):
+    """Real RDC Music case: the label added a catalogue number to the title."""
+    from bandcampsync.freesync import find_duplicate_dirs
+
+    _mkdirs(
+        tmp_path, "RDC Music", ["Monzanto - Monzanto", "Monzanto - Monzanto -RDC 26"]
+    )
+    pairs = find_duplicate_dirs(tmp_path, "RDC Music")
+    assert len(pairs) == 1
+
+
+def test_finds_free_suffix_duplicates(tmp_path):
+    """Real Projekt cases: '(free!)' and '(name-your-price)' suffixes."""
+    from bandcampsync.freesync import find_duplicate_dirs
+
+    _mkdirs(
+        tmp_path,
+        "Projekt Records",
+        [
+            "Various Artists - The Hues of Infinity",
+            "Various Artists - The Hues of Infinity (free!)",
+            "Various Projekt Artists - Projekt2022",
+            "Various Projekt Artists - Projekt2022 (name-your-price)",
+        ],
+    )
+    pairs = find_duplicate_dirs(tmp_path, "Projekt Records")
+    assert len(pairs) == 2
+
+
+def test_does_not_flag_sequels_as_duplicates(tmp_path):
+    """Critical: Trip to Poland and Trip to Poland II are different albums. Merging
+    them would lose music, so a trailing volume marker must never match."""
+    from bandcampsync.freesync import find_duplicate_dirs
+
+    _mkdirs(
+        tmp_path,
+        "Weedian",
+        [
+            "WEEDIAN - Trip to Poland",
+            "WEEDIAN - Trip to Poland II (+100 Bands)",
+            "WEEDIAN - Trip to Germany",
+            "WEEDIAN - Trip to Germany II (+180 Bands)",
+            "WEEDIAN - Volume I",
+            "WEEDIAN - Volume II",
+        ],
+    )
+    assert find_duplicate_dirs(tmp_path, "Weedian") == []
+
+
+def test_does_not_flag_unrelated_titles(tmp_path):
+    from bandcampsync.freesync import find_duplicate_dirs
+
+    _mkdirs(
+        tmp_path,
+        "Future Avenue",
+        [
+            "Various Artists - Atmospheric Progressive #020 (Free Download)",
+            "Various Artists - Atmospheric Progressive #021 (Free Download)",
+        ],
+    )
+    assert find_duplicate_dirs(tmp_path, "Future Avenue") == []
+
+
+def test_missing_label_dir_yields_no_pairs(tmp_path):
+    from bandcampsync.freesync import find_duplicate_dirs
+
+    assert find_duplicate_dirs(tmp_path, "Nonexistent") == []
+
+
+def test_volume_suffix_is_not_a_catalogue_number(tmp_path):
+    """'Album' vs 'Album vol 2' must not match, even though it shares the shape of a
+    catalogue number like 'RDC 26'."""
+    from bandcampsync.freesync import _looks_like_same_release
+
+    assert _looks_like_same_release("some album", "some album vol 2") is False
+    assert _looks_like_same_release("some album", "some album part 3") is False
+    assert _looks_like_same_release("some album", "some album rdc 26") is True
+
+
+def test_index_does_not_lose_directories_to_title_collisions(tmp_path):
+    """The Audio Atelier has four distinct releases titled 'Best of 2025'. A dict keyed
+    by title silently dropped all but one, so albums that were not on disk got reported
+    as downloaded."""
+    label_dir = tmp_path / "The Audio Atelier"
+    (label_dir / "Noetic Resonance - Best Of 2025 (Free Download)").mkdir(parents=True)
+    (label_dir / "Various Artist - Best of 2025 (Free Download)").mkdir(parents=True)
+
+    index = LabelIndex(tmp_path, "The Audio Atelier")
+    total = sum(len(v) for v in index.by_title.values())
+    assert total == 2, "both directories must be indexed"
+
+    album = _album(item_id=999, title="Best of 2025 (Free Download)")
+    name, ambiguous = index.find(album)
+    assert name is None
+    assert ambiguous is True, "must not guess between same-titled directories"
+
+
+def test_id_match_beats_title_collision(tmp_path):
+    """Once id files exist the ambiguity is resolved."""
+    label_dir = tmp_path / "L"
+    a = label_dir / "Artist A - Best of 2025"
+    b = label_dir / "Artist B - Best of 2025"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    (a / "bandcamp_item_id.txt").write_text("111\n")
+    (b / "bandcamp_item_id.txt").write_text("222\n")
+
+    index = LabelIndex(tmp_path, "L")
+    assert index.find(_album(item_id=111, title="Best of 2025")) == (a.name, False)
+    assert index.find(_album(item_id=222, title="Best of 2025")) == (b.name, False)
+    # A third same-titled release is genuinely missing, not ambiguous: both local
+    # directories are already claimed by other ids.
+    assert index.find(_album(item_id=333, title="Best of 2025")) == (None, False)
+
+
+def test_state_load_tolerates_malformed_keys(tmp_path):
+    """A single bad key must not make the whole state file unreadable: that would reset
+    every label to a first full scan and re-fetch thousands of albums."""
+    import json
+
+    path = tmp_path / "s.json"
+    path.write_text(
+        json.dumps(
+            {
+                "labels": {"L": {"band_id": 1}},
+                "items": {"123": {"title": "ok"}, "None": {"title": ""}},
+                "pending": {"456": "L", "junk": "L"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    state = FreeState(path)
+    assert 123 in state.items
+    assert state.items[123]["title"] == "ok"
+    assert state.pending == {456: "L"}
+
+
+def test_cache_refuses_album_without_item_id(tmp_path):
+    """Storing under a None key is what corrupted the state file in the first place."""
+    state = FreeState(tmp_path / "s.json")
+    album = FreeAlbum(
+        item_id=None, title="", artist="", url="", price=0.0, is_set_price=False,
+        require_email=False, free_download=False, num_tracks=0,
+    )
+    state.cache(album, True)
+    assert state.items == {}

--- a/tests/test_freesync.py
+++ b/tests/test_freesync.py
@@ -1067,3 +1067,59 @@ def test_missing_format_is_permanent(tmp_path, monkeypatch):
     state = freesync.FreeState(state_path)
     assert 2 not in state.pending
     assert 2 in state.skipped
+
+
+def test_label_index_finds_albums_when_label_name_has_illegal_char(tmp_path):
+    """The "What Do You Know About Ska Punk?" regression.
+
+    The downloader strips the "?" when building the label directory, so the on-disk name
+    has none. LabelIndex used the raw configured name, producing a path that cannot exist
+    on Windows: it indexed nothing and reported every album as missing, queueing ~30 GB
+    of albums that were already on disk.
+    """
+    label_dir = tmp_path / "What Do You Know About Ska Punk"
+    (label_dir / "V-A - What Do You Know About Ska Punk- Vol. 1").mkdir(parents=True)
+
+    index = LabelIndex(tmp_path, "What Do You Know About Ska Punk?")
+
+    on_disk = _album(item_id=1, title="What Do You Know About Ska Punk? Vol. 1")
+    assert index.find(on_disk)[0] is not None
+
+
+def test_label_index_and_target_path_agree_on_label_dir(tmp_path):
+    """The two derive the label directory independently; they must not diverge again."""
+    from bandcampsync.freedownload import _target_path
+
+    album = FreeAlbum(
+        item_id=5,
+        title="T",
+        artist="A",
+        url="",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=3,
+        item_type="a",
+    )
+    for label_name in (
+        "What Do You Know About Ska Punk?",
+        "Don't Panic Records & Distro",
+        "Memphis Concr\u00e8te",
+        "Les Acteurs de L'Ombre Productions",
+        "Facthedral's Hall",
+        "\u30d4\u30f3\u30af\u30cd\u30aa\u30f3\u6771\u4eac",
+    ):
+        written = _target_path(tmp_path, label_name, album, "A - T.zip").parent
+        looked_up = LabelIndex(tmp_path, label_name).dir
+        assert written == looked_up, label_name
+
+
+def test_label_dir_keeps_apostrophes_so_existing_directories_still_match(tmp_path):
+    """Apostrophes are legal on disk and the existing library uses them. Stripping them
+    (as clean_path_component does) would orphan every album already downloaded."""
+    label_dir = tmp_path / "Don't Panic Records & Distro"
+    (label_dir / "Various Artists - DeKalb Brawl City").mkdir(parents=True)
+
+    index = LabelIndex(tmp_path, "Don't Panic Records & Distro")
+    assert index.find(_album(item_id=2, title="DeKalb Brawl City"))[0] is not None

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,0 +1,81 @@
+"""Tests for the Gmail download-link retrieval, using a fake session."""
+
+import base64
+
+from bandcampsync.gmail import GmailReader, _collect_text, _decode_part
+
+
+def _b64(text):
+    return base64.urlsafe_b64encode(text.encode()).decode().rstrip("=")
+
+
+def _message(item_id):
+    body = (
+        f"Hi there,\nTo start your free download please click:\n"
+        f"https://bandcamp.com/download?from=email&amp;id={item_id}"
+        f"&amp;payment_id=1&amp;sig=abc&amp;type=album\n"
+    )
+    return {"payload": {"body": {"data": _b64(body)}}}
+
+
+class _FakeReader(GmailReader):
+    """Bypasses the Google libraries; records how many message bodies were fetched."""
+
+    def __init__(self, item_ids):
+        self._ids = list(item_ids)
+        self.fetched = 0
+
+    def _get(self, url, **params):
+        if url.endswith("/messages"):
+            return {"messages": [{"id": str(i)} for i in self._ids]}
+        self.fetched += 1
+        return _message(int(url.rsplit("/", 1)[-1]))
+
+
+def test_extracts_link_and_normalises_entities():
+    reader = _FakeReader([111])
+    links = reader.find_download_links()
+    assert 111 in links
+    assert "&amp;" not in links[111]
+    assert "id=111" in links[111]
+
+
+def test_short_circuits_on_wanted_item():
+    """Gmail lists newest first and each body costs a request, so looking for a specific
+    album must stop at the first match rather than reading every recent mail."""
+    reader = _FakeReader([999, 888, 777, 666, 555])
+    links = reader.find_download_links(want_item_id=999)
+    assert 999 in links
+    assert reader.fetched == 1
+
+
+def test_reads_all_when_no_target_given():
+    reader = _FakeReader([1, 2, 3])
+    links = reader.find_download_links()
+    assert set(links) == {1, 2, 3}
+    assert reader.fetched == 3
+
+
+def test_keeps_newest_when_item_repeats():
+    reader = _FakeReader([42, 42])
+    assert 42 in reader.find_download_links(want_item_id=42)
+    assert reader.fetched == 1
+
+
+def test_collect_text_walks_nested_parts():
+    payload = {
+        "body": {},
+        "parts": [
+            {"body": {"data": _b64("plain part")}},
+            {"parts": [{"body": {"data": _b64("nested part")}}], "body": {}},
+        ],
+    }
+    text = _collect_text(payload)
+    assert "plain part" in text
+    assert "nested part" in text
+
+
+def test_decode_part_handles_missing_padding_and_junk():
+    assert _decode_part("") == ""
+    assert _decode_part(None) == ""
+    assert "hello" in _decode_part(_b64("hello"))

--- a/tests/test_labelconfig.py
+++ b/tests/test_labelconfig.py
@@ -49,7 +49,7 @@ def test_various_artists_matches_common_abbreviations():
 
 
 def test_various_artists_does_not_match_a_bare_va():
-    """"VA" on its own is plausible as a real artist name, so it must not match."""
+    """ "VA" on its own is plausible as a real artist name, so it must not match."""
     ok, _ = matches(_album(artist="VA"), {"various_artists": True})
     assert ok is False
 

--- a/tests/test_labelconfig.py
+++ b/tests/test_labelconfig.py
@@ -1,0 +1,276 @@
+import pytest
+
+from bandcampsync.labels import FreeAlbum
+from bandcampsync.labelconfig import ConfigError, load_config, matches
+
+
+def _album(**kwargs):
+    defaults = dict(
+        item_id=1,
+        title="Atmospheric Progressive #021 (Free Download)",
+        artist="Various Artists",
+        url="https://example.bandcamp.com/album/test",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=30,
+    )
+    defaults.update(kwargs)
+    return FreeAlbum(**defaults)
+
+
+# --- Future Avenue shape: album artist "Various Artists", per-track artists populated ---
+
+
+def test_various_artists_matches():
+    ok, _ = matches(_album(), {"various_artists": True})
+    assert ok is True
+
+
+def test_various_artists_tolerates_real_world_spellings():
+    """The Audio Atelier uses all three of these across its own catalogue."""
+    for spelling in (
+        "Various Artists",
+        "Various Artist",
+        "Various artist",
+        "various artists",
+        "  Various Artists  ",
+    ):
+        ok, _ = matches(_album(artist=spelling), {"various_artists": True})
+        assert ok is True, spelling
+
+
+def test_various_artists_still_rejects_near_misses():
+    for spelling in ("Various Artists Collective", "The Various Artists", "Various"):
+        ok, _ = matches(_album(artist=spelling), {"various_artists": True})
+        assert ok is False, spelling
+
+
+def test_various_artists_rejects_single_artist():
+    ok, reason = matches(_album(artist="Magros"), {"various_artists": True})
+    assert ok is False
+    assert "Magros" in reason
+
+
+def test_track_artists_vary_matches():
+    album = _album(track_artists=["A", "B", "C"])
+    ok, _ = matches(album, {"track_artists_vary": True})
+    assert ok is True
+
+
+def test_track_artists_vary_rejects_all_null():
+    """The Tadpole Records shape: every track artist is null."""
+    album = _album(track_artists=[None] * 30)
+    ok, reason = matches(album, {"track_artists_vary": True})
+    assert ok is False
+    assert "0 distinct" in reason
+
+
+# --- Tadpole shape: artist is the label, artist encoded in the track title ---
+
+
+def test_title_separator_matches_tadpole_shape():
+    album = _album(
+        artist="Tadpole Records",
+        track_titles=[
+            "Haest : This Tired Boat Is Sinking",
+            "Vanilla Giver : Light Up Your Life",
+            "Someone : A Song",
+            "Another : Another Song",
+        ],
+    )
+    ok, _ = matches(album, {"title_separator": " : "})
+    assert ok is True
+
+
+def test_title_separator_rejects_when_few_titles_match():
+    album = _album(track_titles=["No separator here", "Nor here", "Only : one", "Nope"])
+    ok, reason = matches(album, {"title_separator": " : "})
+    assert ok is False
+    assert "1/4" in reason
+
+
+def test_future_avenue_rules_reject_tadpole_album():
+    """The two labels share no signal; rules must not cross-match."""
+    tadpole = _album(artist="Tadpole Records", track_artists=[None] * 30)
+    ok, _ = matches(tadpole, {"various_artists": True, "track_artists_vary": True})
+    assert ok is False
+
+
+def test_min_track_artists_rejects_collaborations():
+    """Real Children of Vapor cases: two- and three-person collaborations that
+    track_artists_vary alone wrongly accepted as compilations."""
+    collab = _album(
+        artist="Ecco City & Saturn ARS", track_artists=["Ecco City", "Saturn ARS"]
+    )
+    ok, reason = matches(collab, {"track_artists_vary": True})
+    assert ok is True  # the loose rule accepts it
+    ok, reason = matches(collab, {"min_track_artists": 5})
+    assert ok is False
+    assert "min_track_artists" in reason
+
+
+def test_min_track_artists_accepts_real_compilation():
+    comp = _album(track_artists=[f"Artist {i}" for i in range(30)])
+    ok, _ = matches(comp, {"min_track_artists": 5})
+    assert ok is True
+
+
+def test_min_track_artists_ignores_null_artists():
+    album = _album(track_artists=[None] * 30)
+    ok, _ = matches(album, {"min_track_artists": 5})
+    assert ok is False
+
+
+def test_min_tracks_rejects_short_release():
+    ok, reason = matches(_album(num_tracks=2), {"min_tracks": 8})
+    assert ok is False
+    assert "min_tracks" in reason
+
+
+def test_max_tracks_rejects_long_release():
+    ok, _ = matches(_album(num_tracks=50), {"max_tracks": 40})
+    assert ok is False
+
+
+def test_title_regex():
+    ok, _ = matches(_album(), {"title_regex": r"(?i)atmospheric"})
+    assert ok is True
+    ok, _ = matches(_album(), {"title_regex": r"(?i)sampler"})
+    assert ok is False
+
+
+def test_empty_rules_match_everything():
+    ok, reason = matches(_album(artist="Anyone"), {})
+    assert ok is True
+    assert "all free albums" in reason
+
+
+def test_rules_are_anded():
+    album = _album(track_artists=["A", "B"], num_tracks=3)
+    ok, _ = matches(album, {"track_artists_vary": True, "min_tracks": 8})
+    assert ok is False
+
+
+# --- config loading ---
+
+
+def _write(tmp_path, text):
+    path = tmp_path / "labels.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_load_minimal_config(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+defaults:
+  media_dir: "/tmp/media"
+labels:
+  - name: Future Avenue
+    url: https://futureavenuelabel.bandcamp.com/
+    match:
+      various_artists: true
+""",
+    )
+    config = load_config(path)
+    assert len(config.labels) == 1
+    assert config.labels[0].name == "Future Avenue"
+    assert config.labels[0].match == {"various_artists": True}
+    assert config.enabled_labels == config.labels
+
+
+def test_disabled_labels_excluded(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+labels:
+  - name: A
+    url: https://a.bandcamp.com/
+  - name: B
+    url: https://b.bandcamp.com/
+    enabled: false
+""",
+    )
+    config = load_config(path)
+    assert len(config.labels) == 2
+    assert [label.name for label in config.enabled_labels] == ["A"]
+
+
+def test_unknown_match_rule_rejected(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+labels:
+  - name: A
+    url: https://a.bandcamp.com/
+    match:
+      various_artits: true
+""",
+    )
+    with pytest.raises(ConfigError, match="unknown match rules"):
+        load_config(path)
+
+
+def test_invalid_regex_rejected(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+labels:
+  - name: A
+    url: https://a.bandcamp.com/
+    match:
+      title_regex: "([unclosed"
+""",
+    )
+    with pytest.raises(ConfigError, match="invalid title_regex"):
+        load_config(path)
+
+
+def test_missing_url_rejected(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+labels:
+  - name: A
+""",
+    )
+    with pytest.raises(ConfigError, match="missing"):
+        load_config(path)
+
+
+def test_duplicate_label_rejected(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+labels:
+  - name: A
+    url: https://a.bandcamp.com/
+  - name: A
+    url: https://a2.bandcamp.com/
+""",
+    )
+    with pytest.raises(ConfigError, match="Duplicate"):
+        load_config(path)
+
+
+def test_no_labels_rejected(tmp_path):
+    path = _write(tmp_path, "defaults:\n  media_dir: /tmp\n")
+    with pytest.raises(ConfigError, match="does not define any"):
+        load_config(path)
+
+
+def test_since_parsed(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+labels:
+  - name: A
+    url: https://a.bandcamp.com/
+    since: 2024-01-01
+""",
+    )
+    config = load_config(path)
+    assert config.labels[0].since.year == 2024

--- a/tests/test_labelconfig.py
+++ b/tests/test_labelconfig.py
@@ -41,6 +41,19 @@ def test_various_artists_tolerates_real_world_spellings():
         assert ok is True, spelling
 
 
+def test_various_artists_matches_common_abbreviations():
+    """B O G U S COLLECTIVE credits its compilations to "V/A"."""
+    for spelling in ("V/A", "v/a", "V.A.", "V / A", "V.A"):
+        ok, _ = matches(_album(artist=spelling), {"various_artists": True})
+        assert ok is True, spelling
+
+
+def test_various_artists_does_not_match_a_bare_va():
+    """"VA" on its own is plausible as a real artist name, so it must not match."""
+    ok, _ = matches(_album(artist="VA"), {"various_artists": True})
+    assert ok is False
+
+
 def test_various_artists_still_rejects_near_misses():
     for spelling in ("Various Artists Collective", "The Various Artists", "Various"):
         ok, _ = matches(_album(artist=spelling), {"various_artists": True})

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,122 @@
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from bandcampsync.labels import FreeAlbum, album_from_details, _parse_release_date
+
+
+def _load_payload(name):
+    return json.loads(
+        (Path(__file__).resolve().parent / "data" / name).read_text(encoding="utf-8")
+    )
+
+
+def _album(**kwargs):
+    defaults = dict(
+        item_id=1,
+        title="Test Album",
+        artist="Various Artists",
+        url="https://example.bandcamp.com/album/test",
+        price=0.0,
+        is_set_price=False,
+        require_email=False,
+        free_download=False,
+        num_tracks=10,
+    )
+    defaults.update(kwargs)
+    return FreeAlbum(**defaults)
+
+
+def test_parses_real_free_compilation_payload():
+    album = album_from_details(_load_payload("tralbum-details-free-compilation.json"))
+    assert album.item_id == 760931394
+    assert album.artist == "Various Artists"
+    assert album.price == 0.0
+    assert album.is_set_price is False
+    assert album.require_email is True
+    assert album.num_tracks == 30
+    assert album.currency == "EUR"
+    assert album.is_free is True
+
+
+def test_free_download_false_does_not_mean_paid():
+    """free_download maps to download_pref == 1, not to "is $0 allowed".
+
+    The real payload has free_download false but price 0.0, and is obtainable for free.
+    Gating on free_download would wrongly skip nearly every free album.
+    """
+    album = album_from_details(_load_payload("tralbum-details-free-compilation.json"))
+    assert album.free_download is False
+    assert album.is_free is True
+
+
+def test_non_downloadable_item_is_not_free():
+    """Bandcamp reports price=None for items that are not separately purchasable, e.g.
+    an individual track of a compilation. None coerces to 0.0, so without the
+    has_digital_download check these look free and every download attempt fails."""
+    track = album_from_details(
+        {
+            "id": 519386932,
+            "title": "Pemod - Meduza",
+            "price": None,
+            "is_set_price": False,
+            "has_digital_download": False,
+        }
+    )
+    assert track.price == 0.0
+    assert track.is_free is False
+
+
+def test_missing_has_digital_download_defaults_to_downloadable():
+    album = album_from_details({"id": 1, "title": "x", "price": 0.0})
+    assert album.is_free is True
+
+
+def test_nonzero_price_is_not_free():
+    assert _album(price=5.0).is_free is False
+
+
+def test_set_price_is_not_free_even_at_zero():
+    assert _album(price=0.0, is_set_price=True).is_free is False
+
+
+def test_distinct_track_artists_ignores_nulls():
+    album = _album(track_artists=[None, None, None])
+    assert album.distinct_track_artists == set()
+    album = _album(track_artists=["A", "B", "A", None])
+    assert album.distinct_track_artists == {"A", "B"}
+
+
+def test_parse_release_date_unix_timestamp():
+    parsed = _parse_release_date(1783036800)
+    assert parsed == datetime(2026, 7, 3, tzinfo=timezone.utc)
+
+
+def test_parse_release_date_rfc_string():
+    parsed = _parse_release_date("20 Jul 2026 00:00:00 GMT")
+    assert parsed.year == 2026 and parsed.month == 7 and parsed.day == 20
+
+
+def test_parse_release_date_handles_junk():
+    assert _parse_release_date(None) is None
+    assert _parse_release_date("") is None
+    assert _parse_release_date("not a date") is None
+
+
+def test_parse_release_date_handles_pre_1970():
+    """Negative timestamps are real (Projekt Records) and datetime.fromtimestamp()
+    raises OSError on them on Windows, which crashed a full scan."""
+    parsed = _parse_release_date(-86400)
+    assert parsed == datetime(1969, 12, 31, tzinfo=timezone.utc)
+
+
+def test_parse_release_date_handles_absurd_values():
+    assert _parse_release_date(10**20) is None
+    assert _parse_release_date(-(10**20)) is None
+
+
+def test_album_from_details_tolerates_missing_tracks():
+    album = album_from_details({"id": 5, "title": "x", "price": 0.0})
+    assert album.num_tracks == 0
+    assert album.track_artists == []
+    assert album.is_free is True

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -221,6 +221,26 @@ def test_get_path_for_zip_purchase_label(tmp_path, ignores):
     assert result == tmp_path / "CoolLabel" / "ActualArtist - MyAlbum"
 
 
+def test_get_path_for_zip_purchase_existing_band_dir_treated_as_label(tmp_path, ignores):
+    """If a directory matching band_name already exists, treat it as a label dir
+    even when the ZIP artist matches band_name (label compilation case)."""
+    label_dir = tmp_path / "Start-track.com"
+    label_dir.mkdir()
+
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=True,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item = Mock(band_name="Start-track.com", item_title="START THE TRACK: VOL. XI",
+                folder_suffix="", item_id=1)
+    result = lm.get_path_for_zip_purchase(item, "Start-track.com - START THE TRACK- VOL. XI.zip")
+    assert result == label_dir / "Start-track.com - START THE TRACK- VOL. XI"
+
+
 def test_get_path_for_zip_purchase_label_case_insensitive(tmp_path, ignores):
     """Case-insensitive comparison for label detection."""
     lm = LocalMedia(

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -163,6 +163,31 @@ def test_is_locally_downloaded_by_id(tmp_path, ignores):
     assert lm.is_locally_downloaded_by_id(item_missing) is False
 
 
+def test_is_locally_downloaded_by_id_name_fallback(tmp_path, ignores):
+    """When no tracking file exists but directory name matches, return True."""
+    # Create dir without bandcamp_item_id.txt (e.g. label-subdir album)
+    label_dir = tmp_path / "OldLabel"
+    label_dir.mkdir()
+    album_dir = label_dir / "Artist - Album"
+    album_dir.mkdir()
+
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    # No tracking file, so item_id won't match, but name should
+    item = Mock(item_id=12345, band_name="Artist", item_title="Album", folder_suffix="")
+    assert lm.is_locally_downloaded_by_id(item) is True
+
+    # Completely unknown album should still return False
+    item_unknown = Mock(item_id=99999, band_name="Nobody", item_title="Nothing", folder_suffix="")
+    assert lm.is_locally_downloaded_by_id(item_unknown) is False
+
+
 # --- get_path_for_zip_purchase ---
 
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,258 @@
+"""Tests for LocalMedia zip format support."""
+
+from unittest.mock import Mock
+import pytest
+
+from bandcampsync.media import parse_zip_filename, LocalMedia
+from bandcampsync.ignores import Ignores
+
+
+@pytest.fixture
+def ignores(tmp_path):
+    return Ignores(ign_file_path=None, ign_patterns="")
+
+
+# --- parse_zip_filename ---
+
+
+def test_parse_zip_filename_basic():
+    assert parse_zip_filename("Artist - Album.zip") == ("Artist", "Album")
+
+
+def test_parse_zip_filename_with_spaces():
+    assert parse_zip_filename("Some Artist - Some Album Title.zip") == (
+        "Some Artist",
+        "Some Album Title",
+    )
+
+
+def test_parse_zip_filename_dash_in_album():
+    assert parse_zip_filename("Artist - Album - Deluxe Edition.zip") == (
+        "Artist",
+        "Album - Deluxe Edition",
+    )
+
+
+def test_parse_zip_filename_no_zip_extension():
+    assert parse_zip_filename("Artist - Album") == ("Artist", "Album")
+
+
+def test_parse_zip_filename_no_separator():
+    assert parse_zip_filename("JustAName.zip") == (None, None)
+
+
+def test_parse_zip_filename_empty():
+    assert parse_zip_filename("") == (None, None)
+    assert parse_zip_filename(None) == (None, None)
+
+
+def test_parse_zip_filename_empty_parts():
+    assert parse_zip_filename(" - Album.zip") == (None, None)
+    assert parse_zip_filename("Artist - .zip") == (None, None)
+
+
+# --- _index_zip_format ---
+
+
+def test_index_zip_format_flat(tmp_path, ignores):
+    """Depth 1: media_dir/Artist - Album/"""
+    album_dir = tmp_path / "Artist - Album"
+    album_dir.mkdir()
+    (album_dir / "track1.flac").write_text("audio")
+    (album_dir / "bandcamp_item_id.txt").write_text("123\n")
+
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    assert 123 in lm.media
+    assert "Artist - Album" in lm.item_names
+
+
+def test_index_zip_format_nested(tmp_path, ignores):
+    """Depth 2: media_dir/Label/Artist - Album/"""
+    label_dir = tmp_path / "Label"
+    label_dir.mkdir()
+    album_dir = label_dir / "Artist - Album"
+    album_dir.mkdir()
+    (album_dir / "track1.flac").write_text("audio")
+    (album_dir / "bandcamp_item_id.txt").write_text("456\n")
+
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    assert 456 in lm.media
+    assert "Artist - Album" in lm.item_names
+    assert "Label" in lm.item_names
+
+
+def test_index_zip_format_no_id_file(tmp_path, ignores):
+    """Directories without bandcamp_item_id.txt are still indexed by name."""
+    album_dir = tmp_path / "Artist - Album"
+    album_dir.mkdir()
+    (album_dir / "track1.flac").write_text("audio")
+
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    assert len(lm.media) == 0
+    assert "Artist - Album" in lm.item_names
+
+
+def test_index_zip_format_mixed(tmp_path, ignores):
+    """Mix of flat and nested directories."""
+    # Flat
+    flat_dir = tmp_path / "Artist1 - Album1"
+    flat_dir.mkdir()
+    (flat_dir / "bandcamp_item_id.txt").write_text("100\n")
+    # Nested
+    label_dir = tmp_path / "Label"
+    label_dir.mkdir()
+    nested_dir = label_dir / "Artist2 - Album2"
+    nested_dir.mkdir()
+    (nested_dir / "bandcamp_item_id.txt").write_text("200\n")
+
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    assert 100 in lm.media
+    assert 200 in lm.media
+    assert "Artist1 - Album1" in lm.item_names
+    assert "Label" in lm.item_names
+    assert "Artist2 - Album2" in lm.item_names
+
+
+# --- is_locally_downloaded_by_id ---
+
+
+def test_is_locally_downloaded_by_id(tmp_path, ignores):
+    album_dir = tmp_path / "Artist - Album"
+    album_dir.mkdir()
+    (album_dir / "bandcamp_item_id.txt").write_text("999\n")
+
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item_found = Mock(item_id=999)
+    item_missing = Mock(item_id=888)
+    assert lm.is_locally_downloaded_by_id(item_found) is True
+    assert lm.is_locally_downloaded_by_id(item_missing) is False
+
+
+# --- get_path_for_zip_purchase ---
+
+
+def test_get_path_for_zip_purchase_flat(tmp_path, ignores):
+    """Non-label release: artist matches band_name."""
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=True,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item = Mock(band_name="MyBand", item_title="MyAlbum", folder_suffix="", item_id=1)
+    result = lm.get_path_for_zip_purchase(item, "MyBand - MyAlbum.zip")
+    assert result == tmp_path / "MyBand - MyAlbum"
+
+
+def test_get_path_for_zip_purchase_label(tmp_path, ignores):
+    """Label release: artist differs from band_name."""
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=True,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item = Mock(band_name="CoolLabel", item_title="MyAlbum", folder_suffix="", item_id=1)
+    result = lm.get_path_for_zip_purchase(item, "ActualArtist - MyAlbum.zip")
+    assert result == tmp_path / "CoolLabel" / "ActualArtist - MyAlbum"
+
+
+def test_get_path_for_zip_purchase_label_case_insensitive(tmp_path, ignores):
+    """Case-insensitive comparison for label detection."""
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=True,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item = Mock(band_name="myband", item_title="Album", folder_suffix="", item_id=1)
+    result = lm.get_path_for_zip_purchase(item, "MyBand - Album.zip")
+    assert result == tmp_path / "MyBand - Album"
+
+
+def test_get_path_for_zip_purchase_fallback(tmp_path, ignores):
+    """Fallback when Content-Disposition filename is missing."""
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=True,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item = Mock(band_name="Artist", item_title="Album", folder_suffix="", item_id=1)
+    result = lm.get_path_for_zip_purchase(item, None)
+    assert result == tmp_path / "Artist - Album"
+
+
+def test_get_path_for_zip_purchase_fallback_with_suffix(tmp_path, ignores):
+    """Fallback uses folder_suffix."""
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=True,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item = Mock(band_name="Artist", item_title="Album", folder_suffix=" (2)", item_id=1)
+    result = lm.get_path_for_zip_purchase(item, None)
+    assert result == tmp_path / "Artist - Album (2)"
+
+
+# --- get_path_for_track_purchase ---
+
+
+def test_get_path_for_track_purchase(tmp_path, ignores):
+    lm = LocalMedia(
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=True,
+        sync_ignore_file=False,
+        dir_format="zip",
+    )
+
+    item = Mock(band_name="Artist", item_title="TrackName", folder_suffix="", item_id=1)
+    result = lm.get_path_for_track_purchase(item)
+    assert result == tmp_path / "Artist - TrackName"

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -313,3 +313,25 @@ def test_get_path_for_track_purchase(tmp_path, ignores):
     item = Mock(band_name="Artist", item_title="TrackName", folder_suffix="", item_id=1)
     result = lm.get_path_for_track_purchase(item)
     assert result == tmp_path / "Artist - TrackName"
+
+
+def test_normalize_collapses_whitespace_left_by_dropped_separators():
+    """Real case: dropping the '-' left a double space, so these did not match and the
+    album was downloaded a second time."""
+    n = LocalMedia._normalize_for_match
+    assert n("TRIPLE AGENT RECORDS - Vol. Vll") == n("TRIPLE AGENT RECORDS Vol. Vll")
+    assert n("Best Of 2023 - The Originals") == n("Best Of 2023 | The Originals")
+    assert n("A  B") == n("A B")
+
+
+def test_normalize_still_separates_genuinely_different_titles():
+    n = LocalMedia._normalize_for_match
+    assert n("Trip to Poland") != n("Trip to Poland II")
+    assert n("Vol. 1") != n("Vol. 2")
+    assert n("Atmospheric Progressive #020") != n("Atmospheric Progressive #021")
+
+
+def test_normalize_handles_tabs_and_newlines():
+    n = LocalMedia._normalize_for_match
+    assert n("A\tB") == n("A B")
+    assert n("  leading and trailing  ") == "leading and trailing"

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -371,6 +371,27 @@ def test_clean_label_dir_name_never_returns_empty():
     assert clean_label_dir_name("  . ") == "unknown-label"
 
 
+def test_clean_path_component_strips_windows_illegal_characters():
+    """A pipe or angle bracket in a title made an unwritable path: Flowerpot Records'
+    "12|21" failed with WinError 123 mid-run. Windows cannot create these at all, so
+    stripping them cannot orphan an existing directory."""
+    from bandcampsync.media import clean_path_component
+
+    assert clean_path_component("12|21") == "1221"
+    assert clean_path_component("<i> hate </i> markup") == "i hate i markup"
+    for char in '|<>':
+        assert char not in clean_path_component(f"a{char}b")
+
+
+def test_clean_path_component_covers_every_windows_illegal_character():
+    """clean_path_component must strip at least what clean_label_dir_name does, or the
+    album directory is unwritable inside a label directory that was fine."""
+    from bandcampsync.media import _WINDOWS_ILLEGAL_PATH_CHARS, clean_path_component
+
+    for char in _WINDOWS_ILLEGAL_PATH_CHARS:
+        assert clean_path_component(f"before{char}after") == "beforeafter"
+
+
 def test_clean_label_dir_name_is_narrower_than_clean_path_component():
     """They are not interchangeable: clean_path_component also strips apostrophes, #, %
     and decomposes accents, which is correct for album names but would orphan the

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -184,7 +184,9 @@ def test_is_locally_downloaded_by_id_name_fallback(tmp_path, ignores):
     assert lm.is_locally_downloaded_by_id(item) is True
 
     # Completely unknown album should still return False
-    item_unknown = Mock(item_id=99999, band_name="Nobody", item_title="Nothing", folder_suffix="")
+    item_unknown = Mock(
+        item_id=99999, band_name="Nobody", item_title="Nothing", folder_suffix=""
+    )
     assert lm.is_locally_downloaded_by_id(item_unknown) is False
 
 
@@ -216,12 +218,16 @@ def test_get_path_for_zip_purchase_label(tmp_path, ignores):
         dir_format="zip",
     )
 
-    item = Mock(band_name="CoolLabel", item_title="MyAlbum", folder_suffix="", item_id=1)
+    item = Mock(
+        band_name="CoolLabel", item_title="MyAlbum", folder_suffix="", item_id=1
+    )
     result = lm.get_path_for_zip_purchase(item, "ActualArtist - MyAlbum.zip")
     assert result == tmp_path / "CoolLabel" / "ActualArtist - MyAlbum"
 
 
-def test_get_path_for_zip_purchase_existing_band_dir_treated_as_label(tmp_path, ignores):
+def test_get_path_for_zip_purchase_existing_band_dir_treated_as_label(
+    tmp_path, ignores
+):
     """If a directory matching band_name already exists, treat it as a label dir
     even when the ZIP artist matches band_name (label compilation case)."""
     label_dir = tmp_path / "Start-track.com"
@@ -235,9 +241,15 @@ def test_get_path_for_zip_purchase_existing_band_dir_treated_as_label(tmp_path, 
         dir_format="zip",
     )
 
-    item = Mock(band_name="Start-track.com", item_title="START THE TRACK: VOL. XI",
-                folder_suffix="", item_id=1)
-    result = lm.get_path_for_zip_purchase(item, "Start-track.com - START THE TRACK- VOL. XI.zip")
+    item = Mock(
+        band_name="Start-track.com",
+        item_title="START THE TRACK: VOL. XI",
+        folder_suffix="",
+        item_id=1,
+    )
+    result = lm.get_path_for_zip_purchase(
+        item, "Start-track.com - START THE TRACK- VOL. XI.zip"
+    )
     assert result == label_dir / "Start-track.com - START THE TRACK- VOL. XI"
 
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -335,3 +335,48 @@ def test_normalize_handles_tabs_and_newlines():
     n = LocalMedia._normalize_for_match
     assert n("A\tB") == n("A B")
     assert n("  leading and trailing  ") == "leading and trailing"
+
+
+def test_clean_label_dir_name_strips_only_windows_illegal_characters():
+    from bandcampsync.media import clean_label_dir_name
+
+    assert clean_label_dir_name("What Do You Know About Ska Punk?") == (
+        "What Do You Know About Ska Punk"
+    )
+    assert clean_label_dir_name(r'A<B>C:D"E/F\G|H?I*J') == "ABCDEFGHIJ"
+    # Apostrophes and accents are legal and must survive - the existing library uses them.
+    assert clean_label_dir_name("Don't Panic Records & Distro") == (
+        "Don't Panic Records & Distro"
+    )
+    assert clean_label_dir_name("Memphis Concr\u00e8te") == "Memphis Concr\u00e8te"
+
+
+def test_clean_label_dir_name_composes_accents_to_nfc():
+    """NTFS compares filenames without normalising, so a decomposed name would create a
+    second directory beside the composed one rather than matching it."""
+    from bandcampsync.media import clean_label_dir_name
+
+    decomposed = "Memphis Concre\u0300te"
+    assert clean_label_dir_name(decomposed) == "Memphis Concr\u00e8te"
+    assert clean_label_dir_name(decomposed) == clean_label_dir_name(
+        "Memphis Concr\u00e8te"
+    )
+
+
+def test_clean_label_dir_name_never_returns_empty():
+    """An empty component would place albums in the media root instead of the label dir."""
+    from bandcampsync.media import clean_label_dir_name
+
+    assert clean_label_dir_name("???") == "unknown-label"
+    assert clean_label_dir_name("  . ") == "unknown-label"
+
+
+def test_clean_label_dir_name_is_narrower_than_clean_path_component():
+    """They are not interchangeable: clean_path_component also strips apostrophes, #, %
+    and decomposes accents, which is correct for album names but would orphan the
+    existing label directories."""
+    from bandcampsync.media import clean_label_dir_name, clean_path_component
+
+    name = "Don't Panic Records & Distro"
+    assert clean_path_component(name) == "Dont Panic Records & Distro"
+    assert clean_label_dir_name(name) == name

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,288 @@
+"""Tests for collection report mode."""
+
+import csv
+from unittest.mock import patch
+from pathlib import Path
+
+import pytest
+
+from bandcampsync.bandcamp import BandcampItem
+from bandcampsync.ignores import Ignores
+from bandcampsync.media import LocalMedia
+from bandcampsync.report import classify_item, generate_report, print_report, write_csv
+
+
+def _make_item(item_id, band_name="Artist", item_title="Album", is_preorder=False,
+               item_type="album", folder_suffix=""):
+    data = {
+        "item_id": item_id,
+        "band_name": band_name,
+        "item_title": item_title,
+        "is_preorder": is_preorder,
+        "item_type": item_type,
+        "folder_suffix": folder_suffix,
+    }
+    return BandcampItem(data)
+
+
+@pytest.fixture
+def ignores():
+    return Ignores(ign_file_path=None, ign_patterns="")
+
+
+# --- classify_item: artist-album format ---
+
+
+def test_classify_missing_artist_album(tmp_path, ignores):
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+    )
+    item = _make_item(1, "NewArtist", "NewAlbum")
+    status, path = classify_item(item, lm, ignores, "artist-album")
+    assert status == "missing"
+
+
+def test_classify_downloaded_artist_album(tmp_path, ignores):
+    # Create the expected directory structure with tracking file
+    artist_dir = tmp_path / "Artist"
+    album_dir = artist_dir / "Album"
+    album_dir.mkdir(parents=True)
+    (album_dir / "bandcamp_item_id.txt").write_text("42\n")
+
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+    )
+    item = _make_item(42, "Artist", "Album")
+    status, path = classify_item(item, lm, ignores, "artist-album")
+    assert status == "downloaded"
+    assert path == album_dir
+
+
+def test_classify_preorder(tmp_path, ignores):
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+    )
+    item = _make_item(1, is_preorder=True)
+    status, path = classify_item(item, lm, ignores, "artist-album")
+    assert status == "preorder"
+    assert path is None
+
+
+def test_classify_ignored_by_pattern(tmp_path):
+    ignores = Ignores(ign_file_path=None, ign_patterns="skipme")
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+    )
+    item = _make_item(1, band_name="SkipMe Records")
+    status, path = classify_item(item, lm, ignores, "artist-album")
+    assert status == "ignored"
+    assert path is None
+
+
+def test_classify_ignored_by_id(tmp_path):
+    # Create ignore file with item ID
+    ign_path = tmp_path / "ignores.txt"
+    ign_path.write_text("99\n")
+    ignores = Ignores(ign_file_path=ign_path, ign_patterns="")
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+    )
+    item = _make_item(99, "Artist", "Album")
+    status, path = classify_item(item, lm, ignores, "artist-album")
+    assert status == "ignored"
+
+
+# --- classify_item: zip format ---
+
+
+def test_classify_downloaded_zip_by_id(tmp_path, ignores):
+    album_dir = tmp_path / "Artist - Album"
+    album_dir.mkdir()
+    (album_dir / "bandcamp_item_id.txt").write_text("42\n")
+
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+    )
+    item = _make_item(42, "Artist", "Album")
+    status, path = classify_item(item, lm, ignores, "zip")
+    assert status == "downloaded"
+    assert path == album_dir
+
+
+def test_classify_downloaded_zip_by_name(tmp_path, ignores):
+    # Directory exists but has no tracking file
+    album_dir = tmp_path / "Artist - Album"
+    album_dir.mkdir()
+    (album_dir / "track.flac").write_text("audio")
+
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+    )
+    item = _make_item(99, "Artist", "Album")
+    status, path = classify_item(item, lm, ignores, "zip")
+    assert status == "downloaded"
+
+
+def test_classify_missing_zip(tmp_path, ignores):
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+    )
+    item = _make_item(1, "NewArtist", "NewAlbum")
+    status, path = classify_item(item, lm, ignores, "zip")
+    assert status == "missing"
+
+
+def test_classify_downloaded_zip_label_release(tmp_path, ignores):
+    """Label release: band_name is label, on-disk artist differs."""
+    label_dir = tmp_path / "Side-Line Magazine"
+    label_dir.mkdir()
+    album_dir = label_dir / "Various Artists - Face The Beat- Session 5"
+    album_dir.mkdir()
+
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+    )
+    # band_name is the label, item_title has colon which gets cleaned
+    item = _make_item(99, "Side-Line Magazine", "Face The Beat: Session 5")
+    status, path = classify_item(item, lm, ignores, "zip")
+    assert status == "downloaded"
+
+
+def test_classify_downloaded_zip_metadata_drift(tmp_path, ignores):
+    """Metadata drift: title gained a suffix since download."""
+    # On disk: downloaded as "Spray - Remixes are Inevitable"
+    # Bandcamp now has title "Remixes are Inevitable EP"
+    label_dir = tmp_path / "AnalogueTrash"
+    label_dir.mkdir()
+    album_dir = label_dir / "Spray - Remixes are Inevitable"
+    album_dir.mkdir()
+
+    lm = LocalMedia(
+        media_dir=tmp_path, ignores=ignores,
+        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+    )
+    item = _make_item(99, "Spray", "Remixes are Inevitable EP")
+    status, path = classify_item(item, lm, ignores, "zip")
+    assert status == "downloaded"
+
+
+# --- print_report ---
+
+
+def test_print_report(capsys):
+    items = [
+        (_make_item(1, "A1", "T1"), "downloaded", Path("/music/A1/T1")),
+        (_make_item(2, "A2", "T2"), "missing", None),
+        (_make_item(3, "A3", "T3"), "ignored", None),
+        (_make_item(4, "A4", "T4"), "preorder", None),
+    ]
+    print_report(items)
+    out = capsys.readouterr().out
+    assert "Total purchases: 4" in out
+    assert "Downloaded:    1" in out
+    assert "Missing:       1" in out
+    assert "Ignored:       1" in out
+    assert "Preorders:     1" in out
+    assert "A2 / T2 (id:2)" in out
+
+
+def test_print_report_no_missing(capsys):
+    items = [
+        (_make_item(1, "A1", "T1"), "downloaded", Path("/music/A1/T1")),
+    ]
+    print_report(items)
+    out = capsys.readouterr().out
+    assert "Missing items:" not in out
+
+
+# --- write_csv ---
+
+
+def test_write_csv(tmp_path):
+    csv_path = tmp_path / "report.csv"
+    items = [
+        (_make_item(1, "A1", "T1", item_type="album"), "downloaded", Path("/music/A1/T1")),
+        (_make_item(2, "A2", "T2", item_type="track"), "missing", None),
+    ]
+    write_csv(items, csv_path)
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+
+    assert rows[0] == ["item_id", "band_name", "item_title", "item_type", "status", "local_path"]
+    assert rows[1][0] == "1"
+    assert rows[1][1] == "A1"
+    assert rows[1][4] == "downloaded"
+    assert rows[2][0] == "2"
+    assert rows[2][4] == "missing"
+    assert rows[2][5] == ""
+
+
+# --- generate_report (integration with mocks) ---
+
+
+def test_generate_report(tmp_path, capsys):
+    # Create a local album
+    artist_dir = tmp_path / "Artist"
+    album_dir = artist_dir / "Album"
+    album_dir.mkdir(parents=True)
+    (album_dir / "bandcamp_item_id.txt").write_text("1\n")
+
+    purchases = [
+        _make_item(1, "Artist", "Album"),
+        _make_item(2, "NewArtist", "NewAlbum"),
+    ]
+
+    with patch("bandcampsync.report.Bandcamp") as MockBandcamp:
+        mock_bc = MockBandcamp.return_value
+        mock_bc.verify_authentication.return_value = True
+        mock_bc.load_purchases.return_value = True
+        mock_bc.purchases = purchases
+
+        results = generate_report(
+            cookies="identity=test",
+            media_dir=tmp_path,
+            dir_format="artist-album",
+        )
+
+    assert len(results) == 2
+    assert results[0][1] == "downloaded"
+    assert results[1][1] == "missing"
+
+    out = capsys.readouterr().out
+    assert "Total purchases: 2" in out
+    assert "NewArtist / NewAlbum" in out
+
+
+def test_generate_report_with_csv(tmp_path, capsys):
+    csv_path = tmp_path / "report.csv"
+    purchases = [_make_item(1, "Artist", "Album")]
+
+    with patch("bandcampsync.report.Bandcamp") as MockBandcamp:
+        mock_bc = MockBandcamp.return_value
+        mock_bc.verify_authentication.return_value = True
+        mock_bc.load_purchases.return_value = True
+        mock_bc.purchases = purchases
+
+        generate_report(
+            cookies="identity=test",
+            media_dir=tmp_path,
+            dir_format="artist-album",
+            csv_path=csv_path,
+        )
+
+    assert csv_path.is_file()
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    assert len(rows) == 2  # header + 1 item
+    assert rows[1][1] == "Artist"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -157,22 +157,22 @@ def test_classify_downloaded_zip_label_release(tmp_path, ignores):
     assert status == "downloaded"
 
 
-def test_classify_downloaded_zip_metadata_drift(tmp_path, ignores):
-    """Metadata drift: title gained a suffix since download."""
-    # On disk: downloaded as "Spray - Remixes are Inevitable"
-    # Bandcamp now has title "Remixes are Inevitable EP"
-    label_dir = tmp_path / "AnalogueTrash"
-    label_dir.mkdir()
-    album_dir = label_dir / "Spray - Remixes are Inevitable"
+def test_classify_missing_zip_substring_title(tmp_path, ignores):
+    """Same artist, title is a substring of an existing one — must NOT match.
+
+    Guards against false positives like 'Live at the El Rey' matching
+    'Live at the El Rey (20th Anniversary Edition)', or 'VOL. I' matching 'VOL. IX'.
+    """
+    album_dir = tmp_path / "Collide - Live at the El Rey"
     album_dir.mkdir()
 
     lm = LocalMedia(
         media_dir=tmp_path, ignores=ignores,
         skip_item_index=False, sync_ignore_file=False, dir_format="zip",
     )
-    item = _make_item(99, "Spray", "Remixes are Inevitable EP")
+    item = _make_item(99, "Collide", "Live at the El Rey (20th Anniversary Edition)")
     status, path = classify_item(item, lm, ignores, "zip")
-    assert status == "downloaded"
+    assert status == "missing"
 
 
 # --- print_report ---

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,8 +12,14 @@ from bandcampsync.media import LocalMedia
 from bandcampsync.report import classify_item, generate_report, print_report, write_csv
 
 
-def _make_item(item_id, band_name="Artist", item_title="Album", is_preorder=False,
-               item_type="album", folder_suffix=""):
+def _make_item(
+    item_id,
+    band_name="Artist",
+    item_title="Album",
+    is_preorder=False,
+    item_type="album",
+    folder_suffix="",
+):
     data = {
         "item_id": item_id,
         "band_name": band_name,
@@ -35,8 +41,11 @@ def ignores():
 
 def test_classify_missing_artist_album(tmp_path, ignores):
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="artist-album",
     )
     item = _make_item(1, "NewArtist", "NewAlbum")
     status, path = classify_item(item, lm, ignores, "artist-album")
@@ -51,8 +60,11 @@ def test_classify_downloaded_artist_album(tmp_path, ignores):
     (album_dir / "bandcamp_item_id.txt").write_text("42\n")
 
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="artist-album",
     )
     item = _make_item(42, "Artist", "Album")
     status, path = classify_item(item, lm, ignores, "artist-album")
@@ -62,8 +74,11 @@ def test_classify_downloaded_artist_album(tmp_path, ignores):
 
 def test_classify_preorder(tmp_path, ignores):
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="artist-album",
     )
     item = _make_item(1, is_preorder=True)
     status, path = classify_item(item, lm, ignores, "artist-album")
@@ -74,8 +89,11 @@ def test_classify_preorder(tmp_path, ignores):
 def test_classify_ignored_by_pattern(tmp_path):
     ignores = Ignores(ign_file_path=None, ign_patterns="skipme")
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="artist-album",
     )
     item = _make_item(1, band_name="SkipMe Records")
     status, path = classify_item(item, lm, ignores, "artist-album")
@@ -89,8 +107,11 @@ def test_classify_ignored_by_id(tmp_path):
     ign_path.write_text("99\n")
     ignores = Ignores(ign_file_path=ign_path, ign_patterns="")
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="artist-album",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="artist-album",
     )
     item = _make_item(99, "Artist", "Album")
     status, path = classify_item(item, lm, ignores, "artist-album")
@@ -106,8 +127,11 @@ def test_classify_downloaded_zip_by_id(tmp_path, ignores):
     (album_dir / "bandcamp_item_id.txt").write_text("42\n")
 
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
     )
     item = _make_item(42, "Artist", "Album")
     status, path = classify_item(item, lm, ignores, "zip")
@@ -122,8 +146,11 @@ def test_classify_downloaded_zip_by_name(tmp_path, ignores):
     (album_dir / "track.flac").write_text("audio")
 
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
     )
     item = _make_item(99, "Artist", "Album")
     status, path = classify_item(item, lm, ignores, "zip")
@@ -132,8 +159,11 @@ def test_classify_downloaded_zip_by_name(tmp_path, ignores):
 
 def test_classify_missing_zip(tmp_path, ignores):
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
     )
     item = _make_item(1, "NewArtist", "NewAlbum")
     status, path = classify_item(item, lm, ignores, "zip")
@@ -148,8 +178,11 @@ def test_classify_downloaded_zip_label_release(tmp_path, ignores):
     album_dir.mkdir()
 
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
     )
     # band_name is the label, item_title has colon which gets cleaned
     item = _make_item(99, "Side-Line Magazine", "Face The Beat: Session 5")
@@ -167,8 +200,11 @@ def test_classify_missing_zip_substring_title(tmp_path, ignores):
     album_dir.mkdir()
 
     lm = LocalMedia(
-        media_dir=tmp_path, ignores=ignores,
-        skip_item_index=False, sync_ignore_file=False, dir_format="zip",
+        media_dir=tmp_path,
+        ignores=ignores,
+        skip_item_index=False,
+        sync_ignore_file=False,
+        dir_format="zip",
     )
     item = _make_item(99, "Collide", "Live at the El Rey (20th Anniversary Edition)")
     status, path = classify_item(item, lm, ignores, "zip")
@@ -210,7 +246,11 @@ def test_print_report_no_missing(capsys):
 def test_write_csv(tmp_path):
     csv_path = tmp_path / "report.csv"
     items = [
-        (_make_item(1, "A1", "T1", item_type="album"), "downloaded", Path("/music/A1/T1")),
+        (
+            _make_item(1, "A1", "T1", item_type="album"),
+            "downloaded",
+            Path("/music/A1/T1"),
+        ),
         (_make_item(2, "A2", "T2", item_type="track"), "missing", None),
     ]
     write_csv(items, csv_path)
@@ -219,7 +259,14 @@ def test_write_csv(tmp_path):
         reader = csv.reader(f)
         rows = list(reader)
 
-    assert rows[0] == ["item_id", "band_name", "item_title", "item_type", "status", "local_path"]
+    assert rows[0] == [
+        "item_id",
+        "band_name",
+        "item_title",
+        "item_type",
+        "status",
+        "local_path",
+    ]
     assert rows[1][0] == "1"
     assert rows[1][1] == "A1"
     assert rows[1][4] == "downloaded"

--- a/tests/test_sync_item.py
+++ b/tests/test_sync_item.py
@@ -1,11 +1,9 @@
 """Tests for Syncer's sync_item functionality and retry logic."""
 
-from unittest.mock import Mock, patch, MagicMock
-from pathlib import Path
+from unittest.mock import Mock, patch
 import pytest
 from bandcampsync.sync import Syncer
 from bandcampsync.bandcamp import BandcampError
-from bandcampsync.download import DownloadBadStatusCode, DownloadInvalidContentType
 
 
 @pytest.fixture
@@ -311,7 +309,7 @@ def test_sync_item_zip_track(syncer_zip, mock_bandcamp, tmp_path):
         assert result is True
         args, _ = mock_copy.call_args
         assert "Artist - TrackTitle" in str(args[1])
-        assert "track-slug.flac" in str(args[1])
+        assert "Artist - TrackTitle.flac" in str(args[1])
 
 
 def test_sync_item_zip_fallback_no_content_disposition(syncer_zip, mock_bandcamp, tmp_path):
@@ -346,3 +344,32 @@ def test_sync_item_zip_fallback_no_content_disposition(syncer_zip, mock_bandcamp
             assert result is True
             expected_dir = tmp_path / "Artist - Album"
             assert expected_dir.is_dir()
+
+
+def test_sync_item_zip_name_fallback_skips_download(syncer_zip, mock_bandcamp, tmp_path):
+    """In zip mode, album with matching dir name but no tracking file is skipped."""
+    # Pre-create a label subdir album without bandcamp_item_id.txt
+    label_dir = tmp_path / "OldLabel"
+    label_dir.mkdir()
+    album_dir = label_dir / "MyBand - MyAlbum"
+    album_dir.mkdir()
+    (album_dir / "track1.flac").write_text("existing audio")
+
+    # Re-index so item_names picks up the subdir
+    syncer_zip.local_media.index()
+
+    item = Mock(
+        is_preorder=False,
+        band_name="MyBand",
+        item_title="MyAlbum",
+        item_id=9999,
+        item_type="album",
+        folder_suffix="",
+        download_url="http://example.com/download",
+    )
+
+    with patch("bandcampsync.sync.download_file") as mock_download:
+        result = syncer_zip.sync_item(item)
+
+        assert result is False
+        mock_download.assert_not_called()

--- a/tests/test_sync_item.py
+++ b/tests/test_sync_item.py
@@ -19,28 +19,35 @@ def mock_bandcamp():
         yield mock_instance
 
 
-@pytest.fixture
-def syncer(mock_bandcamp, tmp_path):
-    # We need to mock asyncio.run(self.sync_items()) because it's called in __init__
+def _make_syncer(mock_bandcamp, tmp_path, **kwargs):
+    defaults = dict(
+        cookies="identity=test",
+        dir_path=tmp_path,
+        media_format="flac",
+        temp_dir_root=str(tmp_path),
+        ign_file_path=None,
+        ign_patterns="",
+        notify_url=None,
+        max_retries=2,
+        retry_wait=0,
+    )
+    defaults.update(kwargs)
     with patch("bandcampsync.sync.asyncio.run") as mock_run:
-        s = Syncer(
-            cookies="identity=test",
-            dir_path=tmp_path,
-            media_format="flac",
-            temp_dir_root=str(tmp_path),
-            ign_file_path=None,
-            ign_patterns="",
-            notify_url=None,
-            max_retries=2,
-            retry_wait=0,
-        )
-        # The call to Syncer() triggers self.sync_items() which returns a coroutine.
-        # Since asyncio.run is mocked, this coroutine is never awaited, causing a warning.
-        # We can get the coroutine object from the mock call and close it.
+        s = Syncer(**defaults)
         if mock_run.called:
             coro = mock_run.call_args[0][0]
             coro.close()
     return s
+
+
+@pytest.fixture
+def syncer(mock_bandcamp, tmp_path):
+    return _make_syncer(mock_bandcamp, tmp_path)
+
+
+@pytest.fixture
+def syncer_zip(mock_bandcamp, tmp_path):
+    return _make_syncer(mock_bandcamp, tmp_path, dir_format="zip")
 
 
 def test_sync_item_success(syncer, mock_bandcamp, tmp_path):
@@ -50,6 +57,7 @@ def test_sync_item_success(syncer, mock_bandcamp, tmp_path):
         item_title="Album",
         item_id=1,
         item_type="album",
+        folder_suffix="",
         download_url="http://example.com/download",
     )
 
@@ -87,6 +95,7 @@ def test_sync_item_retries_and_succeeds(syncer, mock_bandcamp, tmp_path):
         item_title="Album",
         item_id=1,
         item_type="album",
+        folder_suffix="",
         download_url="http://example.com/download",
     )
 
@@ -124,6 +133,7 @@ def test_sync_item_fails_after_max_retries(syncer, mock_bandcamp):
         item_title="Album",
         item_id=1,
         item_type="album",
+        folder_suffix="",
         download_url="http://example.com/download",
     )
 
@@ -145,6 +155,7 @@ def test_sync_item_track_success(syncer, mock_bandcamp, tmp_path):
         item_title="TrackTitle",
         item_id=1,
         item_type="track",
+        folder_suffix="",
         url_hints={"slug": "track-slug"},
         download_url="http://example.com/download",
     )
@@ -164,3 +175,174 @@ def test_sync_item_track_success(syncer, mock_bandcamp, tmp_path):
         # Check if copy_file was called with expected destination name (using slug)
         args, _ = mock_copy.call_args
         assert "track-slug.flac" in str(args[1])
+
+
+# --- Zip format sync_item tests ---
+
+
+def test_sync_item_zip_label_detection(syncer_zip, mock_bandcamp, tmp_path):
+    """In zip mode, label release creates Label/Artist - Album dir."""
+    item = Mock(
+        is_preorder=False,
+        band_name="CoolLabel",
+        item_title="MyAlbum",
+        item_id=42,
+        item_type="album",
+        folder_suffix="",
+        download_url="http://example.com/download",
+    )
+
+    mock_bandcamp.get_download_file_url.return_value = "http://example.com/file"
+    mock_bandcamp.check_download_stat.return_value = "http://example.com/file_ok"
+
+    with (
+        patch("bandcampsync.sync.download_file", return_value="ActualArtist - MyAlbum.zip"),
+        patch("bandcampsync.sync.is_zip_file", return_value=True),
+        patch("bandcampsync.sync.unzip_file"),
+        patch("bandcampsync.sync.TemporaryDirectory") as mock_temp_dir,
+    ):
+        temp_dir_path = tmp_path / "temp_extract"
+        temp_dir_path.mkdir()
+        mock_temp_dir.return_value.__enter__.return_value = str(temp_dir_path)
+        (temp_dir_path / "track1.flac").write_text("audio data")
+
+        with patch("bandcampsync.sync.move_file"):
+            result = syncer_zip.sync_item(item)
+
+            assert result is True
+            # Verify the directory was created under Label/Artist - Album
+            expected_dir = tmp_path / "CoolLabel" / "ActualArtist - MyAlbum"
+            assert expected_dir.is_dir()
+
+
+def test_sync_item_zip_flat(syncer_zip, mock_bandcamp, tmp_path):
+    """In zip mode, non-label release creates flat Artist - Album dir."""
+    item = Mock(
+        is_preorder=False,
+        band_name="MyBand",
+        item_title="MyAlbum",
+        item_id=42,
+        item_type="album",
+        folder_suffix="",
+        download_url="http://example.com/download",
+    )
+
+    mock_bandcamp.get_download_file_url.return_value = "http://example.com/file"
+    mock_bandcamp.check_download_stat.return_value = "http://example.com/file_ok"
+
+    with (
+        patch("bandcampsync.sync.download_file", return_value="MyBand - MyAlbum.zip"),
+        patch("bandcampsync.sync.is_zip_file", return_value=True),
+        patch("bandcampsync.sync.unzip_file"),
+        patch("bandcampsync.sync.TemporaryDirectory") as mock_temp_dir,
+    ):
+        temp_dir_path = tmp_path / "temp_extract"
+        temp_dir_path.mkdir()
+        mock_temp_dir.return_value.__enter__.return_value = str(temp_dir_path)
+        (temp_dir_path / "track1.flac").write_text("audio data")
+
+        with patch("bandcampsync.sync.move_file"):
+            result = syncer_zip.sync_item(item)
+
+            assert result is True
+            expected_dir = tmp_path / "MyBand - MyAlbum"
+            assert expected_dir.is_dir()
+
+
+def test_sync_item_zip_existing_dir_skip(syncer_zip, mock_bandcamp, tmp_path):
+    """In zip mode, existing directory is detected and extraction is skipped."""
+    # Pre-create the target directory with a file
+    existing_dir = tmp_path / "MyBand - MyAlbum"
+    existing_dir.mkdir()
+    (existing_dir / "track1.flac").write_text("existing audio")
+
+    item = Mock(
+        is_preorder=False,
+        band_name="MyBand",
+        item_title="MyAlbum",
+        item_id=42,
+        item_type="album",
+        folder_suffix="",
+        download_url="http://example.com/download",
+    )
+
+    mock_bandcamp.get_download_file_url.return_value = "http://example.com/file"
+    mock_bandcamp.check_download_stat.return_value = "http://example.com/file_ok"
+
+    with (
+        patch("bandcampsync.sync.download_file", return_value="MyBand - MyAlbum.zip"),
+        patch("bandcampsync.sync.is_zip_file", return_value=True),
+        patch("bandcampsync.sync.unzip_file") as mock_unzip,
+    ):
+        result = syncer_zip.sync_item(item)
+
+        # Should NOT extract (returns False since no new media was truly downloaded)
+        assert result is False
+        mock_unzip.assert_not_called()
+        # But should write tracking file
+        id_file = existing_dir / "bandcamp_item_id.txt"
+        assert id_file.is_file()
+        assert id_file.read_text().strip() == "42"
+
+
+def test_sync_item_zip_track(syncer_zip, mock_bandcamp, tmp_path):
+    """In zip mode, single track uses Artist - TrackName dir."""
+    item = Mock(
+        is_preorder=False,
+        band_name="Artist",
+        item_title="TrackTitle",
+        item_id=55,
+        item_type="track",
+        folder_suffix="",
+        url_hints={"slug": "track-slug"},
+        download_url="http://example.com/download",
+    )
+
+    mock_bandcamp.get_download_file_url.return_value = "http://example.com/file"
+    mock_bandcamp.check_download_stat.return_value = "http://example.com/file_ok"
+
+    with (
+        patch("bandcampsync.sync.download_file", return_value=None),
+        patch("bandcampsync.sync.is_zip_file", return_value=False),
+        patch("bandcampsync.sync.copy_file") as mock_copy,
+    ):
+        result = syncer_zip.sync_item(item)
+
+        assert result is True
+        args, _ = mock_copy.call_args
+        assert "Artist - TrackTitle" in str(args[1])
+        assert "track-slug.flac" in str(args[1])
+
+
+def test_sync_item_zip_fallback_no_content_disposition(syncer_zip, mock_bandcamp, tmp_path):
+    """In zip mode, missing Content-Disposition falls back to metadata-based name."""
+    item = Mock(
+        is_preorder=False,
+        band_name="Artist",
+        item_title="Album",
+        item_id=77,
+        item_type="album",
+        folder_suffix="",
+        download_url="http://example.com/download",
+    )
+
+    mock_bandcamp.get_download_file_url.return_value = "http://example.com/file"
+    mock_bandcamp.check_download_stat.return_value = "http://example.com/file_ok"
+
+    with (
+        patch("bandcampsync.sync.download_file", return_value=None),
+        patch("bandcampsync.sync.is_zip_file", return_value=True),
+        patch("bandcampsync.sync.unzip_file"),
+        patch("bandcampsync.sync.TemporaryDirectory") as mock_temp_dir,
+    ):
+        temp_dir_path = tmp_path / "temp_extract"
+        temp_dir_path.mkdir()
+        mock_temp_dir.return_value.__enter__.return_value = str(temp_dir_path)
+        (temp_dir_path / "track1.flac").write_text("audio data")
+
+        with patch("bandcampsync.sync.move_file"):
+            result = syncer_zip.sync_item(item)
+
+            assert result is True
+            expected_dir = tmp_path / "Artist - Album"
+            assert expected_dir.is_dir()

--- a/tests/test_sync_item.py
+++ b/tests/test_sync_item.py
@@ -194,7 +194,9 @@ def test_sync_item_zip_label_detection(syncer_zip, mock_bandcamp, tmp_path):
     mock_bandcamp.check_download_stat.return_value = "http://example.com/file_ok"
 
     with (
-        patch("bandcampsync.sync.download_file", return_value="ActualArtist - MyAlbum.zip"),
+        patch(
+            "bandcampsync.sync.download_file", return_value="ActualArtist - MyAlbum.zip"
+        ),
         patch("bandcampsync.sync.is_zip_file", return_value=True),
         patch("bandcampsync.sync.unzip_file"),
         patch("bandcampsync.sync.TemporaryDirectory") as mock_temp_dir,
@@ -312,7 +314,9 @@ def test_sync_item_zip_track(syncer_zip, mock_bandcamp, tmp_path):
         assert "Artist - TrackTitle.flac" in str(args[1])
 
 
-def test_sync_item_zip_fallback_no_content_disposition(syncer_zip, mock_bandcamp, tmp_path):
+def test_sync_item_zip_fallback_no_content_disposition(
+    syncer_zip, mock_bandcamp, tmp_path
+):
     """In zip mode, missing Content-Disposition falls back to metadata-based name."""
     item = Mock(
         is_preorder=False,
@@ -346,7 +350,9 @@ def test_sync_item_zip_fallback_no_content_disposition(syncer_zip, mock_bandcamp
             assert expected_dir.is_dir()
 
 
-def test_sync_item_zip_name_fallback_skips_download(syncer_zip, mock_bandcamp, tmp_path):
+def test_sync_item_zip_name_fallback_skips_download(
+    syncer_zip, mock_bandcamp, tmp_path
+):
     """In zip mode, album with matching dir name but no tracking file is skipped."""
     # Pre-create a label subdir album without bandcamp_item_id.txt
     label_dir = tmp_path / "OldLabel"

--- a/tools/find_root_duplicates.py
+++ b/tools/find_root_duplicates.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+"""
+Find albums that exist BOTH at the root of the media directory and inside a label
+subdirectory, and report how their track lists relate so the pair can be reviewed by hand.
+
+The purchased-collection sync writes albums flat at the top level when no artist directory
+exists, while bandcampfree always writes into media_dir/<Label>/. An album fetched by both
+therefore ends up in two places, and neither tool sees the other's copy.
+
+This only reports. Nothing is moved or deleted: deciding which copy to keep needs a human,
+because the two are often not identical (bandcamp re-encodes, labels extend compilations,
+and album titles are not unique).
+
+Usage:
+    uv run python tools/find_root_duplicates.py "N:/Bandcamp (FLAC)"
+    uv run python tools/find_root_duplicates.py "N:/Bandcamp (FLAC)" --tsv dupes.tsv
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from bandcampsync.media import LocalMedia  # noqa: E402
+
+# Album and track names are heavily unicode (Japanese, Cyrillic, decorated vaporwave
+# titles). The Windows console defaults to cp1252 and would abort mid-report.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except AttributeError:  # pragma: no cover - very old interpreters
+    pass
+
+AUDIO_SUFFIXES = {".flac", ".mp3", ".wav", ".m4a", ".aiff", ".alac", ".ogg"}
+
+
+def album_title(dirname):
+    """'Artist - Album' -> 'Album'. Leaves names without a separator alone."""
+    return dirname.split(" - ", 1)[1] if " - " in dirname else dirname
+
+
+def track_keys(directory):
+    """Return a set of comparable track identities for one album directory.
+
+    Bandcamp embeds the album title in every filename, and that title differs between two
+    copies when a label has renamed the release, so the shared leading prefix is stripped
+    before comparing. Falls back to the whole name when there is no common prefix.
+    """
+    names = [
+        p.name
+        for p in directory.iterdir()
+        if p.is_file() and p.suffix.lower() in AUDIO_SUFFIXES
+    ]
+    if not names:
+        return set()
+    prefix = os.path.commonprefix(names) if len(names) > 1 else ""
+    cut = prefix.rfind(" - ")
+    prefix = prefix[: cut + 3] if cut != -1 else ""
+    keys = set()
+    for name in names:
+        stem = name[len(prefix) :] if prefix and name.startswith(prefix) else name
+        stem = stem.rsplit(".", 1)[0]
+        keys.add(LocalMedia._normalize_for_match(stem))
+    return keys
+
+
+def relation(root_keys, sub_keys):
+    """Describe how two track sets relate, for a human deciding which copy to keep."""
+    if not root_keys and not sub_keys:
+        return "BOTH-EMPTY", ""
+    if not root_keys:
+        return "ROOT-EMPTY", ""
+    if not sub_keys:
+        return "SUB-EMPTY", ""
+    if root_keys == sub_keys:
+        return "IDENTICAL", "same track list - safe to delete either"
+    if root_keys < sub_keys:
+        return (
+            "ROOT-SUBSET",
+            f"subdir has {len(sub_keys - root_keys)} extra - keep subdir",
+        )
+    if sub_keys < root_keys:
+        return "SUB-SUBSET", f"root has {len(root_keys - sub_keys)} extra - keep root"
+    overlap = root_keys & sub_keys
+    if overlap:
+        return "PARTIAL", (
+            f"{len(overlap)} shared, {len(root_keys - sub_keys)} only-root, "
+            f"{len(sub_keys - root_keys)} only-subdir"
+        )
+    return "DISJOINT", "no shared tracks - probably different albums, do not merge"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("media_dir")
+    parser.add_argument("--tsv", default="", help="also write a tab-separated file")
+    parser.add_argument(
+        "--min-tracks",
+        type=int,
+        default=1,
+        help="ignore directories with fewer audio files than this",
+    )
+    args = parser.parse_args()
+
+    media = Path(args.media_dir)
+    if not media.is_dir():
+        sys.exit(f"Not a directory: {media}")
+
+    # Root-level album directories, and label subdirectories, in one pass.
+    root_dirs, label_dirs = {}, {}
+    for child in sorted(p for p in media.iterdir() if p.is_dir()):
+        subs = [p for p in child.iterdir() if p.is_dir()]
+        has_audio = any(
+            p.suffix.lower() in AUDIO_SUFFIXES for p in child.iterdir() if p.is_file()
+        )
+        if has_audio:
+            root_dirs.setdefault(
+                LocalMedia._normalize_for_match(album_title(child.name)), []
+            ).append(child)
+        if subs:
+            label_dirs[child.name] = subs
+
+    sub_index = {}
+    for label, subs in label_dirs.items():
+        for sub in subs:
+            key = LocalMedia._normalize_for_match(album_title(sub.name))
+            sub_index.setdefault(key, []).append((label, sub))
+
+    print(f"root album directories : {sum(len(v) for v in root_dirs.values())}")
+    print(f"label subdirectories   : {sum(len(v) for v in sub_index.values())}")
+    print(f"labels                 : {len(label_dirs)}\n")
+
+    rows = []
+    for key in sorted(set(root_dirs) & set(sub_index)):
+        for root in root_dirs[key]:
+            rk = track_keys(root)
+            if len(rk) < args.min_tracks:
+                continue
+            for label, sub in sub_index[key]:
+                sk = track_keys(sub)
+                verdict, note = relation(rk, sk)
+                rows.append(
+                    (verdict, label, root.name, sub.name, len(rk), len(sk), note)
+                )
+
+    order = [
+        "IDENTICAL",
+        "ROOT-SUBSET",
+        "SUB-SUBSET",
+        "PARTIAL",
+        "DISJOINT",
+        "ROOT-EMPTY",
+        "SUB-EMPTY",
+        "BOTH-EMPTY",
+    ]
+    rows.sort(key=lambda r: (order.index(r[0]) if r[0] in order else 99, r[1], r[2]))
+
+    current = None
+    for verdict, label, rootname, subname, nr, ns, note in rows:
+        if verdict != current:
+            current = verdict
+            print(f"\n=== {verdict} ===")
+        print(f"  [{label}]  {note}")
+        print(f"     root   ({nr:>3} tracks): {rootname}")
+        print(f"     subdir ({ns:>3} tracks): {label}\\{subname}")
+
+    print(f"\n{len(rows)} candidate pair(s)")
+    counts = {}
+    for r in rows:
+        counts[r[0]] = counts.get(r[0], 0) + 1
+    for verdict in order:
+        if verdict in counts:
+            print(f"  {verdict:<12} {counts[verdict]}")
+
+    if args.tsv:
+        with open(args.tsv, "wt", encoding="utf-8") as f:
+            f.write(
+                "verdict\tlabel\troot_dir\tsub_dir\troot_tracks\tsub_tracks\tnote\n"
+            )
+            for r in rows:
+                f.write(
+                    "\t".join(
+                        str(x) for x in (r[0], r[1], r[2], r[3], r[4], r[5], r[6])
+                    )
+                    + "\n"
+                )
+        print(f"\nwrote {args.tsv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "bandcampsync"
@@ -9,6 +13,13 @@ source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "curl-cffi" },
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+gmail = [
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
 ]
 
 [package.dev-dependencies]
@@ -22,7 +33,11 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "curl-cffi", specifier = ">=0.14.0" },
+    { name = "google-auth", marker = "extra == 'gmail'", specifier = ">=2.30.0" },
+    { name = "google-auth-oauthlib", marker = "extra == 'gmail'", specifier = ">=1.2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
+provides-extras = ["gmail"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -136,12 +151,156 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/81/8e983840c6e5b93b33c2ba81aa3d52c2e42f0e9a690ce7607a2e61da4a5c/charset_normalizer-3.4.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a", size = 322240, upload-time = "2026-07-07T14:32:36.236Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/b4319dc3229d8272fba305e206fc0a148e2de8d4087917ce62ae6382f359/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616", size = 216475, upload-time = "2026-07-07T14:32:38.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/33/6c99c1b3e6b8bf730e1bc809b9a2608f224145069114c479a2e9e1494346/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209", size = 238670, upload-time = "2026-07-07T14:32:39.658Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f4/ffbb83546e1f198ecc70ecd372b65cf2b50f9068b380abd67640f17a8e18/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99", size = 233476, upload-time = "2026-07-07T14:32:41.155Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5f/b98b8da398637b551e427e7be922bdec19177dc54d6811dcdaa503f23aac/charset_normalizer-3.4.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8", size = 223817, upload-time = "2026-07-07T14:32:42.592Z" },
+    { url = "https://files.pythonhosted.org/packages/36/31/a276bb2e66243072a3fd06fdcab9cbb61a305b02143d70d2bda21d888fa8/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b", size = 207974, upload-time = "2026-07-07T14:32:44.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/be/7ee4453d7e88dfbc4104ccd34900b9f2c7c17dac22881865fe0e82424a25/charset_normalizer-3.4.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2", size = 221655, upload-time = "2026-07-07T14:32:45.64Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/181c652953eb5276d198f375b1dd641047392050098100a3a02d6534f657/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9", size = 219229, upload-time = "2026-07-07T14:32:47.376Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/aaf6da33fc9f4691cda8f7efbc9f69179d3d39ec8a4799baf273ee1d8db0/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15", size = 209704, upload-time = "2026-07-07T14:32:48.855Z" },
+    { url = "https://files.pythonhosted.org/packages/63/01/f2fb3bd3a73be48b173ee0c6aa8d2497af97d5663a8c4c4b491de4c62f7a/charset_normalizer-3.4.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d", size = 226243, upload-time = "2026-07-07T14:32:50.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/02/c57a22739fe05246b0b5783b3bfb6afaac4eebb46f3ececdfb2f048f780e/charset_normalizer-3.4.9-cp310-cp310-win32.whl", hash = "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381", size = 150935, upload-time = "2026-07-07T14:32:51.676Z" },
+    { url = "https://files.pythonhosted.org/packages/37/8d/ca39a7559a4797505530d084fd3a49a2c959efbbbff146302fb7be4e3b35/charset_normalizer-3.4.9-cp310-cp310-win_amd64.whl", hash = "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee", size = 162314, upload-time = "2026-07-07T14:32:53.193Z" },
+    { url = "https://files.pythonhosted.org/packages/01/da/a44bd7a13d426e69e4894557106cd58669097bfad4a8681123b618fbfc5d/charset_normalizer-3.4.9-cp310-cp310-win_arm64.whl", hash = "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419", size = 153075, upload-time = "2026-07-07T14:32:54.554Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5", size = 317075, upload-time = "2026-07-07T14:32:56.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2", size = 213837, upload-time = "2026-07-07T14:32:57.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/46/03ddc7da576d814fe0a36dd1f0fd3258e95404b4b2e3c026b7923d7e133f/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a", size = 235503, upload-time = "2026-07-07T14:32:59.205Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6e/de0229a7ef40f6f9d28a837eebf4ec47bdca5dab4e900c84f22919af636a/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29", size = 229944, upload-time = "2026-07-07T14:33:00.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c", size = 221276, upload-time = "2026-07-07T14:33:02.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/80282cce0fae9c3061203d723ee87da996aed79679e65d8935050ee7ca1f/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b", size = 205260, upload-time = "2026-07-07T14:33:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/74/2f62c8821b969ea3bd67cc2e6976834f48ca5d12664d2559ebcd9bcfbed7/charset_normalizer-3.4.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db", size = 217786, upload-time = "2026-07-07T14:33:05.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8d/feabb82cb49fcad14515b1d7d1ca4787b0da7fc723a212bf89bc9e0fac52/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993", size = 216798, upload-time = "2026-07-07T14:33:06.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ff/c946d63bc3786d5b84d960b0f7ab7e25b828486a946b5aa997625bcaf6a6/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da", size = 206429, upload-time = "2026-07-07T14:33:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ba/5e5007c370702f85d2ef75791fac7943ed41e080364a673b20142e430e3e/charset_normalizer-3.4.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3", size = 223066, upload-time = "2026-07-07T14:33:09.783Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d5/9096aa3cf532dfad237861544eb47a0f20d5adbf1039760fed8eaae935d9/charset_normalizer-3.4.9-cp311-cp311-win32.whl", hash = "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d", size = 150456, upload-time = "2026-07-07T14:33:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl", hash = "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1", size = 161410, upload-time = "2026-07-07T14:33:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/1569f4d0032d6ba2a4fe4591c35bf87868c600c41a71eb5c2e1ffa8464c2/charset_normalizer-3.4.9-cp311-cp311-win_arm64.whl", hash = "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec", size = 152649, upload-time = "2026-07-07T14:33:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
 ]
 
 [[package]]
@@ -180,12 +339,56 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.56.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/66/b4ba60005743e01933e22b4f62313e063f7460458b7d8a358427b4930013/google_auth-2.56.0.tar.gz", hash = "sha256:f90fa030b569a92654b9d690665a073841df33d57487be53db583a9a0867a553", size = 364629, upload-time = "2026-07-13T19:09:57.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/7d/cd3e187f14ce832e419e70709bfcc40cb0dc11517d5d03c9d3919bcc3101/google_auth-2.56.0-py3-none-any.whl", hash = "sha256:6e88c10217e07a92bfd01cac8ee99e32ccfb08414c3102e6c5b8d58f37a0d1e0", size = 257976, upload-time = "2026-07-13T19:09:42.685Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -204,6 +407,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -252,6 +476,98 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -345,4 +661,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
## Problem

An album title containing `|`, `<` or `>` produced a directory path Windows cannot create, so the download failed outright:

```
Failed to download "12|21": [WinError 123] The filename, directory name,
or volume label syntax is incorrect:
  ...\Flowerpot Records\Reflections Of Stars - 12|21
```

`clean_path_component` stripped `"#%'*/?\`:` but not `|<>`, while its sibling `clean_label_dir_name` has always stripped the full Windows-illegal set via `_WINDOWS_ILLEGAL_PATH_CHARS`. The label directory was therefore writable while the album directory inside it was not.

Found in the wild: this was the only failure in a 207-album run against Flowerpot Records.

## Why widening `clean_path_component` is safe here

Widening it is normally forbidden — a name that stops matching orphans the directory already on disk and the album downloads again, which is exactly what happened with `What Do You Know About Ska Punk?`.

These three characters are the exception. Windows and SMB refuse to create a path component containing them, so no directory that ever landed on disk can hold one, and no existing name can change. Verified empirically by walking all **11,878** directories under the media root: **zero** contain `|`, `<` or `>`.

## Tests

- `test_clean_path_component_strips_windows_illegal_characters` — direct regression, including the literal `12|21` case.
- `test_clean_path_component_covers_every_windows_illegal_character` — asserts `clean_path_component` strips at least what `clean_label_dir_name` does, making the relationship between the two sanitisers a tested invariant so this class of bug cannot recur.

174 tests pass; lint unchanged from baseline.

## Verification

Re-ran the failed download after the fix. It now lands as `Reflections Of Stars - 1221`, and the pending queue and failure list are both empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)